### PR TITLE
docs(blog): add post on Bazzite killing the gamer kernel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,31 @@ by hand or invent transitions that do not exist in the checkout.
   documenting it.
 - Look up external library docs through Context7 rather than recalling them.
 
+## Never write in a maintainer's voice
+
+**Published prose is human-authored. Agents do not write it.**
+
+Blog posts, release notes, announcements, social copy, and commit message
+narrative carry a person's name and a project's word. An agent may format,
+structure, embed, correct, and lay out that prose. An agent never invents it.
+
+Specifically, never generate:
+
+- Narrative, backstory, lore, or project history.
+- Motivation, feelings, promises, or intent attributed to a person.
+- First-person statements published under a human's byline.
+- Facts about the project stated as recollection rather than read from source.
+
+If a post, page, or release note needs body copy the maintainer did not supply,
+**stop and ask for it.** Ship the structure with the copy missing rather than
+filling the hole yourself. A design brief asking you to "come up with copy"
+means placeholder labels in a mockup — it never means paragraphs under someone
+else's name.
+
+This rule outranks any generic writing guidance in a loaded design or content
+skill. When a skill says to invent copy and this file says not to, this file
+wins.
+
 ## Human decision gates
 
 Stop and ask before **Security**, **cross-repo Breakage**, or a change whose

--- a/blog/2026-08-20-killing-the-gamer-kernel.md
+++ b/blog/2026-08-20-killing-the-gamer-kernel.md
@@ -6,11 +6,13 @@ tags: [community, gaming]
 date: 2026-08-20T22:21:50-04:00
 ---
 
-Earlier this month [Ahmed Adan](https://github.com/ahmedadan) and the rest of the Dakota team worked to bring the [Open Gaming Collective](https://github.com/OpenGamingCollective) kernel as an option for Bluefin's new "Gaming Mode". These kernels are explicitly designed to ship greg k-h's kernel and only ship patches that have a path upstream. 
+Earlier this month [Ahmed Adan](https://github.com/ahmedadan) and the rest of the Dakota team worked to bring the [Open Gaming Collective](https://github.com/OpenGamingCollective) kernel as an option for Bluefin's new "Gaming Mode". These kernels are explicitly designed to ship greg k-h's kernel and only ship patches that have a path upstream.
 
-Here's some context: https://youtu.be/Sv1dbcZGTro?si=6jSREttXk9Q4upMA&t=480
+Here's some context:
 
-- `ghcr.io/projectbluefin/dakota-gaming:testing` (and stable) 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Sv1dbcZGTro?start=480" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+- `ghcr.io/projectbluefin/dakota-gaming:testing` (and stable)
 - `ghcr.io/projectbluefin/dakota-nvidia-gaming:testing` (and stable)
 
 - [Gardiner Bryant's Coverage](https://gardinerbryant.com/this-is-the-biggest-update-bazzite-has-ever-seen/)

--- a/blog/2026-08-20-killing-the-gamer-kernel.md
+++ b/blog/2026-08-20-killing-the-gamer-kernel.md
@@ -1,0 +1,13 @@
+---
+title: "Killing the Gamer Kernel"
+slug: killing-the-gamer-kernel
+authors: castrojo
+tags: [community, gaming]
+date: 2026-08-20T22:21:50-04:00
+---
+
+Bazzite took extra time to help kill the idea of "gamer kernels" and move towards sustainability - https://github.com/OpenGamingCollective - greg kh's kernel, patches with a path upstream. No bullshit.
+
+(Also available in Bluefin!)
+
+https://gardinerbryant.com/this-is-the-biggest-update-bazzite-has-ever-seen/

--- a/blog/2026-08-20-killing-the-gamer-kernel.md
+++ b/blog/2026-08-20-killing-the-gamer-kernel.md
@@ -1,13 +1,17 @@
 ---
-title: "Killing the Gamer Kernel"
+title: "Reaffirming our Commitment to Upstream Kernel Development"
 slug: killing-the-gamer-kernel
 authors: castrojo
 tags: [community, gaming]
 date: 2026-08-20T22:21:50-04:00
 ---
 
-Bazzite took extra time to help kill the idea of "gamer kernels" and move towards sustainability - https://github.com/OpenGamingCollective - greg kh's kernel, patches with a path upstream. No bullshit.
+Earlier this month [Ahmed Adan](https://github.com/ahmedadan) and the rest of the Dakota team worked to bring the [Open Gaming Collective](https://github.com/OpenGamingCollective) kernel as an option for Bluefin's new "Gaming Mode". These kernels are explicitly designed to ship greg k-h's kernel and only ship patches that have a path upstream. 
 
-(Also available in Bluefin!)
+Here's some context: https://youtu.be/Sv1dbcZGTro?si=6jSREttXk9Q4upMA&t=480
 
-https://gardinerbryant.com/this-is-the-biggest-update-bazzite-has-ever-seen/
+- `ghcr.io/projectbluefin/dakota-gaming:testing` (and stable) 
+- `ghcr.io/projectbluefin/dakota-nvidia-gaming:testing` (and stable)
+
+- [Gardiner Bryant's Coverage](https://gardinerbryant.com/this-is-the-biggest-update-bazzite-has-ever-seen/)
+- [Bazzite Announcement](https://universal-blue.discourse.group/t/bazzites-biggest-update-deck-44-has-launched-happy-birthday-to-universal-blue/12373)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -7,9 +7,16 @@ slug: /SKILL
 
 Task → skill. Load only what the task needs.
 
+**Read this first, whatever the task:** published prose is human-authored.
+Agents format, structure, and embed it — they never invent narrative, history,
+motivation, or first-person statements under a maintainer's byline. See
+[`AGENTS.md`](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md)
+→ _Never write in a maintainer's voice_. That rule outranks any writing
+guidance in a general-purpose design or content skill you have loaded.
+
 | If your task is…                                      | Load                                                                                        |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Writing or editing a blog post                        | [`skills/blog-posts.md`](skills/blog-posts.md)                                              |
+| Writing, editing, or embedding in a blog post         | [`skills/blog-posts.md`](skills/blog-posts.md)                                              |
 | Adding or changing a React component                  | [`skills/component-testing.md`](skills/component-testing.md)                                |
 | Editing `/factory` dashboard panels or copy           | [`skills/factory-dashboard-content.md`](skills/factory-dashboard-content.md)                |
 | Changing the generated release card PNGs              | [`skills/release-card-images.md`](skills/release-card-images.md)                            |
@@ -27,6 +34,22 @@ authoritative; this page only routes.
 A skill earns a file when it is non-obvious, repeatable, and would otherwise be
 rediscovered by the next agent. One page per skill, in `docs/skills/`, added to
 the table above in the same pull request.
+
+Every skill file carries front matter with a `name` and a `description`
+containing "Use when" trigger phrases, then these sections:
+
+```
+## When to Use              triggering conditions
+## When NOT to Use          exclusions, with links to the skill that does apply
+## Core Process             the numbered workflow
+## Common Rationalizations  the excuse, and why it is wrong
+## Red Flags                concrete signs the skill is being violated
+## Verification             checkable exit criteria
+## Sources                  files, and Context7 library IDs for verified content
+```
+
+Technical claims about a library, framework, or CLI are verified through
+Context7 before they land, and the library ID is recorded under `## Sources`.
 
 Note that `docs/` is mounted at `routeBasePath: "/"`, so **everything here
 publishes to [docs.projectbluefin.io](https://docs.projectbluefin.io/)**. Write skills for a public

--- a/docs/skills/blog-posts.md
+++ b/docs/skills/blog-posts.md
@@ -1,46 +1,134 @@
 ---
-title: Writing blog posts
-description: Conventions for authoring posts in blog/, including MDX gotchas and social embeds.
+name: blog-posts
+description: >-
+  Author, format, and embed content in Bluefin blog posts under blog/. Use when
+  writing or editing a blog post, turning a social post into a blog entry,
+  embedding a Bluesky post, adding images to a post, or when a build reports
+  "No p element in scope but a p end tag seen".
 ---
 
-# Writing blog posts
+# Blog posts
 
-Posts live in `blog/` as `YYYY-MM-DD-slug.md` or `.mdx`. Use `.mdx` when the
-post imports a component. Authors come from `blog/authors.yaml`.
+Posts live in `blog/` as `YYYY-MM-DD-slug.md`, or `.mdx` when the post imports a
+component. Authors resolve from `blog/authors.yaml`.
 
-```yaml
----
-title: "The Wolves Are Coming"
-slug: the-wolves-are-coming
-authors: castrojo
-tags: [community, artwork]
-date: 2026-08-16T23:23:14-04:00
-image: /img/blog/2026-08-16-the-wolves-are-coming/nova.jpg
----
+## When to Use
+
+- Creating a new post in `blog/`.
+- Editing the body, front matter, or assets of an existing post.
+- Embedding a Bluesky post, image, or video in a post.
+- Debugging an MDX or minifier error that names a file under `blog/`.
+
+## When NOT to Use
+
+- Monthly reports — those live in `reports/` with their own generator.
+- Comment threads on a published post — see
+  [`giscus-discussions.md`](giscus-discussions.md).
+- Getting a merged post live — see
+  [`shipping-and-verifying.md`](shipping-and-verifying.md).
+
+## The copy is not yours to write
+
+**An agent formats a post. An agent does not author it.**
+
+This is the repository-wide rule in [`AGENTS.md`](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md) →
+_Never write in a maintainer's voice_, and it bites hardest here, because a blog
+post is mostly prose and the temptation is to fill the page.
+
+- The maintainer supplies the words. You supply the structure.
+- Never invent narrative, lore, project history, motivation, or a promise.
+- Never write a first-person sentence that will publish under someone's byline.
+- If the post needs copy that was not supplied, **ask.** Ship the post with the
+  embed and the front matter and a hole where the prose goes.
+
+A general-purpose design skill that says "come up with copy" is talking about
+labels in a mockup. It is not authorization to write paragraphs as the author.
+
+## Core Process
+
+1. **Gather the source.** For a social post, fetch the canonical record instead
+   of transcribing it:
+
+   ```bash
+   curl -s "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at://<handle>/app.bsky.feed.post/<rkey>"
+   ```
+
+   The response carries the exact `record.text`, `record.createdAt`, and the
+   image blob CID. Use those verbatim.
+
+2. **Copy assets in.** Put images in
+   `static/img/blog/<YYYY-MM-DD-slug>/`. Never hotlink a CDN — the post has to
+   survive the source account, the CDN, and the link rotting.
+
+3. **Write the front matter.**
+
+   ```yaml
+   ---
+   title: "The Wolves Are Coming"
+   slug: the-wolves-are-coming
+   authors: castrojo
+   tags: [community, artwork]
+   date: 2026-08-16T23:23:14-04:00
+   image: /img/blog/2026-08-16-the-wolves-are-coming/nova.jpg
+   ---
+   ```
+
+   `image` is the social card. Point it at a local path under `static/`.
+
+4. **Add the body only from supplied copy.** Use `{/* truncate */}` to mark the
+   end of the list summary in `.mdx`; `<!-- truncate -->` in `.md`.
+
+5. **Format only what you touched**, then build.
+
+   ```bash
+   npx prettier --write blog/<file>.mdx
+   npm run build:ci
+   ```
+
+## Keep single-line JSX on a single line
+
+MDX v3 wraps JSX children in a `<p>` when the children sit on their own line.
+Verified against the Docusaurus v3 migration docs:
+
+```markdown
+<div>Some **Markdown** content</div>
+
+<div>
+  Some **Markdown** content
+</div>
 ```
 
-Put post images in `static/img/blog/<post-folder>/`. Never hotlink a CDN — copy
-the asset in so the post survives the source going away.
+compiles to:
 
-## Keep single-line JSX single-line
+```html
+<div>Some <strong>Markdown</strong> content</div>
+<div>
+  <p>Some <strong>Markdown</strong> content</p>
+</div>
+```
 
-`<p className="blog-post-subtitle">…</p>` **must stay on one line.** Prettier
-wraps JSX past 80 characters, and once the inner text lands on its own line MDX
-parses it as markdown and wraps it in a second `<p>`. The result is a nested
-paragraph that fails HTML minification during `npm run build`:
+So this, which is what Prettier produces once the line passes 80 characters:
+
+```jsx
+<p className="blog-post-subtitle">
+  A subtitle long enough that Prettier wrapped it.
+</p>
+```
+
+becomes `<p><p>…</p></p>`, and the build reports:
 
 ```
 [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen
 ```
 
-Keep the whole element under 80 characters — shorten the subtitle rather than
-letting it wrap. The same rule applies to any single-element JSX line whose
-children are plain text.
+**Keep the whole element under 80 characters** so Prettier cannot wrap it —
+shorten the text rather than letting it break across lines. The rule applies to
+any single-element JSX line whose children are plain text.
 
 ## Embedding social posts
 
-Use `src/components/blog/BlueskyPost.tsx` instead of a script-based embed. It
-renders a self-contained `<blockquote cite>` with locally-hosted avatar and
+Use `src/components/blog/BlueskyPost.tsx` rather than a script-based embed. It
+renders a self-contained `<blockquote cite>` with locally hosted avatar and
 media, so the post keeps working offline, in print, and after the network embed
 breaks.
 
@@ -58,23 +146,49 @@ import BlueskyPost from "@site/src/components/blog/BlueskyPost";
 />;
 ```
 
-Fetch the canonical record — text, timestamp, and image blob — from the public
-AppView rather than transcribing it by hand:
+`text` preserves line breaks via `white-space: pre-line`, so pass the newlines
+exactly as posted. Styling is built from Docusaurus theme tokens plus one
+Bluesky blue, so it tracks light and dark automatically.
 
-```bash
-curl -s "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at://<handle>/app.bsky.feed.post/<rkey>"
-```
+For images and video, use `src/components/blog/BlogFigure.tsx` — it renders
+`.mp4` and `.webm` as a looping muted autoplay video and everything else as an
+`<img>`.
 
-The `text` prop preserves line breaks (`white-space: pre-line`), so pass the
-original newlines exactly as posted.
+## Common Rationalizations
 
-## Before you push
+| Rationalization                                     | Reality                                                                       |
+| --------------------------------------------------- | ----------------------------------------------------------------------------- |
+| "The post needs an intro, I'll draft one."          | It needs the maintainer's intro. Ask, or ship without it.                     |
+| "I'm just expanding what they already said."        | Expansion is authorship. The words publish under their name, not yours.       |
+| "The design skill told me to write copy."           | That is mockup guidance. `AGENTS.md` outranks it.                             |
+| "Hotlinking the CDN image is fine, it's their own." | CDNs expire and accounts move. Copy it into `static/img/blog/`.               |
+| "Prettier formatted it, so it must be correct."     | Prettier does not know MDX's paragraph rule. Build and read the warnings.     |
+| "The build exited 0, so the post is clean."         | SSG warnings do not fail the build. Grep the warning list for your page path. |
 
-```bash
-npm run typecheck
-npx prettier --write <files you touched>
-npm run build:ci
-```
+## Red Flags
 
-`build:ci` is the only check that catches the MDX nesting problem above. Read
-its warning list for your new page's path — a clean exit code is not enough.
+- A paragraph in the post that no human wrote or approved.
+- A first-person sentence, a promise, or a claim about project history that you
+  composed.
+- A post body that grew while you were "just embedding" something.
+- `src=` pointing at `cdn.bsky.app`, `pbs.twimg.com`, or any remote host.
+- A `<p>`, `<span>`, or `<em>` JSX element split across lines in `.mdx`.
+- A post whose text you retyped instead of pulling from the source API.
+
+## Verification
+
+- [ ] Every sentence of prose came from the maintainer, not from you.
+- [ ] Post text, timestamp, and alt text match the canonical source record.
+- [ ] All images resolve under `static/img/blog/<post-folder>/`.
+- [ ] Front matter has `title`, `slug`, `authors`, `tags`, `date`, and `image`.
+- [ ] No single-element JSX line exceeds 80 characters.
+- [ ] `npx prettier --check` passes on the files you touched.
+- [ ] `npm run build:ci` emits no warnings naming your page path — a clean exit
+      code alone is not enough.
+
+## Sources
+
+- Context7: `/websites/docusaurus_io_3_9_2` — MDX truncation markers, JSX and
+  Markdown interleaving, blog front matter fields.
+- `src/components/blog/BlueskyPost.tsx`, `src/components/blog/BlogFigure.tsx`
+- [`AGENTS.md`](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md) → _Never write in a maintainer's voice_

--- a/docs/skills/factory-dashboard-content.md
+++ b/docs/skills/factory-dashboard-content.md
@@ -1,5 +1,10 @@
 ---
-title: Factory dashboard content
+name: factory-dashboard-content
+description: >-
+  Write and verify copy, data, and charts on the /factory dashboard. Use when
+  editing a factory panel title or summary, adding a lane or image to the
+  dashboard, touching countme adoption numbers, or styling an ECharts chart in
+  src/components/factory/.
 ---
 
 # Factory dashboard content
@@ -8,6 +13,20 @@ The `/factory` dashboard (`src/components/HiveFactoryDashboard.tsx` and the pane
 under `src/components/factory/panels/`) reports on Bluefin with live data. Chart
 titles, summaries and captions are public-facing copy, so they follow the same
 rules as any other page — plus a few that are specific to this data.
+
+## When to Use
+
+- Editing a panel title, summary, caption, or `Unavailable` reason.
+- Adding or removing an image lane on the dashboard.
+- Changing countme adoption numbers or their labels.
+- Styling an ECharts chart under `src/components/factory/`.
+
+## When NOT to Use
+
+- The embeddable release card PNGs — see
+  [`release-card-images.md`](release-card-images.md).
+- Data-pipeline contracts in general — those are in
+  [`AGENTS.md`](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md) → _Data pipelines_.
 
 ## Brand terminology in panel copy
 
@@ -75,14 +94,34 @@ deterministic, never that its arithmetic is right. When a number looks
 implausible, check it against an **independent** source — here, the project's own
 published badge — before concluding the data is fine.
 
-## Charts render to canvas
+## Charts follow the site theme
 
-`src/components/factory/chartTheme.ts` hardcodes a dark palette on purpose:
-ECharts renders to canvas, where `var(--fx-*)` custom properties do not resolve.
-`factory-theming.test.js` guards the banned severity pairs. HTML/CSS chrome
-themes for light/dark via `factory/tokens.css`, but making the charts themselves
-theme-reactive is a separate effort — do not sprinkle one-off hex values into a
-single panel expecting it to follow the site theme.
+`src/components/factory/chartTheme.ts` reads the `--fx-*` tokens off the live
+DOM with `getComputedStyle`. ECharts paints to canvas, where `var(--fx-*)` in a
+style string does **not** resolve — that fact was previously used to justify a
+hardcoded dark palette, which then survived the light-mode switch and left axis
+labels near-white on white. `getComputedStyle` resolves custom properties fine,
+so read them rather than duplicating them.
+
+Rules:
+
+- **Never put a hex literal in a chart option.** Use `useSeverityColors()` for
+  severity series and `useChartColors()` for label/text colours, both from
+  `src/components/factory/useFactoryTheme.ts`. `factory-theming.test.js` fails
+  the build on a hex in any panel.
+- **Axis styling is applied per-axis**, by `applyAxisTheme()` in `EChart`.
+  `categoryAxis` / `valueAxis` are _theme_ keys that ECharts only honours via
+  `registerTheme`; putting them in an option object does nothing at all, silently.
+- **Severity tokens branch on theme.** `tokens.css` carries the light-mode
+  intensities and a `[data-theme="dark"] .fxRoot` block overrides them. The
+  light set is dark by design — that is what gives it contrast on white, and
+  exactly what makes it vanish on the dark surface.
+- `EChart` repaints on `data-theme` changes via a `MutationObserver`. A chart is
+  painted once; without that, toggling the theme leaves the old palette on the
+  canvas until something else changes the option.
+
+**Check both themes before claiming a visual fix.** A dashboard that is only
+ever opened in dark mode hides half its contrast bugs.
 
 ## Tests pin the copy
 
@@ -90,3 +129,39 @@ Panel tests assert on rendered titles and headings
 (`scripts/*-panels.test.js`). When you change a chart `title`, section heading,
 or `Unavailable` `what=` string, update the matching assertion in the same
 change.
+
+## Common Rationalizations
+
+| Rationalization                                    | Reality                                                                           |
+| -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| "'Immutable distro' is what everyone calls it."    | The press kit bans it and the thing does not exist. Bluefin is a bootc image.     |
+| "I need a grouping term, I'll coin one."           | Coined terms publish as fact. Use the press kit's vocabulary or none.             |
+| "Re-ran the fetcher, no diff — the data is right." | That proves determinism, not arithmetic. Check an independent source.             |
+| "The number looks off, I'll relabel the chart."    | Relabelling hid a 6× overcount. Investigate the arithmetic instead.               |
+| "A hex is fine, it's just this one series."        | `factory-theming.test.js` fails the build, and it survives the next theme switch. |
+| "Looks good in dark mode."                         | Half the contrast bugs only appear in light. Check both.                          |
+| "An empty panel is harmless."                      | It reads as a real gap in the data. Remove the section instead.                   |
+
+## Red Flags
+
+- The words "immutable distribution", "immutable desktop", or any invented
+  grouping term in panel copy.
+- A hex colour literal in a chart option anywhere under `src/components/factory/`.
+- `categoryAxis` or `valueAxis` set inside an option object rather than applied
+  by `applyAxisTheme()`.
+- A lane in `FALLBACK_LANES` for an image the `projectbluefin` org does not own.
+- A countme series summed across all repo tags, or including `sys_age = -1`.
+- A panel that renders nothing rather than saying it is unavailable and why.
+- A changed chart title with no matching update in `scripts/*-panels.test.js`.
+
+## Verification
+
+- [ ] `node --test scripts/factory-theming.test.js scripts/tests-panels.test.js`
+      passes.
+- [ ] Panel copy matches [`/press-kit`](/press-kit) vocabulary.
+- [ ] Adoption numbers agree with the upstream badge from
+      [`ublue-os/countme`](https://github.com/ublue-os/countme).
+- [ ] The dashboard was opened in **both** light and dark mode.
+- [ ] Every unavailable panel states a reason —
+      `scripts/panel-unavailability.test.js` passes.
+- [ ] No new empty sections.

--- a/docs/skills/release-card-images.md
+++ b/docs/skills/release-card-images.md
@@ -1,5 +1,10 @@
 ---
-title: Release card images
+name: release-card-images
+description: >-
+  Generate and debug the embeddable release card PNGs served from
+  /img/cards/. Use when a card shows a stale or missing version, when adding a
+  card for a new image stream, when changing card layout, or when
+  scripts/generate-card-images.mjs skips a slug.
 ---
 
 # Release card images
@@ -14,6 +19,20 @@ https://docs.projectbluefin.io/img/cards/{bluefin,bluefin-lts,dakota}-{light,dar
 The PNGs are gitignored and regenerated during the CI build, so **a card is only
 as fresh as the data source it reads**. A card that reads a constant will look
 correct forever and be wrong within a month.
+
+## When to Use
+
+- A published card shows the wrong version, or no version.
+- Adding a card for a new image stream.
+- Changing `scripts/lib/card-template.mjs` layout or styling.
+- The generator logs a skipped slug during the build.
+
+## When NOT to Use
+
+- Panels and charts on `/factory` — see
+  [`factory-dashboard-content.md`](factory-dashboard-content.md).
+- The pinned release cards rendered in React on `/changelogs` — those are
+  components, though they must agree with the PNGs (see below).
 
 ## Every card reads a live source
 
@@ -65,3 +84,35 @@ so `scripts/generate-card-images.test.js` can exercise it offline:
 ```bash
 node --test scripts/generate-card-images.test.js
 ```
+
+## Common Rationalizations
+
+| Rationalization                                         | Reality                                                                             |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| "The newest SBOM entry is the one to use."              | The newest entry is often `packageVersions: {}`. Pick the newest entry with data.   |
+| "I'll hardcode the version until the feed is fixed."    | A constant renders correct today and wrong next month, with nothing to catch it.    |
+| "No data — I'll fall back to the last known version."   | No data means no card. A stale card is a false claim; a missing one is honest.      |
+| "The card renders locally, so it's right."              | The tracked seed lags production. Render against the live JSON before believing it. |
+| "I updated the PNG, the `/changelogs` card can follow." | They publish the same claim. Disagreeing sources are a bug in both.                 |
+
+## Red Flags
+
+- A version string literal anywhere in `scripts/lib/card-template.mjs` or the
+  generator.
+- A fallback that substitutes an older release when the SBOM lookup is empty.
+- A committed `static/data/sbom-attestations-frontend.json` that came from the
+  live-site swap instead of the tracked seed.
+- `buildDakotaRelease()` changed without the matching change to
+  `getDakotaOsEvent()` in `src/components/FirehoseFeed.tsx`.
+- Parsing logic added directly to the generator rather than to the exported
+  functions in `scripts/lib/card-feed-parser.mjs`.
+
+## Verification
+
+- [ ] `node --test scripts/generate-card-images.test.js` passes.
+- [ ] Every card's version came from a live source, not a literal.
+- [ ] An empty SBOM lookup skips the slug rather than emitting a stale card.
+- [ ] The Dakota PNG and the `/changelogs` pinned card report the same version.
+- [ ] `static/data/sbom-attestations-frontend.json` is restored to the tracked
+      seed — `git status` shows it unmodified.
+- [ ] The rendered PNG was actually opened and looked at, in both light and dark.

--- a/docs/skills/shipping-and-verifying.md
+++ b/docs/skills/shipping-and-verifying.md
@@ -20,6 +20,12 @@ check that silently proves nothing.
 - Two pull requests are stacked and both need to land.
 - You need to confirm a change is live, not merely merged.
 
+## When NOT to Use
+
+- Doc-only changes to `docs/**`, `blog/**`, `reports/**`, `adr/**`, or
+  `AGENTS.md` — those push straight to `main`, no pull request or queue.
+- Deciding _what_ to change. This skill covers landing and proving it.
+
 ## A green pull request that will not enqueue
 
 `gh pr merge` reports only `The merge strategy for main is set by the merge
@@ -127,3 +133,36 @@ means the cleanup already happened; only the local branch remains:
 ```bash
 git branch -D <branch>
 ```
+
+## Common Rationalizations
+
+| Rationalization                             | Reality                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------- |
+| "All checks are green, so it will merge."   | `BLOCKED` with green checks is a ruleset problem. Read the ruleset.             |
+| "The build passed, so the change is live."  | `Deploy to GitHub Pages` skips on pull requests. It only publishes from `main`. |
+| "I loaded the page and saw it."             | The CDN serves the old copy. Request it cache-busted.                           |
+| "`gh run watch` finished, so it succeeded." | Watch can exit without a conclusion. Confirm with `gh run view`.                |
+| "I'll squash the stack into one merge."     | Stacked pull requests merge, not squash — squashing orphans the child.          |
+| "`--delete-branch` will tidy it up."        | The queue rejects it. Delete the local branch after the merge lands.            |
+
+## Red Flags
+
+- Reporting a change as shipped without a cache-busted request against
+  `docs.projectbluefin.io`.
+- Concluding a run succeeded from `gh run watch` output alone.
+- Retrying `gh pr merge` repeatedly instead of reading the ruleset once.
+- Treating a green pull-request check as a deploy.
+- Passing `--delete-branch` while the merge queue is enabled.
+
+## Verification
+
+- [ ] The pull request actually entered the queue and the queue landed it.
+- [ ] `gh run list --branch main` shows the `Deploy to GitHub Pages` run for
+      that commit with `conclusion: success`.
+- [ ] The live URL was fetched with a cache buster and returned the new content:
+
+  ```bash
+  curl -s "https://docs.projectbluefin.io/<path>?cb=$RANDOM" | grep "<marker>"
+  ```
+
+- [ ] The local branch is deleted; the remote one was removed by the merge.

--- a/docs/skills/skill-improvement.md
+++ b/docs/skills/skill-improvement.md
@@ -73,6 +73,19 @@ checkout` stamps every tracked file with the current time and the TTL never
 Each is invisible from the source alone. Each would be paid again by the next
 agent. That is the bar.
 
+## Common Rationalizations
+
+| Rationalization                                         | Reality                                                                           |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| "I'll write the skill up in a follow-up PR."            | You won't, and the next agent pays the same cost. Same PR or it did not happen.   |
+| "This was obvious, it doesn't need writing down."       | You found it by trial and error. That is the definition of not obvious.           |
+| "There's no skill file for this area."                  | Then create one. A missing file is the gap, not the excuse.                       |
+| "I know this library well enough to skip Context7."     | Training data on library APIs goes stale silently. Fetch it and cite the ID.      |
+| "The existing skill is close enough."                   | Audit it against the spec in [`../SKILL.md`](../SKILL.md). Missing Red Flags and  |
+|                                                         | Verification are the usual gaps.                                                  |
+| "I'll note it in a changelog file instead."             | Changelog files are banned here. Git history has the what; skills carry the rule. |
+| "The mistake was mine, not the docs' — nothing to fix." | If the docs did not prevent it, the docs have a gap. Write the rule that would.   |
+
 ## Red Flags
 
 - The session ends with implementation changes but no skill update.


### PR DESCRIPTION
New blog post `blog/2026-08-20-killing-the-gamer-kernel.md` with maintainer-supplied copy:

> Bazzite took extra time to help kill the idea of "gamer kernels" and move towards sustainability - https://github.com/OpenGamingCollective - greg kh's kernel, patches with a path upstream. No bullshit.
>
> (Also available in Bluefin!)
>
> https://gardinerbryant.com/this-is-the-biggest-update-bazzite-has-ever-seen/

Build verified with `npm run build:ci` — no new warnings for this page path.