### PR TITLE
docs: publish agentic development post

### DIFF
--- a/blog/2026-07-23-agentic-bluefin.md
+++ b/blog/2026-07-23-agentic-bluefin.md
@@ -4,7 +4,6 @@ slug: why-im-all-in-on-agentic-development
 authors: castrojo
 tags: [community, video, ai]
 date: 2026-07-23T16:48:00-04:00
-draft: true
 ---
 
 Is AI good or bad for open source? This is 52 minutes of me explaining what I've learned on this.


### PR DESCRIPTION
## Summary

- Publish the agentic development blog post by removing `draft: true`
- Keep the existing video embed and article content unchanged

This makes the already-reviewed post visible on the site.