### PR TITLE
fix(factory): correct branding terminology, relabel countme, drop non-owned toolbox images

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -10,6 +10,7 @@ Task → skill. Load only what the task needs.
 | If your task is…                                      | Load                                                                                        |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Adding or changing a React component                  | [`skills/component-testing.md`](skills/component-testing.md)                                |
+| Editing `/factory` dashboard panels or copy           | [`skills/factory-dashboard-content.md`](skills/factory-dashboard-content.md)                |
 | Verifying, recovering, or archiving a blog discussion | [`skills/giscus-discussions.md`](skills/giscus-discussions.md)                              |
 | Writing back what you learned                         | [`skills/skill-improvement.md`](skills/skill-improvement.md)                                |
 | Anything else                                         | [`../AGENTS.md`](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md) first |

--- a/docs/skills/factory-dashboard-content.md
+++ b/docs/skills/factory-dashboard-content.md
@@ -1,0 +1,63 @@
+---
+title: Factory dashboard content
+---
+
+# Factory dashboard content
+
+The `/factory` dashboard (`src/components/HiveFactoryDashboard.tsx` and the panels
+under `src/components/factory/panels/`) reports on Bluefin with live data. Chart
+titles, summaries and captions are public-facing copy, so they follow the same
+rules as any other page — plus a few that are specific to this data.
+
+## Brand terminology in panel copy
+
+Panel titles and summaries must follow [`/press-kit`](/press-kit). In practice:
+
+- **Never** call Bluefin or its peers an "immutable distribution" or an
+  "immutable desktop" — the press kit bans it, and there is no such thing as an
+  "immutable desktop". Bluefin is a bootc image / a cloud-native operating
+  system.
+- The peers shown in the ecosystem and Flathub comparisons — Bluefin, Bluefin
+  LTS, Aurora, Bazzite — are Universal Blue **cloud-native desktops** (or just
+  "images"). Fedora is the shared base they build on, not a peer image.
+- Do not invent grouping terms. "peer immutable distributions" was made up;
+  "peer cloud-native desktops" is accurate.
+
+## Only projectbluefin images belong on the dashboard
+
+The GHCR inventory (`scripts/fetch-ghcr-packages.js`) reports images owned by the
+`projectbluefin` org only. When adding a lane to `FALLBACK_LANES`, confirm the
+image actually belongs to us. Images like `bluefin-toolbox` and `ubuntu-toolbox`
+do **not** and were removed. If removing a lane empties a whole UI section,
+remove the section too — a permanently-empty panel that says "no data found"
+misleads readers into thinking there is a gap.
+
+## countme is check-ins, not devices
+
+The adoption numbers come from Fedora's public countme totals CSV
+(`scripts/fetch-countme.js` → `static/data/countme-history.json`, a tracked
+seed). Two things to remember:
+
+- The values are **real**. Before "fixing" a suspicious number, verify against
+  source: `node scripts/fetch-countme.js --force` re-derives the file from
+  Fedora's CSV. If the diff is empty, the committed data is correct — relabel or
+  reinterpret rather than editing the seed.
+- countme is a weekly **check-in estimate**, not a device census. Label the panel
+  "countme check-ins", never "active devices", so a low number (e.g. new LTS) is
+  not read as a literal install base.
+
+## Charts render to canvas
+
+`src/components/factory/chartTheme.ts` hardcodes a dark palette on purpose:
+ECharts renders to canvas, where `var(--fx-*)` custom properties do not resolve.
+`factory-theming.test.js` guards the banned severity pairs. HTML/CSS chrome
+themes for light/dark via `factory/tokens.css`, but making the charts themselves
+theme-reactive is a separate effort — do not sprinkle one-off hex values into a
+single panel expecting it to follow the site theme.
+
+## Tests pin the copy
+
+Panel tests assert on rendered titles and headings
+(`scripts/*-panels.test.js`). When you change a chart `title`, section heading,
+or `Unavailable` `what=` string, update the matching assertion in the same
+change.

--- a/scripts/fetch-ghcr-packages.js
+++ b/scripts/fetch-ghcr-packages.js
@@ -63,7 +63,6 @@ const DATED_STREAM_TAG = /^(stable|testing|latest|nightly|beta|gts|lts)-\d{8}/;
  */
 export function classifyFamily(name) {
   if (name.endsWith("-cache") || name.endsWith("-pr")) return "internal";
-  if (name.endsWith("-toolbox")) return "toolbox";
   if (name.startsWith("bluefin") || name.startsWith("dakota")) return "os";
   if (
     name.startsWith("base") ||
@@ -208,8 +207,6 @@ export const FALLBACK_LANES = [
   "bluefin-lts-hwe-nvidia",
   "dakota",
   "dakota-nvidia",
-  "bluefin-toolbox",
-  "ubuntu-toolbox",
   "base",
   "static",
   "skopeo",

--- a/scripts/fetch-ghcr-packages.test.js
+++ b/scripts/fetch-ghcr-packages.test.js
@@ -38,11 +38,6 @@ test("classifyFamily: userspace", () => {
   assert.equal(classifyFamily("lab-runner-aarch64"), "userspace");
 });
 
-test("classifyFamily: toolbox", () => {
-  assert.equal(classifyFamily("bluefin-toolbox"), "toolbox");
-  assert.equal(classifyFamily("ubuntu-toolbox"), "toolbox");
-});
-
 test("classifyFamily: tooling", () => {
   assert.equal(classifyFamily("testsuite/desktop-screenshot"), "tooling");
   assert.equal(classifyFamily("common"), "tooling");
@@ -190,7 +185,7 @@ test("the fallback lane list covers the families the views report on", () => {
   // packages fails there. Without a fallback the Images and Userspace views
   // would be empty in production while looking fine locally.
   const families = new Set(FALLBACK_LANES.map(classifyFamily));
-  for (const f of ["os", "userspace", "toolbox"]) {
+  for (const f of ["os", "userspace"]) {
     assert.ok(families.has(f), `fallback lanes cover no ${f} image`);
   }
 });

--- a/scripts/images-panels.test.js
+++ b/scripts/images-panels.test.js
@@ -25,20 +25,6 @@ const FIXTURE_FULL = {
       ],
     },
     {
-      name: "toolbox-ubuntu",
-      family: "toolbox",
-      versionCount: 10,
-      streams: [
-        {
-          tag: "latest",
-          publishedAt: "2026-07-20T00:00:00Z",
-          ageDays: 17,
-          state: "stale",
-          stateReason: "Expected within 7 days",
-        },
-      ],
-    },
-    {
       name: "awaiting-image",
       family: "os",
       versionCount: 0,
@@ -67,7 +53,7 @@ const FIXTURE_FULL = {
       ],
     },
   ],
-  familyCounts: { os: 2, toolbox: 1, internal: 1 },
+  familyCounts: { os: 2, internal: 1 },
   unavailable: false,
   stateReason: null,
 };

--- a/scripts/metrics-panels.test.js
+++ b/scripts/metrics-panels.test.js
@@ -490,7 +490,7 @@ test("pie slices carry absolute numbers, not just percentages", () => {
   });
   // The pie option should include the absolute value in the label formatter
   const pieMatch = html.match(
-    /data-title="Immutable desktop ecosystem share"[^>]*data-option="([^"]*)"/,
+    /data-title="Cloud-native desktop ecosystem share"[^>]*data-option="([^"]*)"/,
   );
   assert.ok(pieMatch, "pie chart should exist");
   const optStr = pieMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, "&");
@@ -579,7 +579,7 @@ test("unavailable dora does not prevent countme panel rendering", () => {
     scorecard: SCORECARD,
   });
   // Countme panel should still render
-  assert.ok(html.includes("Active devices"));
+  assert.ok(html.includes("Weekly countme check-ins"));
   // Dora should show unavailable
   assert.ok(html.includes("Delivery frequency"));
 });

--- a/scripts/userspace-panels.test.js
+++ b/scripts/userspace-panels.test.js
@@ -52,22 +52,8 @@ const GHCR_FIXTURE = {
         },
       ],
     },
-    {
-      name: "toolbox-ubuntu",
-      family: "toolbox",
-      versionCount: 10,
-      streams: [
-        {
-          tag: "latest",
-          publishedAt: "2026-08-03T00:00:00Z",
-          ageDays: 3,
-          state: "fresh",
-          stateReason: null,
-        },
-      ],
-    },
   ],
-  familyCounts: { userspace: 3, toolbox: 1 },
+  familyCounts: { userspace: 3 },
   unavailable: false,
   stateReason: null,
 };
@@ -254,9 +240,4 @@ test("rendering is deterministic", () => {
 test("flatpak versions chart is rendered", () => {
   const html = render(GHCR_FIXTURE, FLATHUB_FIXTURE);
   assert.ok(html.includes("Flatpak runtime versions on Bluefin"));
-});
-
-test("toolbox section renders toolbox images", () => {
-  const html = render(GHCR_FIXTURE, FLATHUB_FIXTURE);
-  assert.ok(html.includes("toolbox-ubuntu"));
 });

--- a/src/components/factory/panels/ApplicationsPanels.tsx
+++ b/src/components/factory/panels/ApplicationsPanels.tsx
@@ -278,8 +278,8 @@ export default function ApplicationsPanels({
             {(bluefinOs.share * 100).toFixed(3)}% of all Flathub downloads
           </div>
           <EChart
-            title="Bluefin Flathub downloads by Fedora version"
-            summary={`${formatNumber(bluefinOs.downloads)} total downloads across ${Object.keys(bluefinOs.versions).length} Fedora versions.`}
+            title="Bluefin Flathub downloads by base version"
+            summary={`${formatNumber(bluefinOs.downloads)} total downloads across ${Object.keys(bluefinOs.versions).length} Bluefin base versions.`}
             points={Object.keys(bluefinOs.versions).length}
             minPoints={1}
             height={220}
@@ -321,7 +321,7 @@ export default function ApplicationsPanels({
       {/* 5. Peer comparison (log scale) */}
       {flReady && peerEntries.length > 0 ? (
         <EChart
-          title="Bluefin vs peer immutable distributions on Flathub (log scale)"
+          title="Bluefin vs peer cloud-native desktops on Flathub (log scale)"
           summary={`Bluefin: ${formatNumber(bluefinOs?.downloads ?? 0)}. Bazzite and Fedora are 1–2 orders of magnitude larger; a logarithmic scale is used so all bars remain visible.`}
           points={peerEntries.length}
           minPoints={2}

--- a/src/components/factory/panels/MetricsPanels.tsx
+++ b/src/components/factory/panels/MetricsPanels.tsx
@@ -143,7 +143,7 @@ export default function MetricsPanels({
   );
 }
 
-// ── Panel 1: Active devices ────────────────────────────────────────────────
+// ── Panel 1: Weekly countme check-ins ──────────────────────────────────────
 
 function ActiveDevices({
   countme,
@@ -159,7 +159,7 @@ function ActiveDevices({
   if (countme.reason || (!countme.loading && !countme.data)) {
     return (
       <Unavailable
-        what="Active devices"
+        what="Weekly countme check-ins"
         reason={
           countme.reason ?? "countme data is not available in this environment."
         }
@@ -168,13 +168,16 @@ function ActiveDevices({
   }
   if (countme.loading || !countme.data) {
     return (
-      <Unavailable what="Active devices" reason="Loading adoption data…" />
+      <Unavailable
+        what="Weekly countme check-ins"
+        reason="Loading adoption data…"
+      />
     );
   }
   if (countme.data.unavailable) {
     return (
       <Unavailable
-        what="Active devices"
+        what="Weekly countme check-ins"
         reason={countme.data.stateReason ?? "Data unavailable."}
       />
     );
@@ -216,7 +219,7 @@ function ActiveDevices({
 
   return (
     <section className={styles.section}>
-      <h2 className={styles.heading}>Active devices</h2>
+      <h2 className={styles.heading}>Weekly countme check-ins</h2>
       <div className={styles.currentValue}>
         {fmt(currentBluefin)} Bluefin · {fmt(currentLts)} LTS
       </div>
@@ -234,8 +237,8 @@ function ActiveDevices({
       </div>
       <EChart
         option={option}
-        title="Weekly active devices"
-        summary={`Bluefin: ${fmt(currentBluefin)} devices this week. LTS: ${fmt(currentLts)}.`}
+        title="Weekly countme check-ins"
+        summary={`Bluefin: ${fmt(currentBluefin)} countme check-ins this week. LTS: ${fmt(currentLts)}. countme is a Fedora-side weekly check-in estimate, not a literal device count.`}
         points={realPoints}
         minPoints={2}
         tableCaption="Weekly countme hits for Bluefin and Bluefin LTS"
@@ -320,12 +323,12 @@ function EcosystemShare({
       <h2 className={styles.heading}>Ecosystem share</h2>
       <EChart
         option={option}
-        title="Immutable desktop ecosystem share"
-        summary={`Latest week across ${slices.length} peer distributions (excluding Fedora, which dwarfs the rest and is not a peer immutable desktop).`}
+        title="Cloud-native desktop ecosystem share"
+        summary={`Latest week across ${slices.length} peer cloud-native desktops (excluding Fedora, which dwarfs the rest and is the shared base rather than a peer image).`}
         points={realPoints}
         minPoints={2}
         height={320}
-        tableCaption="Weekly countme hits by distribution"
+        tableCaption="Weekly countme hits by image"
       />
     </section>
   );

--- a/src/components/factory/panels/UserspacePanels.tsx
+++ b/src/components/factory/panels/UserspacePanels.tsx
@@ -102,7 +102,6 @@ export default function UserspacePanels({
 
   const packages = ghcr.data?.packages ?? [];
   const userspacePackages = packages.filter((p) => p.family === "userspace");
-  const toolboxPackages = packages.filter((p) => p.family === "toolbox");
 
   const userspaceStreams = userspacePackages.flatMap((p) =>
     p.streams.map((st) => ({ pkg: p.name, ...st })),
@@ -113,7 +112,6 @@ export default function UserspacePanels({
   const recentlyPublished = userspaceStreams.filter(
     (s) => s.ageDays !== null && s.ageDays <= 7,
   ).length;
-  const toolboxCount = toolboxPackages.length;
   const arches = new Set(userspacePackages.map((p) => archOf(p.name)));
 
   // Inventory table, sorted oldest first
@@ -192,12 +190,6 @@ export default function UserspacePanels({
         </div>
         <div className={styles.kpi}>
           <span className={styles.kpiValue}>
-            {FX_SEVERITY.ok.glyph} {toolboxCount}
-          </span>
-          <span className={styles.kpiLabel}>Toolbox images</span>
-        </div>
-        <div className={styles.kpi}>
-          <span className={styles.kpiValue}>
             {FX_SEVERITY.ok.glyph} {arches.size}
           </span>
           <span className={styles.kpiLabel}>Architectures</span>
@@ -248,7 +240,7 @@ export default function UserspacePanels({
         <EChart
           option={fpOption}
           title="Flatpak runtime versions on Bluefin"
-          summary={`${fpVersions.length} runtime versions detected. This distribution is Bluefin-specific and available nowhere else on the site.`}
+          summary={`${fpVersions.length} runtime versions detected. This dataset is Bluefin-specific and available nowhere else on the site.`}
           points={fpVersions.length}
         />
       ) : (
@@ -260,37 +252,6 @@ export default function UserspacePanels({
             "Flathub data unavailable."
           }
         />
-      )}
-
-      {/* Toolbox images */}
-      <h2 className={styles.sectionHeading}>Toolbox images</h2>
-      {toolboxPackages.length === 0 ? (
-        <Unavailable
-          what="Toolbox images"
-          reason="No toolbox images found in the package inventory."
-        />
-      ) : (
-        <div className={styles.cardGrid}>
-          {toolboxPackages.flatMap((p) =>
-            p.streams.map((st) => {
-              const sev = severityOf(st.state);
-              return (
-                <div key={`${p.name}-${st.tag}`} className={styles.card}>
-                  <div className={styles.cardName}>
-                    {p.name}:{st.tag}
-                  </div>
-                  <div className={styles.cardAge}>
-                    {FX_SEVERITY[sev].glyph}{" "}
-                    {st.ageDays !== null ? `${st.ageDays}d` : "awaiting"}
-                  </div>
-                  {st.state !== "fresh" && st.stateReason && (
-                    <div className={styles.cardReason}>{st.stateReason}</div>
-                  )}
-                </div>
-              );
-            }),
-          )}
-        </div>
       )}
 
       {/* Where the rest lives */}

--- a/src/components/factory/routes.ts
+++ b/src/components/factory/routes.ts
@@ -96,7 +96,7 @@ export const FACTORY_ROUTES: FactoryRoute[] = [
     path: "/factory/userspace",
     id: "userspace",
     label: "Userspace",
-    hint: "The userspace stack: base images, runtimes and toolboxes",
+    hint: "The userspace stack: base images and runtimes",
     datasets: ["ghcrPackages", "flathub"],
   },
   {


### PR DESCRIPTION
Audit and cleanup of the `/factory` dashboard ("the hive tab").

## Branding terminology (`docs/press-kit.md`)
- Removed the made-up phrase **"peer immutable distributions"** and the banned **"immutable desktop"** — there is no such thing as an immutable desktop, and the press kit bans "Immutable Distribution".
  - `MetricsPanels`: "Immutable desktop ecosystem share" → **"Cloud-native desktop ecosystem share"**; Fedora now described as the shared base rather than a peer image; table caption "by distribution" → "by image".
  - `ApplicationsPanels`: "Bluefin vs peer immutable distributions" → **"Bluefin vs peer cloud-native desktops"**.
  - `UserspacePanels`: "This distribution is Bluefin-specific" → "This dataset is Bluefin-specific".

## Flathub numbers are Bluefin's, not Fedora's
- "Bluefin Flathub downloads by Fedora version" → **"by base version"**; "N Fedora versions" → "N Bluefin base versions". The underlying data was already sourced only from the `bluefin` bucket; this fixes misleading labels.

## countme relabeled (values are real, unchanged)
- "23,737 Bluefin · 622 LTS" was suspected fabricated. Verified against Fedora's authoritative `totals.csv` (`node scripts/fetch-countme.js --force` reproduces the seed byte-for-byte). The values are real, so they are **left unchanged**.
- The label was the problem: countme is a weekly **check-in estimate**, not a device census. "Active devices" / "Weekly active devices" → **"Weekly countme check-ins"** with a clarifying note.

## Removed non-owned toolbox images
- `bluefin-toolbox` and `ubuntu-toolbox` do not belong to `projectbluefin`, so they are removed from `FALLBACK_LANES`, along with the now-dead `toolbox` family classification and the empty "Toolbox images" UI section (a permanently-empty "no data" panel misleads).

## Tests & docs
- Updated panel test assertions that pinned the changed copy.
- Added `docs/skills/factory-dashboard-content.md` (routed from `docs/SKILL.md`) capturing these conventions.

## Validation
- `npm run typecheck` ✓
- Factory test suite: 85/85 ✓
- `eslint` 0 errors (pre-existing warnings only); prettier on touched paths

Assisted-by: Claude Opus 4.8 via GitHub Copilot