### PR TITLE
fix(ci): authenticate cross-repo discussion creation

### DIFF
--- a/.github/workflows/open-discussion.yml
+++ b/.github/workflows/open-discussion.yml
@@ -27,9 +27,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate mergeraptor app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          owner: ublue-os
+          repositories: bluefin
+
       - name: Open discussions for new blog posts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: |


### PR DESCRIPTION
Use the mergeraptor GitHub App token to create Discussions in ublue-os/bluefin. The repository-scoped GITHUB_TOKEN cannot write to the cross-repository Discussions target.