### PR TITLE
ci: add just check pre-commit gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -33,6 +33,11 @@ fetch-images-force:
 typecheck:
     npm run typecheck
 
+# Pre-commit gate per projectbluefin/common: typecheck + lint + unit tests
+check: typecheck
+    npm run lint
+    npm test
+
 # Clear Docusaurus build cache — fixes rspack "Dependency with ID not found" panics
 clear:
     npx docusaurus clear


### PR DESCRIPTION
projectbluefin/common's [agentic model](https://github.com/projectbluefin/common/blob/main/docs/factory/agentic-model.md) requires `just check` before every commit in repos with a Justfile. This repo had no `check` recipe.

The recipe runs typecheck + lint + the node:test unit suite. Verified locally: typecheck ✓, lint ✓, 363 tests pass.

Companion to 5acc2883, which adds the factory hard rules (including this gate) to AGENTS.md.

Assisted-by: Kimi K3 via GitHub Copilot