### PR TITLE
Add link to upstream doc about IME setup

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -127,6 +127,12 @@ Your layout may be already included with Fedora, but you need to list extended k
 
 ## How do I set up an Input Method Editor (IME)?
 
+### Option 1: GNOME Keyboard Settings
+
+Add an input source in keyboard settings: [GNOME Help > Keyboard Layouts](https://help.gnome.org/gnome-help/keyboard-layouts.html)
+
+### Option 2: Fcitx5 (Flatpak)
+
 1. Install [Fcitx5](https://flathub.org/en/apps/org.fcitx.Fcitx5):
 
 ```bash


### PR DESCRIPTION
GNOME has built in support for IMEs in keyboard settings (no extra tools required!). 
I think we can keep the Fcitx5 info for users who have used that in traditional Linux systems and want to know how to use that on Bluefin.