### PR TITLE
docs(ci): enforce existing discussion token contract

### DIFF
--- a/.github/workflows/open-discussion.yml
+++ b/.github/workflows/open-discussion.yml
@@ -27,18 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate mergeraptor app token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ vars.MERGERAPTOR_APP_ID }}
-          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-          owner: ublue-os
-          repositories: bluefin
-
       - name: Open discussions for new blog posts
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Existing cross-repository token; do not replace with a new credential.
+          GH_TOKEN: ${{ secrets.BLUEFIN_DISCUSSIONS_TOKEN }}
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: |
@@ -49,6 +41,10 @@ jobs:
           after  = os.environ["AFTER_SHA"]
           event  = os.environ.get("GITHUB_EVENT_NAME")
           zero   = "0" * 40
+
+          if not os.environ.get("GH_TOKEN"):
+              print("BLUEFIN_DISCUSSIONS_TOKEN is not configured", file=sys.stderr)
+              sys.exit(1)
 
           if event == "workflow_dispatch":
               # Backfill discussions for already-published posts, including posts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,15 @@ The shipped entry point is `build/index.html`. It is generated output. Never edi
 The documentation site uses the root route for the docs plugin. Production routes
 are defined by `sidebars.ts` and the source files in `docs/`.
 
+## Blog discussion automation
+
+`.github/workflows/open-discussion.yml` creates the matching Giscus Discussion in
+`ublue-os/bluefin`. It uses the existing repository secret
+`BLUEFIN_DISCUSSIONS_TOKEN`; do not introduce a new token, GitHub App, or
+cross-repository credential scheme. The secret must have Discussion write access
+in `ublue-os/bluefin`. If it is unavailable, the workflow must fail explicitly
+rather than report success without creating a discussion.
+
 - **Getting Started:** `docs/index.md`, `introduction.md`, `downloads.mdx`,
   `installation.md`, `FAQ.md`
 - **Using Bluefin:** `administration.md`, `tips.mdx`, `ai.md`, `command-line.md`,


### PR DESCRIPTION
Document and enforce the existing BLUEFIN_DISCUSSIONS_TOKEN contract. Remove the unconfigured Mergeraptor dependency, fail explicitly when the existing token is missing, and document that no new credential scheme should be introduced.