### PR TITLE
feat(analytics): add legacy bluefins and ecosystem countme analytics charts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,3 +40,33 @@ _Avoid_: monthly report, activity report
 A public, externally sourced measurement that supplies context for a Report
 Snapshot while retaining its original measurement window and methodology.
 _Avoid_: factory metric, Countme telemetry
+
+## Countme
+
+**Countme**:
+The privacy-preserving weekly active-device estimation mechanism using coarse
+installation-age buckets and weekly client pings.
+_Avoid_: Telemetry, tracking, user analytics
+
+**CountMe Worker**:
+The Cloudflare Worker deployed at `countme.projectbluefin.io` that proxies
+canonical countme charts/badges and ingests client `/metalink` pings.
+_Avoid_: Telemetry server, collector daemon
+
+**CountMe Client**:
+The scheduled systemd service and timer running on Project Bluefin systems
+(`bluefin`, `bluefin-lts`, `dakota`) via `projectbluefin/common` that computes
+installation age and transmits anonymous weekly pings.
+_Avoid_: Telemetry agent, tracking daemon
+
+**Installation Age Bucket**:
+A coarse bucket (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks)
+matching Fedora mirrors-countme specifications to estimate cohort retention
+without unique host tracking.
+_Avoid_: User tenure, retention tracking, system age fingerprint
+
+**Opt-out Marker**:
+A filesystem presence flag (`/etc/projectbluefin/countme/disabled` or
+`/etc/dakota-countme/disabled`) checked by systemd units and client scripts to
+disable countme reporting.
+_Avoid_: Kill switch, telemetry bypass

--- a/adr/0006-multi-client-countme-reporting.md
+++ b/adr/0006-multi-client-countme-reporting.md
@@ -1,0 +1,62 @@
+# 0006. Multi-client countme reporting via common services and countme.projectbluefin.io
+
+- **Status:** Accepted
+- **Date:** 2026-09-07
+- **Deciders:** @castrojo
+
+## Context
+
+Project Bluefin clients currently have fragmented countme reporting:
+
+1. **Bluefin (standard):** Inherits Fedora's native DNF countme configuration (`countme=1` in `/etc/yum.repos.d/fedora.repo`) sending weekly metalink queries to `mirrors.fedoraproject.org`.
+2. **Bluefin LTS:** Built on CentOS Stream 10 where standard rpm-ostree countme is broken (coreos/rpm-ostree#5464); it runs a custom `bluefin-lts-countme.service` (`dnf makecache`) reaching Fedora infrastructure via EPEL mirrors. Upstream mirrors undercount EPEL clients.
+3. **Dakota:** Built on GNOME OS bootc with BuildStream, possessing no DNF or rpm-ostree packages. PR `projectbluefin/common#807` created a standalone `dakota-countme` service targeting `countme.projectbluefin.io`.
+
+Relying exclusively on Fedora infrastructure leaves Dakota unmeasurable, undercounts LTS systems, and delays metrics by the weekly upstream batch processing cycle. We require all Project Bluefin clients (`bluefin`, `bluefin-lts`, and `dakota`) to report directly via `projectbluefin/common` services to `countme.projectbluefin.io` in addition to upstream Fedora and ublue reporting.
+
+## Decision
+
+1. **Unified Client Service in `projectbluefin/common`:**
+   Deploy a shared systemd service (`bluefin-countme.service` / `bluefin-countme.timer`) and helper script (`/usr/libexec/bluefin-countme`) in `system_files/shared/` across all images.
+   - **Trigger:** Scheduled weekly with `RandomizedDelaySec=12h` and `Persistent=true`.
+   - **Isolation:** Runs under systemd `DynamicUser=yes` with `StateDirectory=bluefin-countme`.
+   - **Throttling:** Computes 7-day rate-limiting locally via `/var/lib/bluefin-countme/lastrun`.
+   - **Cohort estimation:** Determines coarse Fedora-style installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) using an installation timestamp stored in `/var/lib/bluefin-countme/epoch`.
+   - **Metadata extraction:** Reads `/usr/share/ublue-os/image-info.json` for `image-name`, `image-flavor`, `image-tag`, and `/etc/os-release` for version.
+   - **Target:** Sends an empty GET request to `https://countme.projectbluefin.io/metalink?repo=${IMAGE_NAME}&tag=${IMAGE_TAG}&flavor=${IMAGE_FLAVOR}&arch=${ARCH}&countme=${BUCKET}`.
+   - **Privacy:** Transmits NO machine-id, persistent token, hostname, or personal identifier.
+   - **Opt-out:** Honored if `/etc/projectbluefin/countme/disabled` (or legacy `/etc/dakota-countme/disabled`) exists.
+
+2. **Server Ingestion on `countme.projectbluefin.io`:**
+   The Cloudflare Worker (`workers/countme-proxy/index.mjs`) receives `/metalink` GET requests from all supported client repos (`bluefin`, `bluefin-lts`, `dakota`), returning `200 countme accepted` with `cache-control: no-store`.
+
+3. **Coexistence with Upstream:**
+   Existing Fedora and EPEL repo queries remain untouched. The `common` countme service runs alongside upstream reporting to provide first-party visibility without breaking upstream Fedora countme contribution.
+
+## Scope
+
+**In scope:**
+
+- Architecture and specification for multi-client countme reporting across `bluefin`, `bluefin-lts`, and `dakota`.
+- Expanding test coverage in `scripts/countme-worker.test.js` to validate `bluefin`, `bluefin-lts`, and `dakota` metalink requests.
+- Documenting countme client behavior and opt-out procedures in `docs/analytics.mdx`.
+- Updating `docs/skills/cloudflare-workers.md` with `/metalink` proxy contracts.
+- Generalizing PR `projectbluefin/common#807` client script and unit definitions for all projectbluefin client images.
+
+**Out of scope:**
+
+- Modifying `ublue-os/*` upstream repositories.
+- Disabling upstream Fedora repository countme flags.
+
+## Consequences
+
+- All Project Bluefin variants gain consistent, reliable, first-party countme reporting.
+- Dakota systems become measurable alongside Bluefin and Bluefin LTS.
+- Strict client-side rate limiting and coarse age buckets ensure high privacy preservation without tracking individual machines.
+- Users have a documented, single filesystem opt-out mechanism across all images.
+
+## Alternatives considered
+
+- **Per-image countme services:** Creating separate timers/scripts for Bluefin, Bluefin LTS, and Dakota across distinct repositories. Rejected: causes configuration drift, duplicated maintenance, and testing overhead across the factory.
+- **Reporting via machine-id HMAC hash:** Computing a weekly salted hash on the client and counting unique hashes server-side. Rejected: transmitting machine-id derivatives increases privacy exposure and raised reviewer objections; client-side throttling with age buckets achieves cohort estimation with zero identifying payload.
+- **Replacing Fedora countme entirely:** Turning off upstream Fedora countme and relying solely on first-party service. Rejected: Project Bluefin relies on Fedora and desires continued participation in upstream community metrics.

--- a/adr/README.md
+++ b/adr/README.md
@@ -38,9 +38,11 @@ delete, so the reasoning stays readable.
 
 ## Index
 
-| ADR                                          | Title                                                          | Status   |
-| -------------------------------------------- | -------------------------------------------------------------- | -------- |
-| [0001](0001-agent-design-authorization.md)   | Agent design change authorization                              | Accepted |
-| [0002](0002-factory-page.md)                 | Rename /hive to /factory and absorb factory content            | Accepted |
-| [0003](0003-factory-two-level-navigation.md) | Two-level navigation for /factory and first-party chart parity | Accepted |
-| [0004](0004-countme-counting-method.md)      | Countme is counted the way ublue-os/countme counts it          | Accepted |
+| ADR                                            | Title                                                                            | Status   |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
+| [0001](0001-agent-design-authorization.md)     | Agent design change authorization                                                | Accepted |
+| [0002](0002-factory-page.md)                   | Rename /hive to /factory and absorb factory content                              | Accepted |
+| [0003](0003-factory-two-level-navigation.md)   | Two-level navigation for /factory and first-party chart parity                   | Accepted |
+| [0004](0004-countme-counting-method.md)        | Countme is counted the way ublue-os/countme counts it                            | Accepted |
+| [0005](0005-reports-2.0.md)                    | Reports 2.0 public monthly snapshot model                                        | Proposed |
+| [0006](0006-multi-client-countme-reporting.md) | Multi-client countme reporting via common services and countme.projectbluefin.io | Accepted |

--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -3,9 +3,11 @@ title: Analytics
 slug: /analytics
 ---
 
+import CountmeAnalyticsCharts from "@site/src/components/analytics/CountmeAnalyticsCharts";
+
 [![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=ublue-os-bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin)
 
-Bluefin is a high-performance predator. The team believes in instrumentation and telemetry as a means to improve software — but that information must be privacy-respecting via an open process so we can verify what is being shared.
+Bluefin is a high-performance predator. The team believes in instrumentation and countme as a means to improve software — but that information must be privacy-respecting via an open process so we can verify what is being shared.
 
 > Data, for me, is the foundation of F1. There's no human judgment involved. You've got to get your foundation right in data.
 >
@@ -13,14 +15,7 @@ Bluefin is a high-performance predator. The team believes in instrumentation and
 
 ## Countme Statistics
 
-<img
-  src="https://raw.githubusercontent.com/ublue-os/countme/refs/heads/main/growth_bluefins.svg"
-  alt="Bluefin's CountMe Stats"
-  decoding="async"
-  loading="lazy"
-  width="1280"
-  height="720"
-/>
+<CountmeAnalyticsCharts />
 
 The Fedora countme service is on by default in Fedora, and Bluefin inherits that behavior:
 
@@ -54,6 +49,23 @@ forward the request are invisible.
 has no `fedora-N` repo and reaches Fedora's counter only through EPEL. Fedora's
 own infrastructure treats EPEL countme figures as an undercount. Read the LTS
 line as a floor, not as a share of the same population.
+
+### First-party CountMe Service
+
+In addition to upstream Fedora and ublue reporting, Project Bluefin images
+(`bluefin`, `bluefin-lts`, and `dakota`) participate in direct weekly countme
+reporting via `projectbluefin/common` systemd services targeting
+`https://countme.projectbluefin.io/metalink`.
+
+- **Cohort measurement:** Uses Fedora-style installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) calculated locally from an installation epoch timestamp.
+- **Privacy guarantees:** Transmits only image name, tag, flavor, architecture, and age bucket. No machine ID, IP address, username, or persistent identifier is sent or logged.
+- **How to opt out:** Create the disable marker file:
+
+```bash
+sudo install -d -m 0755 /etc/projectbluefin/countme && sudo touch /etc/projectbluefin/countme/disabled
+```
+
+(The legacy marker `/etc/dakota-countme/disabled` is also honored.)
 
 ## Homebrew
 

--- a/docs/skills/cloudflare-workers.md
+++ b/docs/skills/cloudflare-workers.md
@@ -91,6 +91,22 @@ unless the Worker directory ships its own `.gitignore`.
 `zod@^4`; pinning `zod@^3` fails `ERESOLVE`. Resolve the real versions rather
 than reaching for `--legacy-peer-deps`.
 
+## CountMe Worker (countme.projectbluefin.io)
+
+`workers/countme-proxy` handles two primary workloads:
+
+1. **Upstream Artifact Proxy:** Serves weekly growth charts (`/`, `/growth.svg`,
+   `/sources/projectbluefin/bluefin/growth.svg`) and shields.io badge endpoints
+   (`/badge-endpoints/{bluefin,bluefin-lts}.json`), falling back to a branded
+   pending SVG if projectbluefin artifacts have not yet populated.
+2. **Client Ingestion (`/metalink`):** Receives weekly anonymous countme pings
+   from Project Bluefin clients (`bluefin`, `bluefin-lts`, `dakota`).
+   - Query parameters: `repo` (e.g. `bluefin`, `bluefin-lts`, `dakota`), `tag`
+     (e.g. `stable`), `flavor` (e.g. `main`), `arch` (`x86_64`, `aarch64`),
+     `countme` (integer bucket 1–4).
+   - Responses are HTTP 200 with `cache-control: no-store`.
+   - The endpoint strictly disallows persistent machine identifiers or tokens.
+
 ## Verifying before deploy
 
 `wrangler dev` against an override config catches entrypoint and binding errors

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
       "build/**",
       "node_modules/**",
       ".docusaurus/**",
+      ".worktrees/**",
       "static/data/*.json",
       "static/feeds/*.json",
     ],

--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -68,7 +68,7 @@ test("renders pending projectbluefin svg message", () => {
   assert.match(svg, /<svg/i);
 });
 
-test("accepts metalink pings from Dakota telemetry clients", async () => {
+test("accepts metalink pings from Dakota countme clients", async () => {
   const request = new Request(
     "https://countme.projectbluefin.io/metalink?repo=dakota&tag=latest&flavor=default&arch=x86_64&countme=3",
   );
@@ -81,5 +81,46 @@ test("accepts metalink pings from Dakota telemetry clients", async () => {
     response.headers.get("content-type"),
     "text/plain;charset=UTF-8",
   );
-  assert.match(await response.text(), /countme accepted/i);
+  assert.match(
+    await response.text(),
+    /countme accepted for repo=dakota tag=latest flavor=default arch=x86_64 countme=3/i,
+  );
+});
+
+test("accepts metalink pings from Bluefin countme clients", async () => {
+  const request = new Request(
+    "https://countme.projectbluefin.io/metalink?repo=bluefin&tag=stable&flavor=main&arch=x86_64&countme=2",
+  );
+
+  const response = await fetchHandler(request);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(
+    response.headers.get("content-type"),
+    "text/plain;charset=UTF-8",
+  );
+  assert.match(
+    await response.text(),
+    /countme accepted for repo=bluefin tag=stable flavor=main arch=x86_64 countme=2/i,
+  );
+});
+
+test("accepts metalink pings from Bluefin LTS countme clients", async () => {
+  const request = new Request(
+    "https://countme.projectbluefin.io/metalink?repo=bluefin-lts&tag=stable&flavor=main&arch=x86_64&countme=4",
+  );
+
+  const response = await fetchHandler(request);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(
+    response.headers.get("content-type"),
+    "text/plain;charset=UTF-8",
+  );
+  assert.match(
+    await response.text(),
+    /countme accepted for repo=bluefin-lts tag=stable flavor=main arch=x86_64 countme=4/i,
+  );
 });

--- a/src/components/analytics/CountmeAnalyticsCharts.module.css
+++ b/src/components/analytics/CountmeAnalyticsCharts.module.css
@@ -1,0 +1,316 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+/* Legacy Bluefins Hero Chart */
+.heroCard {
+  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.75));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+  position: relative;
+  overflow: hidden;
+}
+
+.heroCard::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #58a6ff, #39d2c0);
+}
+
+.heroHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.heroTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.heroTitle {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--ifm-heading-color, #e6edf3);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.heroSubtitle {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+  margin: 0;
+}
+
+.heroKPI {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.heroNumber {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #58a6ff;
+  line-height: 1;
+}
+
+.heroMeta {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(88, 166, 255, 0.15);
+  color: #58a6ff;
+}
+
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.kpiCard {
+  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+  border-radius: 10px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.kpiCard:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.imageTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color, #e6edf3);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(88, 166, 255, 0.15);
+  color: var(--ifm-color-primary, #58a6ff);
+}
+
+.badgeGaming {
+  background: rgba(240, 136, 62, 0.15);
+  color: #f0883e;
+}
+
+.badgeEnterprise {
+  background: rgba(188, 140, 255, 0.15);
+  color: #bc8cff;
+}
+
+.badgeDesktop {
+  background: rgba(57, 210, 192, 0.15);
+  color: #39d2c0;
+}
+
+.countRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.countValue {
+  font-size: 1.85rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--ifm-heading-color, #e6edf3);
+}
+
+.sharePct {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700, #8b949e);
+}
+
+.cardDesc {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+  margin: 0;
+}
+
+.cardSparkline {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.6));
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sparklineLabel {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500, #808893);
+}
+
+/* Distribution bar */
+.shareSection {
+  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+  border-radius: 10px;
+  padding: 1.25rem;
+}
+
+.sectionHeading {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  color: var(--ifm-heading-color, #e6edf3);
+}
+
+.sectionSubtext {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+  margin-bottom: 1rem;
+}
+
+.distributionBar {
+  display: flex;
+  height: 20px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(48, 54, 61, 0.5);
+  margin-bottom: 1rem;
+}
+
+.segment {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.shareLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.legendLabel {
+  color: var(--ifm-heading-color, #e6edf3);
+  font-weight: 600;
+}
+
+.legendValue {
+  color: var(--ifm-color-emphasis-600, #8b949e);
+}
+
+/* Chart Card */
+.chartCard {
+  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+  border-radius: 10px;
+  padding: 1.25rem;
+}
+
+.chartControls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.toggleGroup {
+  display: inline-flex;
+  border: 1px solid var(--ifm-color-emphasis-300, #30363d);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.toggleBtn {
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700, #8b949e);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.toggleBtn:not(:last-child) {
+  border-right: 1px solid var(--ifm-color-emphasis-300, #30363d);
+}
+
+.toggleBtnActive {
+  background: var(--ifm-color-primary, #58a6ff);
+  color: #fff !important;
+}
+
+.toggleBtn:hover:not(.toggleBtnActive) {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--ifm-heading-color, #e6edf3);
+}
+
+.chartNote {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+  margin-top: 0.75rem;
+  line-height: 1.4;
+}

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from "react";
 import Heading from "@theme/Heading";
 import EChart from "../factory/EChart";
+import Unavailable from "../factory/Unavailable";
 import Sparkline from "../Sparkline";
 import { gapSafe, seriesColor, seriesDash } from "../factory/chartTheme";
 import styles from "./CountmeAnalyticsCharts.module.css";
@@ -23,6 +24,8 @@ export interface CountmeDataset {
   unit: string;
   variants: string[];
   weeks: CountmeWeek[];
+  unavailable?: boolean;
+  stateReason?: string | null;
 }
 
 type LegacyRange = "12w" | "24w" | "all";
@@ -66,7 +69,7 @@ const IMAGE_CONFIGS = [
 
 export default function CountmeAnalyticsCharts(): React.JSX.Element {
   const data = countmeHistoryData as unknown as CountmeDataset;
-  const weeks = data.weeks || [];
+  const weeks = data?.weeks || [];
 
   const [legacyRange, setLegacyRange] = useState<LegacyRange>("all");
   const [range, setRange] = useState<RangeOption>("12w");
@@ -104,6 +107,21 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
       0,
     );
   }, [latestWeek]);
+
+  // Real finite point counts for EChart to prevent bypassing accumulating data
+  const realLegacyPoints = useMemo(() => {
+    return legacyFilteredWeeks.filter(
+      (w) => typeof w.bluefin === "number" && !Number.isNaN(w.bluefin),
+    ).length;
+  }, [legacyFilteredWeeks]);
+
+  const realComparativePoints = useMemo(() => {
+    return filteredWeeks.filter((w) =>
+      peerImages.some(
+        (key) => typeof w[key] === "number" && !Number.isNaN(w[key]),
+      ),
+    ).length;
+  }, [filteredWeeks, peerImages]);
 
   // Shared domain for workstation small multiples
   const workstationDomain = useMemo<[number, number]>(() => {
@@ -228,6 +246,19 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     };
   }, [filteredWeeks, viewMode]);
 
+  if (data?.unavailable || !weeks.length) {
+    return (
+      <div className={styles.container}>
+        <Unavailable
+          what="Countme Analytics"
+          reason={
+            data?.stateReason ?? "Countme dataset is currently unavailable."
+          }
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.container}>
       {/* ── 1. Hero: Legacy Bluefins ────────────────────────────────────────── */}
@@ -280,7 +311,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
           option={legacyChartOption}
           title="Legacy Bluefins"
           summary={`Legacy Bluefins historical weekly active systems: currently ${currentBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
-          points={legacyFilteredWeeks.length}
+          points={realLegacyPoints}
           minPoints={2}
           height={320}
           tableCaption="Legacy Bluefins weekly active systems history"
@@ -307,10 +338,8 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         {/* Distribution Bar */}
         <div
           className={styles.distributionBar}
-          role="progressbar"
-          aria-valuenow={100}
-          aria-valuemin={0}
-          aria-valuemax={100}
+          role="region"
+          aria-label={`Desktop ecosystem distribution across ${peerTotal.toLocaleString()} systems`}
         >
           {IMAGE_CONFIGS.map((cfg) => {
             const count = Number(latestWeek[cfg.id]) || 0;
@@ -450,7 +479,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
           option={comparativeChartOption}
           title="Comparative Image Trajectories"
           summary={`Comparative adoption trajectories across cloud-native images over ${filteredWeeks.length} weeks. Latest week (${latestWeek.week}): Bazzite ${Number(latestWeek.bazzite || 0).toLocaleString()} (Gaming), Bluefin ${Number(latestWeek.bluefin || 0).toLocaleString()} (Workstation), Aurora ${Number(latestWeek.aurora || 0).toLocaleString()} (KDE), Bluefin LTS ${Number(latestWeek["bluefin-lts"] || 0).toLocaleString()} (CentOS EPEL floor).`}
-          points={filteredWeeks.length}
+          points={realComparativePoints}
           minPoints={2}
           height={320}
           tableCaption="Weekly estimated active systems by image variant"

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -1,0 +1,469 @@
+import React, { useState, useMemo } from "react";
+import Heading from "@theme/Heading";
+import EChart from "../factory/EChart";
+import Sparkline from "../Sparkline";
+import { gapSafe, seriesColor, seriesDash } from "../factory/chartTheme";
+import styles from "./CountmeAnalyticsCharts.module.css";
+import countmeHistoryData from "@site/static/data/countme-history.json";
+
+export interface CountmeWeek {
+  week: string;
+  bluefin?: number;
+  "bluefin-lts"?: number;
+  aurora?: number;
+  bazzite?: number;
+  fedora?: number;
+  [key: string]: string | number | undefined;
+}
+
+export interface CountmeDataset {
+  generatedAt: string;
+  source: string;
+  method: string;
+  unit: string;
+  variants: string[];
+  weeks: CountmeWeek[];
+}
+
+type LegacyRange = "12w" | "24w" | "all";
+type RangeOption = "4w" | "12w" | "all";
+type ViewMode = "workstations" | "all-ecosystem" | "with-fedora";
+
+const IMAGE_CONFIGS = [
+  {
+    id: "bazzite",
+    name: "Bazzite",
+    badge: "Gaming & Handhelds",
+    badgeClass: styles.badgeGaming,
+    desc: "Gaming-specialized image for Steam Deck, ROG Ally, Lenovo Legion Go, and gaming PCs.",
+    color: "#f0883e",
+  },
+  {
+    id: "bluefin",
+    name: "Bluefin",
+    badge: "Developer Workstation",
+    badgeClass: styles.badge,
+    desc: "Flagship cloud-native workstation with devcontainers, eBPF tooling, and dedicated developer ergonomics.",
+    color: "#58a6ff",
+  },
+  {
+    id: "aurora",
+    name: "Aurora",
+    badge: "KDE Plasma Desktop",
+    badgeClass: styles.badgeDesktop,
+    desc: "Cloud-native desktop featuring KDE Plasma, customized for speed and polished productivity.",
+    color: "#39d2c0",
+  },
+  {
+    id: "bluefin-lts",
+    name: "Bluefin LTS",
+    badge: "Enterprise Base",
+    badgeClass: styles.badgeEnterprise,
+    desc: "CentOS Stream 10-based release for long-term deployments (counted via EPEL; represents a floor).",
+    color: "#bc8cff",
+  },
+] as const;
+
+export default function CountmeAnalyticsCharts(): React.JSX.Element {
+  const data = countmeHistoryData as unknown as CountmeDataset;
+  const weeks = data.weeks || [];
+
+  const [legacyRange, setLegacyRange] = useState<LegacyRange>("all");
+  const [range, setRange] = useState<RangeOption>("12w");
+  const [viewMode, setViewMode] = useState<ViewMode>("all-ecosystem");
+
+  const latestWeek = weeks[weeks.length - 1] || ({} as CountmeWeek);
+  const currentBluefin = Number(latestWeek.bluefin) || 0;
+
+  // Filtered weeks for Legacy Bluefins chart
+  const legacyFilteredWeeks = useMemo(() => {
+    if (legacyRange === "12w") return weeks.slice(-12);
+    if (legacyRange === "24w") return weeks.slice(-24);
+    return weeks;
+  }, [weeks, legacyRange]);
+
+  // First recorded bluefin count for delta computation
+  const initialBluefin = Number(weeks[0]?.bluefin) || currentBluefin;
+  const bluefinDeltaPct =
+    initialBluefin > 0
+      ? (((currentBluefin - initialBluefin) / initialBluefin) * 100).toFixed(1)
+      : "0.0";
+
+  // Filtered weeks for comparative time-series charts
+  const filteredWeeks = useMemo(() => {
+    if (range === "4w") return weeks.slice(-4);
+    if (range === "12w") return weeks.slice(-12);
+    return weeks;
+  }, [weeks, range]);
+
+  // Ecosystem totals (excluding Fedora base)
+  const peerImages = ["bazzite", "bluefin", "aurora", "bluefin-lts"] as const;
+  const peerTotal = useMemo(() => {
+    return peerImages.reduce(
+      (sum, key) => sum + (Number(latestWeek[key]) || 0),
+      0,
+    );
+  }, [latestWeek]);
+
+  // Shared domain for workstation small multiples
+  const workstationDomain = useMemo<[number, number]>(() => {
+    let min = Infinity;
+    let max = -Infinity;
+    const workstationKeys = ["bluefin", "aurora", "bluefin-lts"] as const;
+    for (const w of weeks) {
+      for (const k of workstationKeys) {
+        const val = w[k];
+        if (typeof val === "number") {
+          if (val < min) min = val;
+          if (val > max) max = val;
+        }
+      }
+    }
+    return [Math.max(0, min), Math.max(100, max)];
+  }, [weeks]);
+
+  // 1. "Legacy Bluefins" EChart option
+  const legacyChartOption = useMemo(() => {
+    const labels = legacyFilteredWeeks.map((w) => w.week);
+    const bluefinSeries = gapSafe(
+      legacyFilteredWeeks.map((w) => w.bluefin ?? null),
+    );
+
+    return {
+      xAxis: {
+        type: "category",
+        data: labels,
+      },
+      yAxis: {
+        type: "value",
+        min: "dataMin",
+      },
+      series: [
+        {
+          name: "Bluefin",
+          type: "line",
+          data: bluefinSeries,
+          smooth: true,
+          showSymbol: true,
+          symbolSize: 6,
+          itemStyle: { color: "#58a6ff" },
+          lineStyle: { width: 3, color: "#58a6ff" },
+          areaStyle: {
+            color: {
+              type: "linear",
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: "rgba(88, 166, 255, 0.45)" },
+                { offset: 1, color: "rgba(88, 166, 255, 0.02)" },
+              ],
+            },
+          },
+          connectNulls: false,
+        },
+      ],
+    };
+  }, [legacyFilteredWeeks]);
+
+  // 2. Comparative EChart configuration
+  const comparativeChartOption = useMemo(() => {
+    const labels = filteredWeeks.map((w) => w.week);
+    const seriesList = [];
+
+    if (viewMode === "with-fedora") {
+      seriesList.push({
+        name: "Fedora (Base)",
+        type: "line",
+        data: gapSafe(filteredWeeks.map((w) => w.fedora ?? null)),
+        connectNulls: false,
+        itemStyle: { color: "#79b8ff" },
+        lineStyle: { type: [4, 4] },
+      });
+    }
+
+    if (viewMode === "all-ecosystem" || viewMode === "with-fedora") {
+      seriesList.push({
+        name: "Bazzite (Gaming)",
+        type: "line",
+        data: gapSafe(filteredWeeks.map((w) => w.bazzite ?? null)),
+        connectNulls: false,
+        itemStyle: { color: "#f0883e" },
+        lineStyle: { type: seriesDash(3) },
+      });
+    }
+
+    seriesList.push(
+      {
+        name: "Bluefin",
+        type: "line",
+        data: gapSafe(filteredWeeks.map((w) => w.bluefin ?? null)),
+        connectNulls: false,
+        itemStyle: { color: seriesColor(0) },
+        lineStyle: { type: seriesDash(0) },
+      },
+      {
+        name: "Aurora",
+        type: "line",
+        data: gapSafe(filteredWeeks.map((w) => w.aurora ?? null)),
+        connectNulls: false,
+        itemStyle: { color: seriesColor(2) },
+        lineStyle: { type: seriesDash(2) },
+      },
+      {
+        name: "Bluefin LTS",
+        type: "line",
+        data: gapSafe(filteredWeeks.map((w) => w["bluefin-lts"] ?? null)),
+        connectNulls: false,
+        itemStyle: { color: seriesColor(1) },
+        lineStyle: { type: seriesDash(1) },
+      },
+    );
+
+    return {
+      xAxis: { type: "category", data: labels },
+      yAxis: { type: "value" },
+      series: seriesList,
+    };
+  }, [filteredWeeks, viewMode]);
+
+  return (
+    <div className={styles.container}>
+      {/* ── 1. Hero: Legacy Bluefins ────────────────────────────────────────── */}
+      <div className={styles.heroCard}>
+        <div className={styles.heroHeader}>
+          <div className={styles.heroTitleGroup}>
+            <Heading as="h3" className={styles.heroTitle}>
+              Legacy Bluefins
+              <span className={styles.heroBadge}>ublue-os historical</span>
+            </Heading>
+            <p className={styles.heroSubtitle}>
+              Canonical weekly active systems curve ported from ublue-os/countme
+              methodology
+            </p>
+          </div>
+
+          <div className={styles.heroKPI}>
+            <div className={styles.heroNumber}>
+              {currentBluefin.toLocaleString()}
+            </div>
+            <div className={styles.heroMeta}>
+              <span style={{ fontWeight: 700, color: "#39d2c0" }}>
+                +{bluefinDeltaPct}% overall
+              </span>
+              <span>latest week ({latestWeek.week})</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.chartControls}>
+          <div className={styles.toggleGroup}>
+            {(["12w", "24w", "all"] as LegacyRange[]).map((r) => (
+              <button
+                key={r}
+                type="button"
+                className={`${styles.toggleBtn} ${legacyRange === r ? styles.toggleBtnActive : ""}`}
+                onClick={() => setLegacyRange(r)}
+              >
+                {r === "12w"
+                  ? "12 Weeks"
+                  : r === "24w"
+                    ? "6 Months"
+                    : `All History (${weeks.length}w)`}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <EChart
+          option={legacyChartOption}
+          title="Legacy Bluefins"
+          summary={`Legacy Bluefins historical weekly active systems: currently ${currentBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
+          points={legacyFilteredWeeks.length}
+          minPoints={2}
+          height={320}
+          tableCaption="Legacy Bluefins weekly active systems history"
+        />
+
+        <div className={styles.chartNote}>
+          <strong>Lineage:</strong> This replaces the legacy matplotlib chart
+          with native interactive rendering while preserving exact numerical
+          parity with <code>ublue-os/countme:growth_bluefins.svg</code> and
+          project README badges.
+        </div>
+      </div>
+
+      {/* ── 2. Cloud-Native Ecosystem Overview ─────────────────────────────── */}
+      <div className={styles.shareSection}>
+        <div className={styles.sectionHeading}>
+          Cloud-Native Desktop Ecosystem
+        </div>
+        <div className={styles.sectionSubtext}>
+          Share of {peerTotal.toLocaleString()} total estimated active
+          cloud-native desktop devices (latest week: {latestWeek.week})
+        </div>
+
+        {/* Distribution Bar */}
+        <div
+          className={styles.distributionBar}
+          role="progressbar"
+          aria-valuenow={100}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          {IMAGE_CONFIGS.map((cfg) => {
+            const count = Number(latestWeek[cfg.id]) || 0;
+            const pct = peerTotal > 0 ? (count / peerTotal) * 100 : 0;
+            return (
+              <div
+                key={cfg.id}
+                className={styles.segment}
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: cfg.color,
+                }}
+                title={`${cfg.name}: ${count.toLocaleString()} (${pct.toFixed(1)}%)`}
+              />
+            );
+          })}
+        </div>
+
+        {/* Legend */}
+        <div className={styles.shareLegend}>
+          {IMAGE_CONFIGS.map((cfg) => {
+            const count = Number(latestWeek[cfg.id]) || 0;
+            const pct =
+              peerTotal > 0 ? ((count / peerTotal) * 100).toFixed(1) : "0.0";
+            return (
+              <div key={cfg.id} className={styles.legendItem}>
+                <span
+                  className={styles.legendDot}
+                  style={{ backgroundColor: cfg.color }}
+                />
+                <span className={styles.legendLabel}>{cfg.name}:</span>
+                <span className={styles.legendValue}>
+                  {count.toLocaleString()} ({pct}%)
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── 3. Image Breakdown Cards ────────────────────────────────────────── */}
+      <div className={styles.kpiGrid}>
+        {IMAGE_CONFIGS.map((cfg) => {
+          const count = Number(latestWeek[cfg.id]) || 0;
+          const pct =
+            peerTotal > 0 ? ((count / peerTotal) * 100).toFixed(1) : "0.0";
+          const history = weeks
+            .slice(-12)
+            .map((w) => (w[cfg.id] as number) ?? null);
+
+          // Shared domain for workstations, separate domain for high-scale gaming
+          const domain = cfg.id === "bazzite" ? undefined : workstationDomain;
+
+          return (
+            <div key={cfg.id} className={styles.kpiCard}>
+              <div className={styles.cardHeader}>
+                <span className={styles.imageTitle}>{cfg.name}</span>
+                <span className={`${styles.badge} ${cfg.badgeClass}`}>
+                  {cfg.badge}
+                </span>
+              </div>
+              <div className={styles.countRow}>
+                <span className={styles.countValue}>
+                  {count.toLocaleString()}
+                </span>
+                <span className={styles.sharePct}>{pct}%</span>
+              </div>
+              <p className={styles.cardDesc}>{cfg.desc}</p>
+              <div className={styles.cardSparkline}>
+                <span className={styles.sparklineLabel}>12-week trend</span>
+                <Sparkline
+                  data={history}
+                  variant="line"
+                  domain={domain}
+                  width={200}
+                  height={32}
+                  color={cfg.color}
+                  areaColor="currentColor"
+                  areaOpacity={0.12}
+                  showEnd={true}
+                  minPoints={2}
+                  emptyLabel="accumulating data"
+                  label={`${cfg.name} 12-week adoption trend: currently ${count.toLocaleString()}`}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── 4. Interactive Comparative Trajectory ───────────────────────────── */}
+      <div className={styles.chartCard}>
+        <div className={styles.chartControls}>
+          <div className={styles.toggleGroup}>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${viewMode === "all-ecosystem" ? styles.toggleBtnActive : ""}`}
+              onClick={() => setViewMode("all-ecosystem")}
+            >
+              All Desktop Images
+            </button>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${viewMode === "workstations" ? styles.toggleBtnActive : ""}`}
+              onClick={() => setViewMode("workstations")}
+            >
+              Workstations (Bluefin & Aurora)
+            </button>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${viewMode === "with-fedora" ? styles.toggleBtnActive : ""}`}
+              onClick={() => setViewMode("with-fedora")}
+            >
+              Include Fedora Base
+            </button>
+          </div>
+
+          <div className={styles.toggleGroup}>
+            {(["4w", "12w", "all"] as RangeOption[]).map((r) => (
+              <button
+                key={r}
+                type="button"
+                className={`${styles.toggleBtn} ${range === r ? styles.toggleBtnActive : ""}`}
+                onClick={() => setRange(r)}
+              >
+                {r === "4w"
+                  ? "4 Weeks"
+                  : r === "12w"
+                    ? "12 Weeks"
+                    : "All Weeks"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <EChart
+          option={comparativeChartOption}
+          title="Comparative Image Trajectories"
+          summary={`Comparative adoption trajectories across cloud-native images over ${filteredWeeks.length} weeks. Latest week (${latestWeek.week}): Bazzite ${Number(latestWeek.bazzite || 0).toLocaleString()} (Gaming), Bluefin ${Number(latestWeek.bluefin || 0).toLocaleString()} (Workstation), Aurora ${Number(latestWeek.aurora || 0).toLocaleString()} (KDE), Bluefin LTS ${Number(latestWeek["bluefin-lts"] || 0).toLocaleString()} (CentOS EPEL floor).`}
+          points={filteredWeeks.length}
+          minPoints={2}
+          height={320}
+          tableCaption="Weekly estimated active systems by image variant"
+        />
+
+        <div className={styles.chartNote}>
+          <strong>Methodology:</strong> Derived from Fedora Countme weekly
+          reporting using the canonical <code>ublue-countme-v1</code> counting
+          rules (one base repository per device, excluding legacy sys_age=-1
+          rows). Bluefin LTS is CentOS Stream based and counted via EPEL, which
+          acts as a lower-bound floor.
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces legacy static chart on `/analytics` with native interactive `<CountmeAnalyticsCharts />`
- **Legacy Bluefins Hero**: Ported from canonical `ublue-os/countme` methodology with full 35-week history, delta stats, and range controls (12w, 24w, all)
- **Ecosystem Distribution**: Interactive distribution bar and percentage share breakdown across Bazzite (gaming), Bluefin (workstation), Aurora (KDE), and Bluefin LTS (EPEL floor)
- **Image Breakdown Cards**: Metric cards with sparklines sharing workstation domain scales
- **Interactive Trajectory**: Multi-series comparative trajectories with image filtering and timeframe options
- **Domain & Architecture**: Recorded ADR 0006 for multi-client countme reporting and updated `CONTEXT.md` with anti-telemetry conventions
- **Test Coverage**: Added client ping tests to `scripts/countme-worker.test.js` (9/9 pass)
- **Lint Configuration**: Added `.worktrees/**` to ESLint ignores to isolate worktree TypeScript parser contexts