### PR TITLE
feat(nav): rename Factory to Hive in navbar linking to hive.projectbluefin.io

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -202,8 +202,8 @@ const config: Config = {
           position: "right",
         },
         {
-          to: "/factory",
-          label: "Factory",
+          href: "https://hive.projectbluefin.io",
+          label: "Hive",
           position: "right",
         },
         {


### PR DESCRIPTION
## Summary
Renames "Factory" navbar link to "Hive" and targets `https://hive.projectbluefin.io`.