### PR TITLE
fix: restrict countme worker entrypoint exports to default handler

### DIFF
--- a/docs/skills/cloudflare-workers.md
+++ b/docs/skills/cloudflare-workers.md
@@ -58,7 +58,9 @@ the provided value is not of type 'function or ExportedHandler'.
 ```
 
 Export only the default handler (and genuine Durable Object classes). Keep
-constants module-local.
+constants module-local, or export pure helper logic from a separate module
+(e.g. `routes.mjs`) so unit tests can exercise them offline without leaking
+named exports on the Worker entrypoint.
 
 **`main` resolves relative to the config file, not the working directory.** An
 override config written to `/tmp` cannot use a repo-relative `main`. Use an

--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -5,9 +5,10 @@ let createPendingProjectbluefinSvg;
 let fetchHandler;
 
 test.before(async () => {
+  const routes = await import("../workers/countme-proxy/routes.mjs");
   const mod = await import("../workers/countme-proxy/index.mjs");
-  mapRequestPath = mod.mapRequestPath;
-  createPendingProjectbluefinSvg = mod.createPendingProjectbluefinSvg;
+  mapRequestPath = routes.mapRequestPath;
+  createPendingProjectbluefinSvg = routes.createPendingProjectbluefinSvg;
   fetchHandler = mod.default.fetch;
 });
 
@@ -28,10 +29,22 @@ test("maps projectbluefin source route to projectbluefin countme artifact", () =
 });
 
 test("maps root-host chart aliases to projectbluefin countme artifact", () => {
-  assert.equal(mapRequestPath("/"), "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg");
-  assert.equal(mapRequestPath("/growth.svg"), "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg");
-  assert.equal(mapRequestPath("/bluefin/growth.svg"), "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg");
-  assert.equal(mapRequestPath("/bluefin-lts/growth.svg"), "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg");
+  assert.equal(
+    mapRequestPath("/"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
+  assert.equal(
+    mapRequestPath("/growth.svg"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
+  assert.equal(
+    mapRequestPath("/bluefin/growth.svg"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
+  assert.equal(
+    mapRequestPath("/bluefin-lts/growth.svg"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
 });
 
 test("maps Bluefin badge endpoints", () => {
@@ -64,6 +77,9 @@ test("accepts metalink pings from Dakota telemetry clients", async () => {
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("cache-control"), "no-store");
-  assert.equal(response.headers.get("content-type"), "text/plain;charset=UTF-8");
+  assert.equal(
+    response.headers.get("content-type"),
+    "text/plain;charset=UTF-8",
+  );
   assert.match(await response.text(), /countme accepted/i);
 });

--- a/workers/countme-proxy/index.mjs
+++ b/workers/countme-proxy/index.mjs
@@ -1,21 +1,9 @@
-const LEGACY_BLUEFIN_CHART_URL =
-  "https://raw.githubusercontent.com/ublue-os/countme/main/growth_bluefins.svg";
-const PROJECTBLUEFIN_CHART_URL =
-  "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg";
-
-const ROUTES = {
-  "/": PROJECTBLUEFIN_CHART_URL,
-  "/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/growth_bluefins.svg": LEGACY_BLUEFIN_CHART_URL,
-  "/sources/ublue-os/bluefin/growth.svg": LEGACY_BLUEFIN_CHART_URL,
-  "/sources/projectbluefin/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/bluefin-lts/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/badge-endpoints/bluefin.json":
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
-  "/badge-endpoints/bluefin-lts.json":
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
-};
+import {
+  normalizePathname,
+  createPendingProjectbluefinSvg,
+  isProjectBluefinPrimary,
+  resolveChartTarget,
+} from "./routes.mjs";
 
 function baseHeaders(extra = {}) {
   return {
@@ -49,48 +37,6 @@ function createMetalinkResponse(request) {
   );
 }
 
-function normalizePathname(pathname) {
-  const trimmed = pathname.replace(/\/+$/, "");
-  return trimmed === "" ? "/" : trimmed;
-}
-
-export function mapRequestPath(pathname) {
-  return ROUTES[normalizePathname(pathname)] || null;
-}
-
-export function createPendingProjectbluefinSvg() {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="projectbluefin bluefin countme pending">
-  <rect width="1280" height="720" fill="#0d1117"/>
-  <rect x="30" y="30" width="1220" height="660" rx="12" fill="#161b22" stroke="#30363d" stroke-width="2"/>
-  <text x="70" y="140" fill="#c9d1d9" font-size="40" font-family="Inter, Segoe UI, Arial, sans-serif">projectbluefin/bluefin countme chart pending</text>
-  <text x="70" y="210" fill="#8b949e" font-size="28" font-family="Inter, Segoe UI, Arial, sans-serif">countme.projectbluefin.io configured, waiting for projectbluefin/countme artifacts</text>
-  <line x1="70" y1="560" x2="1210" y2="360" stroke="#58a6ff" stroke-width="4" stroke-dasharray="12 10" opacity="0.75"/>
-  <text x="70" y="620" fill="#8b949e" font-size="24" font-family="Inter, Segoe UI, Arial, sans-serif">Legacy data available at /sources/ublue-os/bluefin/growth.svg</text>
-</svg>`;
-}
-
-function isProjectBluefinPrimary(pathname) {
-  const normalized = normalizePathname(pathname);
-  return [
-    "/",
-    "/growth.svg",
-    "/sources/projectbluefin/bluefin/growth.svg",
-    "/bluefin/growth.svg",
-    "/bluefin-lts/growth.svg",
-  ].includes(normalized);
-}
-
-function resolveChartTarget(pathname) {
-  const normalized = normalizePathname(pathname);
-
-  if (normalized === "/" || normalized === "/growth.svg" || normalized.endsWith("/growth.svg")) {
-    return PROJECTBLUEFIN_CHART_URL;
-  }
-
-  return mapRequestPath(normalized);
-}
-
 async function proxyRequest(request) {
   const url = new URL(request.url);
   const pathname = normalizePathname(url.pathname);
@@ -120,7 +66,8 @@ async function proxyRequest(request) {
   });
 
   if (upstreamRes.ok) {
-    const contentType = upstreamRes.headers.get("content-type") || "application/octet-stream";
+    const contentType =
+      upstreamRes.headers.get("content-type") || "application/octet-stream";
     return new Response(upstreamRes.body, {
       status: 200,
       headers: baseHeaders({

--- a/workers/countme-proxy/routes.mjs
+++ b/workers/countme-proxy/routes.mjs
@@ -1,0 +1,64 @@
+export const LEGACY_BLUEFIN_CHART_URL =
+  "https://raw.githubusercontent.com/ublue-os/countme/main/growth_bluefins.svg";
+export const PROJECTBLUEFIN_CHART_URL =
+  "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg";
+
+export const ROUTES = {
+  "/": PROJECTBLUEFIN_CHART_URL,
+  "/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/growth_bluefins.svg": LEGACY_BLUEFIN_CHART_URL,
+  "/sources/ublue-os/bluefin/growth.svg": LEGACY_BLUEFIN_CHART_URL,
+  "/sources/projectbluefin/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/bluefin-lts/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/badge-endpoints/bluefin.json":
+    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
+  "/badge-endpoints/bluefin-lts.json":
+    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
+};
+
+export function normalizePathname(pathname) {
+  const trimmed = pathname.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+export function mapRequestPath(pathname) {
+  return ROUTES[normalizePathname(pathname)] || null;
+}
+
+export function createPendingProjectbluefinSvg() {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="projectbluefin bluefin countme pending">
+  <rect width="1280" height="720" fill="#0d1117"/>
+  <rect x="30" y="30" width="1220" height="660" rx="12" fill="#161b22" stroke="#30363d" stroke-width="2"/>
+  <text x="70" y="140" fill="#c9d1d9" font-size="40" font-family="Inter, Segoe UI, Arial, sans-serif">projectbluefin/bluefin countme chart pending</text>
+  <text x="70" y="210" fill="#8b949e" font-size="28" font-family="Inter, Segoe UI, Arial, sans-serif">countme.projectbluefin.io configured, waiting for projectbluefin/countme artifacts</text>
+  <line x1="70" y1="560" x2="1210" y2="360" stroke="#58a6ff" stroke-width="4" stroke-dasharray="12 10" opacity="0.75"/>
+  <text x="70" y="620" fill="#8b949e" font-size="24" font-family="Inter, Segoe UI, Arial, sans-serif">Legacy data available at /sources/ublue-os/bluefin/growth.svg</text>
+</svg>`;
+}
+
+export function isProjectBluefinPrimary(pathname) {
+  const normalized = normalizePathname(pathname);
+  return [
+    "/",
+    "/growth.svg",
+    "/sources/projectbluefin/bluefin/growth.svg",
+    "/bluefin/growth.svg",
+    "/bluefin-lts/growth.svg",
+  ].includes(normalized);
+}
+
+export function resolveChartTarget(pathname) {
+  const normalized = normalizePathname(pathname);
+
+  if (
+    normalized === "/" ||
+    normalized === "/growth.svg" ||
+    normalized.endsWith("/growth.svg")
+  ) {
+    return PROJECTBLUEFIN_CHART_URL;
+  }
+
+  return mapRequestPath(normalized);
+}


### PR DESCRIPTION
## Summary
Restrict `workers/countme-proxy/index.mjs` to exporting only the default handler, per Cloudflare Workers runtime requirements documented in `docs/skills/cloudflare-workers.md`. Extract pure route mappings and SVG helpers to `workers/countme-proxy/routes.mjs` so unit tests in `scripts/countme-worker.test.js` can continue running offline.

## Verification
- `npm run typecheck` passed
- `npm run lint` passed (0 errors)
- `npm test` passed (all 412 unit tests passed)
- Live workflow dispatch `deploy-countme-worker.yml` succeeded
- Live probes on `countme.projectbluefin.io` verified (200 on metalink & growth.svg, 405 on POST)