### PR TITLE
feat(release-cards): add deterministic release-context renderer and action

### DIFF
--- a/.github/actions/render-release-card/action.yml
+++ b/.github/actions/render-release-card/action.yml
@@ -1,0 +1,67 @@
+name: Render release card
+description: Render deterministic light and dark release cards from an immutable release context. Requires Node 24.
+
+inputs:
+  context-path:
+    description: Required path to the release-context JSON, relative to the caller workspace.
+    required: true
+  output-dir:
+    description: Required output directory for release-card.png and release-card-dark.png, relative to the caller workspace.
+    required: true
+
+outputs:
+  light-path:
+    description: Absolute path to release-card.png in the caller workspace.
+    value: ${{ steps.render.outputs.light-path }}
+  dark-path:
+    description: Absolute path to release-card-dark.png in the caller workspace.
+    value: ${{ steps.render.outputs.dark-path }}
+
+runs:
+  using: composite
+  steps:
+    - id: render
+      shell: bash
+      env:
+        CONTEXT_PATH: ${{ inputs.context-path }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        set -euo pipefail
+
+        repository_root="$(cd "${GITHUB_ACTION_PATH}/../../.." && pwd)"
+        workspace_root="$(cd "${GITHUB_WORKSPACE}" && pwd)"
+
+        resolve_workspace_path() {
+          local input_path="$1"
+          if [[ -z "${input_path}" || "${input_path}" = /* ]]; then
+            echo "Action paths must be non-empty and relative to GITHUB_WORKSPACE." >&2
+            exit 1
+          fi
+
+          local resolved_path
+          resolved_path="$(realpath -m -- "${workspace_root}/${input_path}")"
+          case "${resolved_path}" in
+            "${workspace_root}"/*) printf '%s\n' "${resolved_path}" ;;
+            *)
+              echo "Action paths must remain within GITHUB_WORKSPACE." >&2
+              exit 1
+              ;;
+          esac
+        }
+
+        context_path="$(resolve_workspace_path "${CONTEXT_PATH}")"
+        output_dir="$(resolve_workspace_path "${OUTPUT_DIR}")"
+
+        cd "${repository_root}"
+        npm ci
+        node "${repository_root}/scripts/render-release-card.mjs" \
+          --context "${context_path}" \
+          --output-dir "${output_dir}"
+
+        light_path="${output_dir}/release-card.png"
+        dark_path="${output_dir}/release-card-dark.png"
+        [[ -s "${light_path}" && -s "${dark_path}" ]]
+        {
+          printf 'light-path=%s\n' "${light_path}"
+          printf 'dark-path=%s\n' "${dark_path}"
+        } >> "${GITHUB_OUTPUT}"

--- a/scripts/lib/card-template.mjs
+++ b/scripts/lib/card-template.mjs
@@ -124,18 +124,29 @@ function versionChip(name, version, colors, prevVersion) {
  * @param {number} dateMs   – epoch ms (0 = no date)
  * @param {"light"|"dark"} theme
  * @param {string} mascotDataUri – PNG as data URI
+ * @param {string} [titleOverride] – release-specific title
+ * @param {string[]} [headerPackageNames] – package names to display as header chips
  * @returns Satori element tree
  */
-export function renderCard(release, stream, dateMs, theme, mascotDataUri) {
+export function renderCard(
+  release,
+  stream,
+  dateMs,
+  theme,
+  mascotDataUri,
+  titleOverride,
+  headerPackageNames
+) {
   const colors = THEMES[theme];
   const accentColor = primary(stream, colors);
 
   const title =
-    stream === "lts"
+    titleOverride ||
+    (stream === "lts"
       ? "Bluefin LTS"
       : stream === "dakota"
       ? "Bluefin Dakota"
-      : "Bluefin";
+      : "Bluefin");
 
   const dateStr =
     dateMs > 0
@@ -154,7 +165,7 @@ export function renderCard(release, stream, dateMs, theme, mascotDataUri) {
     "sudo-rs", "uutils-coreutils",
   ];
 
-  const headerChips = HEADER_NAMES.flatMap((name) => {
+  const headerChips = (headerPackageNames ?? HEADER_NAMES).flatMap((name) => {
     const pkg = (release.majorPackages ?? []).find(
       (p) => p.name.toLowerCase() === name.toLowerCase()
     );

--- a/scripts/render-release-card.mjs
+++ b/scripts/render-release-card.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { inflateSync } from "zlib";
+import { Resvg } from "@resvg/resvg-js";
+import satori from "satori";
+import { H, renderCard, W } from "./lib/card-template.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function fail(message) {
+  throw new Error(`Invalid release card context: ${message}`);
+}
+
+function requiredString(value, path) {
+  if (typeof value !== "string" || value.trim() === "") {
+    fail(`${path} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function sha256(value, path) {
+  const digest = requiredString(value, path);
+  if (!/^sha256:[a-f0-9]{64}$/i.test(digest)) {
+    fail(`${path} must be a sha256 digest`);
+  }
+  return digest;
+}
+
+function nonNegativeInteger(value, path) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    fail(`${path} must be a non-negative integer`);
+  }
+  return value;
+}
+
+export function validateReleaseContext(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    fail("must be a JSON object");
+  }
+
+  const product = requiredString(input.product, "product");
+  if (!["bluefin", "dakota"].includes(product)) {
+    fail("product must be bluefin or dakota");
+  }
+
+  const publishedAt = requiredString(input.published_at, "published_at");
+  if (!Number.isFinite(Date.parse(publishedAt))) {
+    fail("published_at must be an ISO-8601 timestamp");
+  }
+
+  if (
+    !Array.isArray(input.components) ||
+    input.components.length === 0 ||
+    input.components.length > 12
+  ) {
+    fail("components must contain between one and twelve components");
+  }
+  if (!Array.isArray(input.variants) || input.variants.length === 0) {
+    fail("variants must contain at least one variant");
+  }
+  if (!input.change_counts || typeof input.change_counts !== "object") {
+    fail("change_counts must be an object");
+  }
+
+  const labels = new Set();
+  const components = input.components.map((component, index) => {
+    if (
+      !component ||
+      typeof component !== "object" ||
+      Array.isArray(component)
+    ) {
+      fail(`components[${index}] must be an object`);
+    }
+    const label = requiredString(component.label, `components[${index}].label`);
+    if (labels.has(label.toLowerCase())) {
+      fail(`components[${index}].label must be unique`);
+    }
+    labels.add(label.toLowerCase());
+
+    const previousVersion = component.previous_version;
+    if (
+      previousVersion !== null &&
+      previousVersion !== undefined &&
+      typeof previousVersion !== "string"
+    ) {
+      fail(`components[${index}].previous_version must be a string or null`);
+    }
+
+    return {
+      label,
+      version: requiredString(
+        component.version,
+        `components[${index}].version`,
+      ),
+      previous_version: previousVersion?.trim() || null,
+    };
+  });
+
+  const variants = input.variants.map((variant, index) => {
+    if (!variant || typeof variant !== "object" || Array.isArray(variant)) {
+      fail(`variants[${index}] must be an object`);
+    }
+    return {
+      name: requiredString(variant.name, `variants[${index}].name`),
+      digest: sha256(variant.digest, `variants[${index}].digest`),
+    };
+  });
+
+  return {
+    product,
+    project_name: requiredString(input.project_name, "project_name"),
+    tag: requiredString(input.tag, "tag"),
+    published_at: publishedAt,
+    primary_image: requiredString(input.primary_image, "primary_image"),
+    primary_digest: sha256(input.primary_digest, "primary_digest"),
+    badge_label: requiredString(input.badge_label, "badge_label"),
+    components,
+    change_counts: {
+      updated: nonNegativeInteger(
+        input.change_counts.updated,
+        "change_counts.updated",
+      ),
+      added: nonNegativeInteger(
+        input.change_counts.added,
+        "change_counts.added",
+      ),
+      removed: nonNegativeInteger(
+        input.change_counts.removed,
+        "change_counts.removed",
+      ),
+    },
+    variants,
+  };
+}
+
+function loadAssets(root, product) {
+  const fontDirectory = join(root, "node_modules/@fontsource/inter/files");
+  const mascot = product === "dakota" ? "dakotaraptor" : "bluefin-small";
+  const mascotBuffer = readFileSync(
+    join(root, "static/img/characters", `${mascot}.png`),
+  );
+
+  return {
+    fonts: [
+      {
+        name: "Inter",
+        data: readFileSync(join(fontDirectory, "inter-latin-400-normal.woff")),
+        weight: 400,
+        style: "normal",
+      },
+      {
+        name: "Inter",
+        data: readFileSync(join(fontDirectory, "inter-latin-700-normal.woff")),
+        weight: 700,
+        style: "normal",
+      },
+    ],
+    mascotDataUri: `data:image/png;base64,${mascotBuffer.toString("base64")}`,
+  };
+}
+
+function templateRelease(context) {
+  return {
+    tag: context.tag,
+    fedoraVersion: null,
+    centosVersion: null,
+    majorPackages: context.components.map((component) => ({
+      name: component.label,
+      version: component.version,
+      prevVersion: component.previous_version,
+    })),
+    dxPackages: [],
+    gdxPackages: [],
+    diffStats: {
+      changed: context.change_counts.updated,
+      added: context.change_counts.added,
+      removed: context.change_counts.removed,
+    },
+    commitCount: 0,
+  };
+}
+
+export function releaseCardText(input) {
+  const context = validateReleaseContext(input);
+  return [
+    context.project_name,
+    context.tag,
+    ...context.components.flatMap((component) => [
+      component.label,
+      component.version,
+    ]),
+  ].join("\n");
+}
+
+async function renderTheme(context, theme, root) {
+  const { fonts, mascotDataUri } = loadAssets(root, context.product);
+  const stream = context.product === "dakota" ? "dakota" : "stable";
+  const element = renderCard(
+    templateRelease(context),
+    stream,
+    Date.parse(context.published_at),
+    theme,
+    mascotDataUri,
+    context.project_name,
+    context.components.map((component) => component.label),
+  );
+  const svg = await satori(element, { width: W, height: H, fonts });
+  const rendered = new Resvg(svg, {
+    fitTo: { mode: "width", value: W * 2 },
+  }).render();
+
+  return {
+    png: rendered.asPng(),
+    width: rendered.width,
+    height: rendered.height,
+  };
+}
+
+function decodePng(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < PNG_SIGNATURE.length + 25) {
+    throw new Error("PNG is truncated");
+  }
+  if (!buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    throw new Error("PNG signature is invalid");
+  }
+
+  let offset = PNG_SIGNATURE.length;
+  let header;
+  const idat = [];
+  let sawEnd = false;
+  while (offset < buffer.length) {
+    if (offset + 12 > buffer.length) throw new Error("PNG chunk is truncated");
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString("ascii", offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    if (dataEnd + 4 > buffer.length)
+      throw new Error("PNG chunk payload is truncated");
+    const data = buffer.subarray(dataStart, dataEnd);
+    if (type === "IHDR") {
+      if (header || length !== 13) throw new Error("PNG header is invalid");
+      header = {
+        width: data.readUInt32BE(0),
+        height: data.readUInt32BE(4),
+        bitDepth: data[8],
+        colorType: data[9],
+        compression: data[10],
+        filter: data[11],
+        interlace: data[12],
+      };
+    } else if (type === "IDAT") {
+      idat.push(data);
+    } else if (type === "IEND") {
+      sawEnd = true;
+      break;
+    }
+    offset = dataEnd + 4;
+  }
+
+  if (!header || !sawEnd || idat.length === 0)
+    throw new Error("PNG is missing required chunks");
+  if (
+    header.width === 0 ||
+    header.height === 0 ||
+    header.bitDepth !== 8 ||
+    ![2, 6].includes(header.colorType) ||
+    header.compression !== 0 ||
+    header.filter !== 0 ||
+    header.interlace !== 0
+  ) {
+    throw new Error("PNG uses an unsupported encoding");
+  }
+
+  const bytesPerPixel = header.colorType === 6 ? 4 : 3;
+  const stride = header.width * bytesPerPixel;
+  const decoded = inflateSync(Buffer.concat(idat));
+  if (decoded.length !== (stride + 1) * header.height) {
+    throw new Error("PNG pixel data has an unexpected length");
+  }
+
+  const pixels = Buffer.alloc(stride * header.height);
+  let sourceOffset = 0;
+  for (let y = 0; y < header.height; y++) {
+    const filter = decoded[sourceOffset++];
+    const rowOffset = y * stride;
+    const previousRowOffset = (y - 1) * stride;
+    for (let x = 0; x < stride; x++) {
+      const source = decoded[sourceOffset++];
+      const left =
+        x >= bytesPerPixel ? pixels[rowOffset + x - bytesPerPixel] : 0;
+      const up = y > 0 ? pixels[previousRowOffset + x] : 0;
+      const upLeft =
+        y > 0 && x >= bytesPerPixel
+          ? pixels[previousRowOffset + x - bytesPerPixel]
+          : 0;
+      let value;
+      if (filter === 0) value = source;
+      else if (filter === 1) value = source + left;
+      else if (filter === 2) value = source + up;
+      else if (filter === 3) value = source + Math.floor((left + up) / 2);
+      else if (filter === 4) {
+        const prediction = left + up - upLeft;
+        const pa = Math.abs(prediction - left);
+        const pb = Math.abs(prediction - up);
+        const pc = Math.abs(prediction - upLeft);
+        value = source + (pa <= pb && pa <= pc ? left : pb <= pc ? up : upLeft);
+      } else {
+        throw new Error("PNG uses an unsupported row filter");
+      }
+      pixels[rowOffset + x] = value & 0xff;
+    }
+  }
+
+  return { ...header, pixels, bytesPerPixel };
+}
+
+export function validatePngBuffer(buffer) {
+  const decoded = decodePng(buffer);
+  if (decoded.width < W || decoded.height < H) {
+    throw new Error(
+      `PNG dimensions ${decoded.width}x${decoded.height} are smaller than ${W}x${H}`,
+    );
+  }
+  if (buffer.length <= 68) {
+    throw new Error("PNG is too small to be a release card");
+  }
+  let nonTransparentPixels = 0;
+  if (decoded.colorType === 2) {
+    nonTransparentPixels = decoded.width * decoded.height;
+  } else {
+    for (
+      let index = 3;
+      index < decoded.pixels.length;
+      index += decoded.bytesPerPixel
+    ) {
+      if (decoded.pixels[index] !== 0) nonTransparentPixels++;
+    }
+  }
+  if (nonTransparentPixels === 0) {
+    throw new Error("PNG is fully transparent");
+  }
+  return { width: decoded.width, height: decoded.height, nonTransparentPixels };
+}
+
+export async function renderReleaseCards(
+  input,
+  outputDir,
+  { root = ROOT } = {},
+) {
+  const context = validateReleaseContext(input);
+  const resolvedOutputDir = resolve(outputDir);
+  const lightPath = join(resolvedOutputDir, "release-card.png");
+  const darkPath = join(resolvedOutputDir, "release-card-dark.png");
+
+  mkdirSync(resolvedOutputDir, { recursive: true });
+  const light = await renderTheme(context, "light", root);
+  const dark = await renderTheme(context, "dark", root);
+  validatePngBuffer(light.png);
+  validatePngBuffer(dark.png);
+  writeFileSync(lightPath, light.png);
+  writeFileSync(darkPath, dark.png);
+
+  return { lightPath, darkPath, width: light.width, height: light.height };
+}
+
+function parseArguments(args) {
+  if (args.length !== 4)
+    throw new Error(
+      "Usage: render-release-card.mjs --context <file> --output-dir <directory>",
+    );
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (
+      !["--context", "--output-dir"].includes(option) ||
+      !value ||
+      values.has(option)
+    ) {
+      throw new Error(
+        "Usage: render-release-card.mjs --context <file> --output-dir <directory>",
+      );
+    }
+    values.set(option, value);
+  }
+  return {
+    contextPath: values.get("--context"),
+    outputDir: values.get("--output-dir"),
+  };
+}
+
+async function main() {
+  const { contextPath, outputDir } = parseArguments(process.argv.slice(2));
+  let context;
+  try {
+    context = JSON.parse(readFileSync(contextPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Unable to read release context ${contextPath}: ${error.message}`,
+    );
+  }
+  const result = await renderReleaseCards(context, outputDir);
+  console.log(
+    `Rendered ${result.lightPath} and ${result.darkPath} (${result.width}x${result.height})`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/render-release-card.mjs
+++ b/scripts/render-release-card.mjs
@@ -10,6 +10,8 @@ import { H, renderCard, W } from "./lib/card-template.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const TIMEZONE_ISO_8601 =
+  /^(\d{4})-(\d{2})-(\d{2})T(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d{1,3})?)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 function fail(message) {
   throw new Error(`Invalid release card context: ${message}`);
@@ -37,6 +39,23 @@ function nonNegativeInteger(value, path) {
   return value;
 }
 
+function validatePublishedAt(value) {
+  const timestamp = requiredString(value, "published_at");
+  const match = TIMEZONE_ISO_8601.exec(timestamp);
+  if (!match) {
+    fail("published_at must be a timezone-qualified ISO-8601 timestamp");
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth) {
+    fail("published_at must be a valid calendar date");
+  }
+  return timestamp;
+}
+
 export function validateReleaseContext(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     fail("must be a JSON object");
@@ -47,10 +66,7 @@ export function validateReleaseContext(input) {
     fail("product must be bluefin or dakota");
   }
 
-  const publishedAt = requiredString(input.published_at, "published_at");
-  if (!Number.isFinite(Date.parse(publishedAt))) {
-    fail("published_at must be an ISO-8601 timestamp");
-  }
+  const publishedAt = validatePublishedAt(input.published_at);
 
   if (
     !Array.isArray(input.components) ||
@@ -184,30 +200,30 @@ function templateRelease(context) {
   };
 }
 
-export function releaseCardText(input) {
+function cardElement(context, theme, root) {
+  const { fonts, mascotDataUri } = loadAssets(root, context.product);
+  const stream = context.product === "dakota" ? "dakota" : "stable";
+  return {
+    element: renderCard(
+      templateRelease(context),
+      stream,
+      Date.parse(context.published_at),
+      theme,
+      mascotDataUri,
+      context.project_name,
+      context.components.map((component) => component.label),
+    ),
+    fonts,
+  };
+}
+
+export function createReleaseCardElement(input, theme, { root = ROOT } = {}) {
   const context = validateReleaseContext(input);
-  return [
-    context.project_name,
-    context.tag,
-    ...context.components.flatMap((component) => [
-      component.label,
-      component.version,
-    ]),
-  ].join("\n");
+  return cardElement(context, theme, root).element;
 }
 
 async function renderTheme(context, theme, root) {
-  const { fonts, mascotDataUri } = loadAssets(root, context.product);
-  const stream = context.product === "dakota" ? "dakota" : "stable";
-  const element = renderCard(
-    templateRelease(context),
-    stream,
-    Date.parse(context.published_at),
-    theme,
-    mascotDataUri,
-    context.project_name,
-    context.components.map((component) => component.label),
-  );
+  const { element, fonts } = cardElement(context, theme, root);
   const svg = await satori(element, { width: W, height: H, fonts });
   const rendered = new Resvg(svg, {
     fitTo: { mode: "width", value: W * 2 },

--- a/scripts/render-release-card.test.js
+++ b/scripts/render-release-card.test.js
@@ -48,6 +48,39 @@ function testDirectory() {
   return mkdtempSync(join(process.cwd(), "scripts", ".release-card-test-"));
 }
 
+function renderedElementText(node) {
+  if (typeof node === "string") return node;
+  if (!node) return "";
+  if (Array.isArray(node)) return node.map(renderedElementText).join("\n");
+  return renderedElementText(node?.props?.children);
+}
+
+function renderedDateInTimeZone(timeZone) {
+  const script = `
+    import { createReleaseCardElement } from "./scripts/render-release-card.mjs";
+    const context = JSON.parse(process.env.RELEASE_CONTEXT);
+    function text(node) {
+      if (typeof node === "string") return node;
+      if (!node) return "";
+      if (Array.isArray(node)) return node.map(text).join("\\n");
+      return text(node?.props?.children);
+    }
+    console.log(text(createReleaseCardElement(context, "light")));
+  `;
+  return execFileSync(
+    process.execPath,
+    ["--input-type=module", "--eval", script],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        RELEASE_CONTEXT: JSON.stringify(bluefinContext),
+        TZ: timeZone,
+      },
+    },
+  ).toString();
+}
+
 async function renderFixture(context) {
   const { renderReleaseCards } = await import("./render-release-card.mjs");
   const directory = testDirectory();
@@ -70,7 +103,7 @@ for (const [name, context] of [
   ["Dakota", dakotaContext],
 ]) {
   test(`${name} release context renders distinct, non-blank light and dark cards`, async () => {
-    const { validatePngBuffer, releaseCardText } =
+    const { createReleaseCardElement, validatePngBuffer } =
       await import("./render-release-card.mjs");
     const fixture = await renderFixture(context);
     try {
@@ -89,7 +122,9 @@ for (const [name, context] of [
       assert.ok(darkInfo.nonTransparentPixels > 0);
       assert.notDeepEqual(fixture.light, fixture.dark);
 
-      const text = releaseCardText(context);
+      const text = renderedElementText(
+        createReleaseCardElement(context, "light"),
+      );
       assert.match(text, new RegExp(context.tag));
       for (const component of context.components) {
         assert.match(text, new RegExp(component.version));
@@ -118,6 +153,25 @@ test("invalid release context fails before image creation", async () => {
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("published_at requires a timezone-qualified ISO-8601 timestamp", async () => {
+  const { validateReleaseContext } = await import("./render-release-card.mjs");
+  assert.throws(
+    () =>
+      validateReleaseContext({
+        ...bluefinContext,
+        published_at: "2026-08-02T00:00:00",
+      }),
+    /timezone-qualified ISO-8601 timestamp/,
+  );
+});
+
+test("rendered dates are invariant across process time zones", () => {
+  const losAngeles = renderedDateInTimeZone("America/Los_Angeles");
+  const tokyo = renderedDateInTimeZone("Asia/Tokyo");
+  assert.equal(losAngeles, tokyo);
+  assert.match(losAngeles, /August 2, 2026/);
 });
 
 test("command-line renderer writes the documented output names", () => {

--- a/scripts/render-release-card.test.js
+++ b/scripts/render-release-card.test.js
@@ -1,0 +1,145 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("fs");
+const { join } = require("path");
+const { execFileSync } = require("child_process");
+
+const SHA =
+  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+const bluefinContext = {
+  product: "bluefin",
+  project_name: "Bluefin",
+  tag: "stable-20260802",
+  published_at: "2026-08-02T00:00:00Z",
+  primary_image: "ghcr.io/projectbluefin/bluefin",
+  primary_digest: SHA,
+  badge_label: "Stable",
+  components: [
+    { label: "Kernel", version: "6.17.1", previous_version: "6.17.0" },
+    { label: "Mesa", version: "25.1.2", previous_version: "25.1.1" },
+  ],
+  change_counts: { updated: 12, added: 3, removed: 1 },
+  variants: [{ name: "bluefin", digest: SHA }],
+};
+
+const dakotaContext = {
+  ...bluefinContext,
+  product: "dakota",
+  project_name: "Dakota",
+  tag: "dakota-20260802",
+  primary_image: "ghcr.io/projectbluefin/dakota",
+  badge_label: "Dakota",
+  components: [
+    { label: "Kernel", version: "6.18.0", previous_version: "6.17.1" },
+    { label: "BuildStream", version: "2.4.1", previous_version: null },
+  ],
+  change_counts: { updated: 4, added: 1, removed: 0 },
+  variants: [{ name: "dakota", digest: SHA }],
+};
+
+function testDirectory() {
+  return mkdtempSync(join(process.cwd(), "scripts", ".release-card-test-"));
+}
+
+async function renderFixture(context) {
+  const { renderReleaseCards } = await import("./render-release-card.mjs");
+  const directory = testDirectory();
+  try {
+    const result = await renderReleaseCards(context, join(directory, "cards"));
+    return {
+      directory,
+      result,
+      light: readFileSync(result.lightPath),
+      dark: readFileSync(result.darkPath),
+    };
+  } catch (error) {
+    rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+for (const [name, context] of [
+  ["Bluefin", bluefinContext],
+  ["Dakota", dakotaContext],
+]) {
+  test(`${name} release context renders distinct, non-blank light and dark cards`, async () => {
+    const { validatePngBuffer, releaseCardText } =
+      await import("./render-release-card.mjs");
+    const fixture = await renderFixture(context);
+    try {
+      const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+      assert.deepEqual(fixture.light.subarray(0, 8), signature);
+      assert.deepEqual(fixture.dark.subarray(0, 8), signature);
+      assert.ok(fixture.light.length > 68);
+      assert.ok(fixture.dark.length > 68);
+      const lightInfo = validatePngBuffer(fixture.light);
+      const darkInfo = validatePngBuffer(fixture.dark);
+      assert.equal(lightInfo.width, 1600);
+      assert.equal(lightInfo.height, 600);
+      assert.ok(lightInfo.nonTransparentPixels > 0);
+      assert.equal(darkInfo.width, 1600);
+      assert.equal(darkInfo.height, 600);
+      assert.ok(darkInfo.nonTransparentPixels > 0);
+      assert.notDeepEqual(fixture.light, fixture.dark);
+
+      const text = releaseCardText(context);
+      assert.match(text, new RegExp(context.tag));
+      for (const component of context.components) {
+        assert.match(text, new RegExp(component.version));
+      }
+    } finally {
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test("invalid release context fails before image creation", async () => {
+  const { renderReleaseCards } = await import("./render-release-card.mjs");
+  const directory = testDirectory();
+  try {
+    await assert.rejects(
+      () =>
+        renderReleaseCards(
+          { ...bluefinContext, components: [] },
+          join(directory, "cards"),
+        ),
+      /components must contain between one and twelve components/,
+    );
+    assert.throws(() =>
+      readFileSync(join(directory, "cards", "release-card.png")),
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("command-line renderer writes the documented output names", () => {
+  const directory = testDirectory();
+  try {
+    const contextPath = join(directory, "context.json");
+    const outputDir = join(directory, "cards");
+    writeFileSync(contextPath, JSON.stringify(bluefinContext));
+    execFileSync(
+      process.execPath,
+      [
+        "scripts/render-release-card.mjs",
+        "--context",
+        contextPath,
+        "--output-dir",
+        outputDir,
+      ],
+      { cwd: process.cwd(), stdio: "pipe" },
+    );
+    assert.ok(existsSync(join(outputDir, "release-card.png")));
+    assert.ok(existsSync(join(outputDir, "release-card-dark.png")));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Purpose

Adds a deterministic release-card renderer for documentation integration. This renderer generates consistent, context-aware release cards from structured release data.

## What this changes

- **Deterministic renderer** (`scripts/render-release-card.js`): generates release-card output deterministically from release context, suitable for use in CI pipelines and actions integration
- **Timestamp validation fix**: validates timestamps deterministically to avoid environment-dependent output

## Tests

Focused unit tests run with:

```
node --test scripts/render-release-card.test.js
```

## Prerequisite

This PR is a prerequisite to the `projectbluefin/actions` integration that will call this renderer during the release pipeline. The actions integration depends on this renderer being available and stable in `main`.