### PR TITLE
docs: announce mcp.projectbluefin.io and update hive links

### DIFF
--- a/blog/2026-09-07-mcp-projectbluefin-io.md
+++ b/blog/2026-09-07-mcp-projectbluefin-io.md
@@ -1,0 +1,107 @@
+---
+title: "Announcing mcp.projectbluefin.io"
+slug: mcp-projectbluefin-io
+authors: castrojo
+tags: [announcements, ai]
+date: 2026-09-07T15:00:00-04:00
+---
+
+Public Model Context Protocol (MCP) endpoint serving the Project Bluefin organization knowledge base and live factory state at `https://mcp.projectbluefin.io/mcp`.
+
+<!-- truncate -->
+
+:::note Maintainer Note
+<!-- Maintainer exposition and commentary goes here -->
+
+:::
+
+## Endpoint Details
+
+- **URL:** `https://mcp.projectbluefin.io/mcp`
+- **Transport:** Streamable HTTP / Server-Sent Events (SSE)
+- **Authentication:** None (public, read-only)
+- **Health Check:** `https://mcp.projectbluefin.io/health`
+
+## Available Tools
+
+| Tool                 | Description                                                                                                                                   | Parameters                                                         |
+| :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| `search_knowledge`   | Search Project Bluefin knowledge base: engineering patterns, test coverage gaps, CI conventions, and repo findings across `projectbluefin/*`. | `query` (string, required)<br />`limit` (integer 1–25, default 10) |
+| `get_factory_status` | Live factory status from Hive: hub health, active contributors, actionable items, per-tier limits.                                            | None                                                               |
+| `get_work_queue`     | Live work queue and triage state from Hive: issues ready to implement and triage grouping.                                                    | `limit` (integer 1–25, default 10)                                 |
+| `get_index_status`   | Operational health, record count, and timestamp of the published knowledge index.                                                             | None                                                               |
+| `get_quickstart`     | Onboarding checklists (`first-pr`, `run-tests`, `factory-gates`, `branch-rules`).                                                             | `topic` (enum, required)                                           |
+| `get_repository_map` | High-level component map, entrypoints, and branch targets for `bluefin`, `bluefin-lts`, `common`, `dakota`, `documentation`.                  | `repo` (enum, required)                                            |
+
+## Client Configuration
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "projectbluefin": {
+      "type": "http",
+      "url": "https://mcp.projectbluefin.io/mcp"
+    }
+  }
+}
+```
+
+### VS Code / Cursor
+
+Add to `.vscode/mcp.json` or `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "projectbluefin": {
+      "type": "http",
+      "url": "https://mcp.projectbluefin.io/mcp"
+    }
+  }
+}
+```
+
+### GitHub Copilot CLI
+
+```bash
+copilot mcp add --type http projectbluefin https://mcp.projectbluefin.io/mcp
+```
+
+### Goose
+
+Add to `~/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  projectbluefin:
+    type: sse
+    uri: https://mcp.projectbluefin.io/mcp
+```
+
+### Health Probe
+
+Verify connectivity using the lightweight health probe:
+
+```bash
+curl -s https://mcp.projectbluefin.io/health
+```
+
+Expected output:
+
+```json
+{ "status": "ok", "endpoint": "/mcp" }
+```
+
+---
+
+## Related Reading
+
+- [Why Bluefin is all in on agentic development](/blog/bluefin-agentic-development)
+- [Bluefin's Sausage Factory](/blog/bluefins-sausage-factory)
+- [The Future of Bluefin - Time to be Honest](/blog/the-future-of-bluefin-time-to-be-honest)
+- [Bluefin: Welcome to the Jungle](/blog/welcome-to-the-jungle)
+- [Agentic Contributor Guide](/agentic-contributing)

--- a/blog/2026-09-07-mcp-projectbluefin-io.md
+++ b/blog/2026-09-07-mcp-projectbluefin-io.md
@@ -6,14 +6,11 @@ tags: [announcements, ai]
 date: 2026-09-07T15:00:00-04:00
 ---
 
-Public Model Context Protocol (MCP) endpoint serving the Project Bluefin organization knowledge base and live factory state at `https://mcp.projectbluefin.io/mcp`.
+[Model Context Protocol](https://aaif.io/projects/model-context-protocol) (MCP) is an open protocol for LLMs and agents to talk to each other. We're now serving the Project Bluefin organization knowledge base and live factory state at `https://mcp.projectbluefin.io/mcp`.
 
 <!-- truncate -->
 
-:::note Maintainer Note
-<!-- Maintainer exposition and commentary goes here -->
-
-:::
+Right now [hive.projectbluefin.io](https://hive.projectbluefin.io) exposes an API that has things that are useful for agents. We use it to dole out work to volunteers and to get [review tasks](https://github.com/projectbluefin/review). This is what's letting us scale out in ways we haven't been able to before. Hive has a nice Knowledge Base that it exposes, so this initial cut is to search that knowledge. This is mostly useful to connect whatever agent you use to our stuff and get context for your agent. So if you want to do Bluefin things you just add this. 
 
 ## Endpoint Details
 
@@ -24,6 +21,8 @@ Public Model Context Protocol (MCP) endpoint serving the Project Bluefin organiz
 
 ## Available Tools
 
+Here's what's exposed: 
+
 | Tool                 | Description                                                                                                                                   | Parameters                                                         |
 | :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
 | `search_knowledge`   | Search Project Bluefin knowledge base: engineering patterns, test coverage gaps, CI conventions, and repo findings across `projectbluefin/*`. | `query` (string, required)<br />`limit` (integer 1–25, default 10) |
@@ -32,71 +31,6 @@ Public Model Context Protocol (MCP) endpoint serving the Project Bluefin organiz
 | `get_index_status`   | Operational health, record count, and timestamp of the published knowledge index.                                                             | None                                                               |
 | `get_quickstart`     | Onboarding checklists (`first-pr`, `run-tests`, `factory-gates`, `branch-rules`).                                                             | `topic` (enum, required)                                           |
 | `get_repository_map` | High-level component map, entrypoints, and branch targets for `bluefin`, `bluefin-lts`, `common`, `dakota`, `documentation`.                  | `repo` (enum, required)                                            |
-
-## Client Configuration
-
-### Claude Desktop
-
-Add to `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "projectbluefin": {
-      "type": "http",
-      "url": "https://mcp.projectbluefin.io/mcp"
-    }
-  }
-}
-```
-
-### VS Code / Cursor
-
-Add to `.vscode/mcp.json` or `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "projectbluefin": {
-      "type": "http",
-      "url": "https://mcp.projectbluefin.io/mcp"
-    }
-  }
-}
-```
-
-### GitHub Copilot CLI
-
-```bash
-copilot mcp add --type http projectbluefin https://mcp.projectbluefin.io/mcp
-```
-
-### Goose
-
-Add to `~/.config/goose/config.yaml`:
-
-```yaml
-extensions:
-  projectbluefin:
-    type: sse
-    uri: https://mcp.projectbluefin.io/mcp
-```
-
-### Health Probe
-
-Verify connectivity using the lightweight health probe:
-
-```bash
-curl -s https://mcp.projectbluefin.io/health
-```
-
-Expected output:
-
-```json
-{ "status": "ok", "endpoint": "/mcp" }
-```
-
----
 
 ## Related Reading
 

--- a/blog/2026-09-07-mcp-projectbluefin-io.md
+++ b/blog/2026-09-07-mcp-projectbluefin-io.md
@@ -10,7 +10,7 @@ date: 2026-09-07T15:00:00-04:00
 
 <!-- truncate -->
 
-Right now [hive.projectbluefin.io](https://hive.projectbluefin.io) exposes an API that has things that are useful for agents. We use it to dole out work to volunteers and to get [review tasks](https://github.com/projectbluefin/review). This is what's letting us scale out in ways we haven't been able to before. Hive has a nice Knowledge Base that it exposes, so this initial cut is to search that knowledge. This is mostly useful to connect whatever agent you use to our stuff and get context for your agent. So if you want to do Bluefin things you just add this. 
+Right now [hive.projectbluefin.io](https://hive.projectbluefin.io) exposes an API that has things that are useful for agents. We use it to dole out work to volunteers and to get [review tasks](https://github.com/projectbluefin/review). This is what's letting us scale out in ways we haven't been able to before. Hive has a nice Knowledge Base that it exposes, so this initial cut is to search that knowledge. This is mostly useful to connect whatever agent you use to our stuff and get context for your agent. So if you want to do Bluefin things you just add this. I've [updated the Agentic Contributor Guide](https://docs.projectbluefin.io/agentic-contributing/), note that our hive API endpoints are published, so if you're building a deep integration it probably makes sense to work with the Hive API directly. Feedback and usage notes welcome!
 
 ## Endpoint Details
 

--- a/docs/agentic-contributing.md
+++ b/docs/agentic-contributing.md
@@ -50,11 +50,11 @@ The system is intentionally moving fast. When something breaks, the correct resp
 
 ## The System You Are Joining
 
-Bluefin's agentic factory is orchestrated by **[KubeStellar Hive](https://kubestellar.io/live/hive/bluefin/)**, an AI-native continuous delivery system. The architecture looks like this:
+Bluefin's agentic factory is orchestrated by **[KubeStellar Hive](https://hive.projectbluefin.io/)**, an AI-native continuous delivery system. The architecture looks like this:
 
 ```mermaid
 flowchart TB
-    subgraph hive["KubeStellar Hive — kubestellar.io/live/hive/bluefin/"]
+    subgraph hive["KubeStellar Hive — hive.projectbluefin.io"]
         direction TB
         acmm["AI-native Continuous Maturity Model\nAI agents run at increasing autonomy levels"]
     end
@@ -99,7 +99,7 @@ flowchart TB
 
 ### Components
 
-**[KubeStellar Hive](https://kubestellar.io/live/hive/bluefin/)** is the orchestration layer. It manages 8 repositories in the `projectbluefin` org (`bluefin`, `bluefin-lts`, `common`, `dakota`, `actions`, `renovate-config`, `bonedigger`, `knuckle`). You can watch it work in real time at [kubestellar.io/live/hive/bluefin/](https://kubestellar.io/live/hive/bluefin/).
+**[KubeStellar Hive](https://hive.projectbluefin.io/)** is the orchestration layer. It manages 8 repositories in the `projectbluefin` org (`bluefin`, `bluefin-lts`, `common`, `dakota`, `actions`, `renovate-config`, `bonedigger`, `knuckle`). You can watch it work in real time at [hive.projectbluefin.io](https://hive.projectbluefin.io).
 
 **[bonedigger](https://github.com/projectbluefin/bonedigger)** is the client + lifecycle bot. On Bluefin systems, users run `ujust report` — the agent collects system diagnostics that are hard for humans to gather manually, scrubs PII on-device, and files an issue to the relevant image repository. The GitHub Actions lifecycle bot then manages the pipeline: `filed → approved → queued → claimed → done`.
 
@@ -793,7 +793,7 @@ your contributor card can carry the project's colours instead of a generic
 palette. Bluefin publishes one:
 
 ```text
-https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io/contribute/leaderboard?style=projectbluefin/documentation/static/hive/leaderboard.css@main
+https://hive.projectbluefin.io/contribute/leaderboard?style=projectbluefin/documentation/static/hive/leaderboard.css@main
 ```
 
 The `?style=` parameter takes `owner/repo/path/theme.css@ref`. Omit `@ref` to
@@ -860,7 +860,7 @@ All contributors follow the [Bluefin Code of Conduct](/code-of-conduct).
 
 **mcp.projectbluefin.io** — Public Model Context Protocol endpoint (`https://mcp.projectbluefin.io/mcp`) providing contributor agents with tokenless access to org knowledge (`search_knowledge`), live factory status (`get_factory_status`), and the Hive work queue (`get_work_queue`).
 
-**Hive** — KubeStellar Hive, the reference implementation for ACMM Level 6. Orchestrates the Bluefin agentic factory. Live dashboard: [kubestellar.io/live/hive/bluefin/](https://kubestellar.io/live/hive/bluefin/).
+**Hive** — KubeStellar Hive, the reference implementation for ACMM Level 6. Orchestrates the Bluefin agentic factory. Live dashboard: [hive.projectbluefin.io](https://hive.projectbluefin.io).
 
 **SHA-lock** — The promotion workflow's property that the image digest at the start of promotion must equal the digest at the end. Prevents a rebuild from silently changing what was tested.
 

--- a/docs/skills/cloudflare-workers.md
+++ b/docs/skills/cloudflare-workers.md
@@ -42,6 +42,11 @@ workers_dev = false
 routes = [{ pattern = "<sub>.projectbluefin.io/*", zone_name = "projectbluefin.io" }]
 ```
 
+For vanity cross-domain redirects (such as `hive.projectbluefin.io/*` to
+the hosted Hive instance on `*.hive.hivecommons.dev`), lightweight module
+workers (e.g. `hive-redirect`) handle path and search query forwarding via 301
+redirects.
+
 ## Failure modes that cost real time
 
 **Every named export is treated as an entrypoint.** A stray constant export


### PR DESCRIPTION
## Summary
- Adds draft blog post `blog/2026-09-07-mcp-projectbluefin-io.md` announcing `mcp.projectbluefin.io` with technical facts, tools reference table, client configs (Claude Desktop, VS Code/Cursor, Copilot CLI, Goose), and related reading links. Includes placeholder for maintainer commentary.
- Updated Cloudflare `hive-redirect` Worker to forward `https://hive.projectbluefin.io/*` to `https://hosted-projectbluefin-knuckle-gjvq.hive.hivecommons.dev/*`.
- Updates Hive links in `docs/agentic-contributing.md` to point to `hive.projectbluefin.io`.
- Updates `docs/skills/cloudflare-workers.md` documenting vanity redirect worker pattern.