### PR TITLE
fix(factory): attribute Hive to KubeStellar, not an individual

### DIFF
--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -4684,13 +4684,10 @@ export function FactoryAbout({ s }: { s: FactoryLive }): React.JSX.Element {
               repository in the formation.
             </p>
             <p>
-              <strong>Hive</strong> is an open-source AI agent orchestration
-              system by Andy Anderson. The system implements the{" "}
-              <Link href="https://arxiv.org/abs/2604.09388">
-                AI Codebase Maturity Model
-              </Link>{" "}
-              (ACMM) — a framework from AI-assisted coding to fully autonomous
-              development.
+              <strong>Hive</strong> is an open source AI agent orchestration
+              system that is part of{" "}
+              <Link href="https://kubestellar.io/">KubeStellar</Link>, a CNCF
+              Sandbox Project.
             </p>
             <p>
               No one has ever built an agentic OS like this before. This


### PR DESCRIPTION
The About panel on `/factory` described Hive as "an open-source AI agent orchestration system by Andy Anderson" that "implements the AI Codebase Maturity Model (ACMM)".

Replaced with the project-level attribution:

> **Hive** is an open source AI agent orchestration system that is part of [KubeStellar](https://kubestellar.io/), a CNCF Sandbox Project.

Single paragraph in `FactoryAbout` (`src/components/HiveFactoryDashboard.tsx`), rendered on `/factory` via `FactoryShell`. The `aboutLinks` row is unchanged.

`npm run typecheck` clean, `prettier --check` clean, `eslint` 0 errors.