### PR TITLE
docs: add /dakota variant page

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -33,6 +33,11 @@ fetch-images-force:
 typecheck:
     npm run typecheck
 
+# Pre-commit gate per projectbluefin/common: typecheck + lint + unit tests
+check: typecheck
+    npm run lint
+    npm test
+
 # Clear Docusaurus build cache — fixes rspack "Dependency with ID not found" panics
 clear:
     npx docusaurus clear

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -19,6 +19,7 @@ guidance in a general-purpose design or content skill you have loaded.
 | Writing, editing, or embedding in a blog post         | [`skills/blog-posts.md`](skills/blog-posts.md)                                              |
 | Adding or changing a React component                  | [`skills/component-testing.md`](skills/component-testing.md)                                |
 | Editing `/factory` dashboard panels or copy           | [`skills/factory-dashboard-content.md`](skills/factory-dashboard-content.md)                |
+| Adding a top-level page for a variant (dakota, lts…)  | [`skills/variant-docs-pages.md`](skills/variant-docs-pages.md)                              |
 | Changing the generated release card PNGs              | [`skills/release-card-images.md`](skills/release-card-images.md)                            |
 | Verifying, recovering, or archiving a blog discussion | [`skills/giscus-discussions.md`](skills/giscus-discussions.md)                              |
 | Landing a pull request, or proving a change is live   | [`skills/shipping-and-verifying.md`](skills/shipping-and-verifying.md)                      |

--- a/docs/dakota.mdx
+++ b/docs/dakota.mdx
@@ -1,0 +1,92 @@
+---
+title: Dakota — Bluefin on GNOME OS
+slug: /dakota
+---
+
+import { DakotaSection } from "@site/src/components/DownloadSectionTesting";
+import DriverVersionsCatalog from "@site/src/components/DriverVersionsCatalog";
+
+# Dakota
+
+**Dakota** (_Dakotaraptor steini_) is Bluefin built on [GNOME OS](https://os.gnome.org/), assembled entirely from source with [Apache BuildStream](https://buildstream.build/) and published as a `bootc` image. It eschews the traditional Linux distribution model — there are no RPMs — and is designed to deliver software directly from upstream sources.
+
+:::info[Alpha]
+Dakota is in alpha. [Filing issues](https://github.com/projectbluefin/dakota/issues) is the whole point — every user running Dakota is part of a structured feedback loop back into upstream GNOME, freedesktop, and the kernel.
+:::
+
+## Download and install
+
+<DakotaSection />
+
+You **cannot** rebase to Dakota from another image — if you're not on Dakota already, you need to reinstall from the ISO.
+
+Each image is signed with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing via GitHub Actions OIDC. Verify with:
+
+```bash
+cosign verify ghcr.io/projectbluefin/dakota:latest \
+  --certificate-identity-regexp="https://github.com/projectbluefin/dakota/.github/workflows/build.yml" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+## Image streams
+
+Dakota uses the [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk) version as its base version (e.g. 25.08.11 is the 11th release of the August 2025 major update).
+
+| Tag        | Stream  | What it is                                                                |
+| ---------- | ------- | ------------------------------------------------------------------------- |
+| `:stable`  | Stable  | GNOME 50 — production. Mon/Wed/Fri automated promotion from `:testing`.   |
+| `:testing` | Dev     | GNOME 50 — daily builds from the `testing` branch. Boot-check gated.      |
+| `:next`    | Rolling | GNOME master — the bleeding edge. Tracks gnome-build-meta `master` daily. |
+| `:btw`     | Rolling | Alias for `:next`.                                                        |
+
+```bash
+# Switch to the rolling stream
+sudo bootc switch ghcr.io/projectbluefin/dakota:next
+```
+
+### Gaming streams
+
+The game mode images add the [Open Gaming Collective kernel](https://github.com/OpenGamingCollective/linux) (sched_ext, ntsync), Steam with 32-bit compatibility libraries and controller udev rules, gamescope and the Steam Big Picture gamescope session, GameMode / MangoHud / vkBasalt, InputPlumber, and first-boot Flathub installs of Lutris, Heroic, Bottles, ProtonPlus, Protontricks, and GOverlay. The `dakota:btw` alias is also offered for the gaming kernel stream.
+
+| Image         | Stream  | Command                                                                 |
+| ------------- | ------- | ----------------------------------------------------------------------- |
+| Gaming        | Stable  | `sudo bootc switch ghcr.io/projectbluefin/dakota-gaming:stable`         |
+| Gaming        | Testing | `sudo bootc switch ghcr.io/projectbluefin/dakota-gaming:testing`        |
+| NVIDIA Gaming | Stable  | `sudo bootc switch ghcr.io/projectbluefin/dakota-nvidia-gaming:stable`  |
+| NVIDIA Gaming | Testing | `sudo bootc switch ghcr.io/projectbluefin/dakota-nvidia-gaming:testing` |
+
+## The feedback loop
+
+When something breaks on your hardware, three commands flow the evidence back upstream:
+
+| Command                 | What it does                                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `ujust report`          | Captures your system state and opens a pre-filled issue.                                           |
+| `ujust confirm <issue>` | Tells the team your hardware hits the same bug — adds a hardware fingerprint, no duplicate filing. |
+| `ujust verify <issue>`  | After a fix ships in a nightly, confirms it works on your machine.                                 |
+
+No telemetry, no phone-home. Every report is reviewed by you before it leaves your machine, lives in a gist you own, and can be deleted anytime. When three users independently run `ujust verify` on a fix, that issue closes with real confidence. See the full [feedback loop design](https://github.com/projectbluefin/dakota/blob/testing/docs/feedback-loop.md).
+
+## Under the hood
+
+- **Boot**: `systemd-boot`, UKIs, memory-safe defaults (sudo-rs, uutils-coreutils), Ghostty as the terminal.
+- **Swap**: zswap backed by a disk swapfile at `/var/swap/swapfile` (sized `min(RAM / 2, 8 GiB)`), instead of GNOME OS's zram device. Kernel arguments live in `/usr/lib/bootc/kargs.d/20-zswap.toml` so `bootc` applies them on image switches and upgrades: `zswap.enabled=1`, `zswap.compressor=zstd`, `zswap.max_pool_percent=20`, `zswap.shrinker_enabled=1`, `vm.swappiness=100`.
+- **Architecture**: the build is defined declaratively in BuildStream elements; see [oci-assembly.md](https://github.com/projectbluefin/dakota/blob/testing/docs/oci-assembly.md) and [patches.md](https://github.com/projectbluefin/dakota/blob/testing/docs/patches.md) in the dakota repo.
+
+## Current versions
+
+<DriverVersionsCatalog streamId="dakota-latest" />
+
+## Known gaps
+
+- The installation path is still being worked on.
+- Upgrades and rollbacks need more hardening.
+
+See the [open issues](https://github.com/projectbluefin/dakota/issues) for where things stand. ISO-specific issues go to [projectbluefin/dakota-iso](https://github.com/projectbluefin/dakota-iso/issues).
+
+## Further reading
+
+- [projectbluefin/dakota](https://github.com/projectbluefin/dakota) — README, image streams, contributor workflow in AGENTS.md
+- Repo docs: [build](https://github.com/projectbluefin/dakota/blob/testing/docs/build.md), [CI](https://github.com/projectbluefin/dakota/blob/testing/docs/ci.md), [workflow](https://github.com/projectbluefin/dakota/blob/testing/docs/workflow.md), [feedback loop](https://github.com/projectbluefin/dakota/blob/testing/docs/feedback-loop.md)
+- Blog: [Dakota Alpha 1](/blog/dakota-alpha-1) · [Gaming Mode and Dakota Alpha 5](/blog/dakota-alpha-5)
+- [GNOME OS](https://os.gnome.org/) · [BuildStream](https://buildstream.build/) · [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk)

--- a/docs/skills/variant-docs-pages.md
+++ b/docs/skills/variant-docs-pages.md
@@ -1,0 +1,60 @@
+---
+title: Variant docs pages
+description: Use when adding or updating a top-level docs page for a Bluefin variant or sibling project (bluefin-lts, dakota, knuckle, and future editions) — page structure, component embedding, sidebar placement, and the shipping constraints that differ from ordinary docs edits.
+---
+
+# Variant docs pages
+
+A "variant page" is the single landing page for one OS image family:
+`/lts`, `/knuckle`, `/dakota`. The reader arrived from the repo README or a
+blog announcement and wants: what is this, how do I get it, what can break.
+
+## Structure
+
+Model on `docs/knuckle.md` (static) or `docs/dakota.mdx` (embeds components):
+
+1. Frontmatter `title` and explicit `slug: /<name>` — the page lives at the
+   site root, not under a category path.
+2. One-paragraph identity: what it is, what it's built on, status callout
+   (`:::info` for alpha/pre-alpha).
+3. Download/install. Embed `<DakotaSection />` from
+   `src/components/DownloadSectionTesting.tsx` when ISOs exist instead of
+   hand-writing ISO links — the component is the single source for URLs and
+   checksums.
+4. Image streams table with `bootc switch` commands.
+5. Known gaps + issue tracker links.
+6. Live versions via `<DriverVersionsCatalog streamId="…" />` when the stream
+   has a catalog (see `docs/driver-versions.mdx` for valid streamIds).
+7. "Further reading" links out to repo `docs/` — deep technical content lives
+   in the variant's repo, never copied here (it would rot).
+
+Facts only, read from the repo and blog sources. Do not invent narrative or
+motivation prose — see _Never write in a maintainer's voice_ in AGENTS.md.
+
+## Sidebar
+
+Add the doc id to the "Specialized Editions & Hardware" category in
+`sidebars.ts`. The doc id is the filename without extension.
+
+## Gotchas
+
+- **`.md` vs `.mdx`**: any JSX component import requires `.mdx`; the sidebar
+  id is identical either way.
+- **`sidebars.ts` voids the doc-only push exception.** The exception covers
+  `docs/**`, `blog/**`, `reports/**`, `adr/**` only — a page that adds itself
+  to the sidebar always ships via PR.
+- **Prettier whole-file hazard**: `npx prettier --write sidebars.ts`
+  reformats unrelated lines (prettier config drift vs. the committed file).
+  Make the one-line sidebar edit by hand and leave the rest of the file
+  byte-identical; only `--write` the new page file.
+- Verify with `npm run build:ci` and check `build/<slug>/index.html` exists
+  and contains the expected strings — the minifier warnings on other pages
+  are pre-existing noise.
+
+## Checklist
+
+- [ ] Page uses `.mdx` if it embeds components, explicit `slug` set
+- [ ] Download section reuses the existing DownloadCard component, not raw links
+- [ ] Sidebar diff is exactly one line
+- [ ] `npm run build:ci` succeeds; `build/<slug>/index.html` spot-checked
+- [ ] PR (not direct push) because `sidebars.ts` changed

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
         "lts",
         "t2-mac",
         "knuckle",
+        "dakota",
       ],
     },
     {


### PR DESCRIPTION
## Summary

Adds a `/dakota` landing page documenting **Dakota (Dakotaraptor)** — Bluefin built on GNOME OS, assembled from source with BuildStream and published as a bootc image. Modeled on the `/knuckle` page.

Content is consolidated from the [projectbluefin/dakota](https://github.com/projectbluefin/dakota) README + repo `docs/`, the Alpha 1 / Alpha 5 blog posts, and existing site mentions (downloads-testing, driver-versions, supply-chain):

- Intro + alpha status callout
- **Downloads** via the shared `<DakotaSection />` component (single source for ISO URLs/checksums) + cosign verification command
- **Image streams**: `:stable` / `:testing` / `:next` / `:btw`, plus the OGC gaming streams (`dakota-gaming`, `dakota-nvidia-gaming`) with `bootc switch` commands
- **Feedback loop**: `ujust report` / `confirm` / `verify`
- Under the hood: freedesktop-sdk versioning, zswap-backed swap config, UKI/memory-safe defaults
- **Live versions** via `<DriverVersionsCatalog streamId="dakota-latest" />`
- Known gaps + issue tracker links; further reading links out to repo docs

Also includes the skill-improvement deliverable: new `docs/skills/variant-docs-pages.md` capturing the variant-page pattern (structure, component embedding, sidebar/doc-only-push gotchas), routed from `docs/SKILL.md`.

`sidebars.ts` gains one line (`"dakota"` under Specialized Editions & Hardware), so this ships via PR rather than the doc-only push path.

## Verification

- `npm run typecheck` ✅ (pre-existing untracked `useFactoryTheme.ts` errors excluded — unrelated to this change)
- `eslint` on touched files ✅, `npm test` ✅ (0 failures)
- `npm run build:ci` ✅ — `build/dakota/index.html` spot-checked: title, ISO links, streams, and catalog all render
- Prettier: new files pass `--check`; sidebar diff is exactly one line