### PR TITLE
docs(downloads): promote Dakota alpha5

### DIFF
--- a/src/components/DownloadSectionTesting.tsx
+++ b/src/components/DownloadSectionTesting.tsx
@@ -20,13 +20,13 @@ export const DakotaSection: React.FC = () => (
     ]}
     sections={[
       {
-        label: "Alpha 4",
+        label: "Alpha 5",
         entries: [
           {
             label: "AMD / Intel + Nvidia (Unified)",
-            isoUrl: `${BASE}/dakota-live-alpha4.iso`,
-            isoFilename: "dakota-live-alpha4.iso",
-            checksumUrl: `${BASE}/dakota-live-alpha4.iso-CHECKSUM`,
+            isoUrl: `${BASE}/dakota-live-alpha5.iso`,
+            isoFilename: "dakota-live-alpha5.iso",
+            checksumUrl: `${BASE}/dakota-live-alpha5.iso-CHECKSUM`,
           },
         ],
       },


### PR DESCRIPTION
Summary: update the named Dakota testing download from Alpha 4 to Alpha 5 and point it at the verified current Alpha 5 ISO and checksum. Evidence: https://github.com/projectbluefin/dakota-iso/actions/runs/30763437632. Validation: npm run lint; npm test. Known baseline limitations: repository-wide formatting has unrelated failures; typecheck and build require generated data files absent from a fresh checkout.