### PR TITLE
feat(analytics): unify Bluefin family countme charts and multi-image catalog

### DIFF
--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -22,40 +22,35 @@ The Fedora countme service is on by default in Fedora, and Bluefin inherits that
 - [countme](https://github.com/wgwoods/fedora-countme-data)
 - [How to turn it off](https://coreos.github.io/rpm-ostree/countme/)
 
-### How the numbers are counted
+### Single Source of Truth
 
-The chart above and the [Factory metrics view](/factory/metrics) are both derived
-from Fedora's published `totals.csv` using the rules in
-[ublue-os/countme](https://github.com/ublue-os/countme), which is the project's
-canonical implementation. Two of those rules matter for reading the numbers:
+The charts above serve as the single source of truth for the entire Project Bluefin
+workstation family, preserving direct historical continuity with the canonical
+baseline from `ublue-os/bluefin`.
 
-- **A hit is not a device.** DNF sends a countme request once a week for _each
-  repository_ that has it enabled, so a machine with the base, updates, openh264
-  and source repos produces four hits. Counting devices means restricting to the
-  single base `fedora-N` repo that each system has exactly one of.
-- **Not every row is the same measurement.** Rows carrying `sys_age = -1` are a
-  separate legacy unique-IP estimate that Fedora computes in a second pass and
-  writes into the same file. They are excluded.
+Active systems across all Project Bluefin images are combined into the unified
+Bluefin fleet view:
 
-Two weeks are skipped outright: the partial week at the end of 2024, and the week
-of the July 2025 Fedora infrastructure migration, which shows a ~40% drop that
-reflects the migration rather than a loss of users.
+- **Bluefin (Flagship Workstation):** Standard Fedora bootc cloud-native developer workstation.
+- **Bluefin LTS (Enterprise Workstation):** CentOS Stream 10 bootc long-term support release with 10-year platform stability.
+- **Project Bluefin Dakota (Next-Gen Workstation):** Assembled from source with Apache BuildStream on GNOME OS bootc.
+- **Project Bluefin Utah (Next-Gen Workstation):** Modular workstation on minimal Fedora Hummingbird bootc with GNOME 51 desktop layer.
 
-Countme is an estimate, not a census. It only sees systems that actually ran dnf
-during the week, it can be turned off, and systems behind a mirror that does not
-forward the request are invisible.
+### First-party Countme Service
 
-**Bluefin LTS is not comparable to the others.** It is CentOS Stream based, so it
-has no `fedora-N` repo and reaches Fedora's counter only through EPEL. Fedora's
-own infrastructure treats EPEL countme figures as an undercount. Read the LTS
-line as a floor, not as a share of the same population.
-
-### First-party CountMe Service
-
-In addition to upstream Fedora and ublue reporting, Project Bluefin images
-(`bluefin`, `bluefin-lts`, and `dakota`) participate in direct weekly countme
-reporting via `projectbluefin/common` systemd services targeting
+Project Bluefin images (`bluefin`, `bluefin-lts`, `dakota`, and `utah`) participate
+in direct weekly countme reporting via `projectbluefin/common` systemd services targeting
 `https://countme.projectbluefin.io/metalink`.
+
+- **Cohort measurement:** Uses installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) calculated locally from an installation epoch timestamp.
+- **Privacy guarantees:** Transmits only image name, tag, flavor, architecture, and age bucket. No machine ID, IP address, username, or persistent identifier is sent or logged.
+- **How to opt out:** Create the disable marker file:
+
+```bash
+sudo install -d -m 0755 /etc/projectbluefin/countme && sudo touch /etc/projectbluefin/countme/disabled
+```
+
+(The legacy marker `/etc/dakota-countme/disabled` is also honored.)
 
 - **Cohort measurement:** Uses Fedora-style installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) calculated locally from an installation epoch timestamp.
 - **Privacy guarantees:** Transmits only image name, tag, flavor, architecture, and age bucket. No machine ID, IP address, username, or persistent identifier is sent or logged.

--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -45,9 +45,17 @@ test("maps root-host chart aliases to projectbluefin countme artifact", () => {
     mapRequestPath("/bluefin-lts/growth.svg"),
     "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
   );
+  assert.equal(
+    mapRequestPath("/dakota/growth.svg"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
+  assert.equal(
+    mapRequestPath("/utah/growth.svg"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+  );
 });
 
-test("maps Bluefin badge endpoints", () => {
+test("maps Bluefin, Dakota, and Utah badge endpoints", () => {
   assert.equal(
     mapRequestPath("/badge-endpoints/bluefin.json"),
     "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
@@ -55,6 +63,14 @@ test("maps Bluefin badge endpoints", () => {
   assert.equal(
     mapRequestPath("/badge-endpoints/bluefin-lts.json"),
     "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
+  );
+  assert.equal(
+    mapRequestPath("/badge-endpoints/dakota.json"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/dakota.json",
+  );
+  assert.equal(
+    mapRequestPath("/badge-endpoints/utah.json"),
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/utah.json",
   );
 });
 
@@ -123,4 +139,33 @@ test("accepts metalink pings from Bluefin LTS countme clients", async () => {
     await response.text(),
     /countme accepted for repo=bluefin-lts tag=stable flavor=main arch=x86_64 countme=4/i,
   );
+});
+
+test("accepts metalink pings from Utah countme clients", async () => {
+  const request = new Request(
+    "https://countme.projectbluefin.io/metalink?repo=utah&tag=testing&flavor=default&arch=x86_64&countme=1",
+  );
+
+  const response = await fetchHandler(request);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(
+    response.headers.get("content-type"),
+    "text/plain;charset=UTF-8",
+  );
+  assert.match(
+    await response.text(),
+    /countme accepted for repo=utah tag=testing flavor=default arch=x86_64 countme=1/i,
+  );
+});
+
+test("renders pending projectbluefin svg message with specific variant", () => {
+  const dakotaSvg = createPendingProjectbluefinSvg("dakota");
+  assert.match(dakotaSvg, /projectbluefin\/dakota countme chart pending/i);
+  assert.match(dakotaSvg, /Dakota countme\.projectbluefin\.io configured/i);
+
+  const utahSvg = createPendingProjectbluefinSvg("utah");
+  assert.match(utahSvg, /projectbluefin\/utah countme chart pending/i);
+  assert.match(utahSvg, /Utah countme\.projectbluefin\.io configured/i);
 });

--- a/src/components/analytics/CountmeAnalyticsCharts.module.css
+++ b/src/components/analytics/CountmeAnalyticsCharts.module.css
@@ -90,6 +90,28 @@
   color: #58a6ff;
 }
 
+.heroSubBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.heroSubBadge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(48, 54, 61, 0.5);
+  color: var(--ifm-color-emphasis-700, #c9d1d9);
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+}
+
+.heroSubBadgeHighlight {
+  color: #58a6ff;
+  border-color: rgba(88, 166, 255, 0.4);
+}
+
 .kpiGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -313,4 +335,139 @@
   color: var(--ifm-color-emphasis-600, #8b949e);
   margin-top: 0.75rem;
   line-height: 1.4;
+}
+
+/* Family section */
+.familySection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.familyGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.familyCard {
+  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.75));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.familyCard:hover {
+  transform: translateY(-2px);
+  border-color: var(--ifm-color-primary, #58a6ff);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.familyCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.familyCardTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.familyName {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color, #e6edf3);
+  margin: 0;
+}
+
+.familyEdition {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600, #8b949e);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.statusActive {
+  background: rgba(57, 210, 192, 0.15);
+  color: #39d2c0;
+}
+
+.statusPending {
+  background: rgba(188, 140, 255, 0.15);
+  color: #bc8cff;
+}
+
+.familyMetaRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  font-size: 0.75rem;
+}
+
+.familyMetaItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.familyMetaLabel {
+  color: var(--ifm-color-emphasis-500, #8b949e);
+}
+
+.familyMetaValue {
+  color: var(--ifm-color-emphasis-800, #e6edf3);
+  font-weight: 600;
+  font-family: var(--ifm-font-family-monospace, monospace);
+  font-size: 0.75rem;
+}
+
+.familyFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.6));
+}
+
+.familyLink {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary, #58a6ff);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.familyLink:hover {
+  text-decoration: underline;
 }

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import EChart from "../factory/EChart";
 import Unavailable from "../factory/Unavailable";
@@ -14,6 +15,8 @@ export interface CountmeWeek {
   aurora?: number;
   bazzite?: number;
   fedora?: number;
+  dakota?: number;
+  utah?: number;
   [key: string]: string | number | undefined;
 }
 
@@ -28,68 +31,113 @@ export interface CountmeDataset {
   stateReason?: string | null;
 }
 
-type LegacyRange = "12w" | "24w" | "all";
+type HeroRange = "12w" | "24w" | "all";
+type HeroMode = "unified" | "split";
 type RangeOption = "4w" | "12w" | "all";
 type ViewMode = "workstations" | "all-ecosystem" | "with-fedora";
 
-const IMAGE_CONFIGS = [
-  {
-    id: "bazzite",
-    name: "Bazzite",
-    badge: "Gaming & Handhelds",
-    badgeClass: styles.badgeGaming,
-    desc: "Gaming-specialized image for Steam Deck, ROG Ally, Lenovo Legion Go, and gaming PCs.",
-    color: "#f0883e",
-  },
+interface ProjectBluefinImageSpec {
+  id: "bluefin" | "bluefin-lts" | "dakota" | "utah";
+  name: string;
+  badge: string;
+  edition: string;
+  stream: string;
+  desc: string;
+  color: string;
+  link: string;
+  status: "active" | "bootstrapping" | "provisioning";
+  statusText: string;
+}
+
+const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
   {
     id: "bluefin",
     name: "Bluefin",
-    badge: "Developer Workstation",
-    badgeClass: styles.badge,
-    desc: "Flagship cloud-native workstation with devcontainers, eBPF tooling, and dedicated developer ergonomics.",
+    badge: "Fedora bootc",
+    edition: "Flagship Workstation",
+    stream: ":stable (GNOME 50.1 / Linux 7.0)",
+    desc: "Flagship cloud-native developer workstation with devcontainers, eBPF tooling, and dedicated developer ergonomics.",
     color: "#58a6ff",
-  },
-  {
-    id: "aurora",
-    name: "Aurora",
-    badge: "KDE Plasma Desktop",
-    badgeClass: styles.badgeDesktop,
-    desc: "Cloud-native desktop featuring KDE Plasma, customized for speed and polished productivity.",
-    color: "#39d2c0",
+    link: "/downloads",
+    status: "active",
+    statusText: "Active Tracking",
   },
   {
     id: "bluefin-lts",
     name: "Bluefin LTS",
-    badge: "Enterprise Base",
-    badgeClass: styles.badgeEnterprise,
-    desc: "CentOS Stream 10-based release for long-term deployments (counted via EPEL; represents a floor).",
+    badge: "CentOS Stream 10 bootc",
+    edition: "Enterprise Workstation",
+    stream: ":lts (GNOME 47 / Linux 6.12 LTS)",
+    desc: "Long-term support release providing 10-year platform stability, certified enterprise kernel base, and rock-solid reliability.",
     color: "#bc8cff",
+    link: "/lts",
+    status: "active",
+    statusText: "Active Tracking",
   },
-] as const;
+  {
+    id: "dakota",
+    name: "Project Bluefin Dakota",
+    badge: "GNOME OS bootc",
+    edition: "Next-Gen BuildStream",
+    stream: ":stable & :testing (GNOME 50)",
+    desc: "Built from source with Apache BuildStream. Eschews traditional packaging for pure upstream GNOME delivering a direct feedback loop.",
+    color: "#39d2c0",
+    link: "/dakota",
+    status: "bootstrapping",
+    statusText: "Alpha · Telemetry Activating",
+  },
+  {
+    id: "utah",
+    name: "Project Bluefin Utah",
+    badge: "Hummingbird bootc",
+    edition: "Modular Hummingbird",
+    stream: ":testing (GNOME 51)",
+    desc: "Hardened minimal Fedora Hummingbird bootable base with Bluefin package contract and modular GNOME 51 desktop layer.",
+    color: "#f0883e",
+    link: "/utah",
+    status: "provisioning",
+    statusText: "Pre-alpha · Telemetry Provisioning",
+  },
+];
 
 export default function CountmeAnalyticsCharts(): React.JSX.Element {
   const data = countmeHistoryData as unknown as CountmeDataset;
   const weeks = data?.weeks || [];
 
-  const [legacyRange, setLegacyRange] = useState<LegacyRange>("all");
+  const [heroRange, setHeroRange] = useState<HeroRange>("all");
+  const [heroMode, setHeroMode] = useState<HeroMode>("unified");
   const [range, setRange] = useState<RangeOption>("12w");
   const [viewMode, setViewMode] = useState<ViewMode>("all-ecosystem");
 
   const latestWeek = weeks[weeks.length - 1] || ({} as CountmeWeek);
-  const currentBluefin = Number(latestWeek.bluefin) || 0;
+  const latestBluefin = Number(latestWeek.bluefin) || 0;
+  const latestBluefinLts = Number(latestWeek["bluefin-lts"]) || 0;
+  const latestDakota = Number(latestWeek.dakota) || 0;
+  const latestUtah = Number(latestWeek.utah) || 0;
+  const currentTotalBluefin =
+    latestBluefin + latestBluefinLts + latestDakota + latestUtah;
 
-  // Filtered weeks for Legacy Bluefins chart
-  const legacyFilteredWeeks = useMemo(() => {
-    if (legacyRange === "12w") return weeks.slice(-12);
-    if (legacyRange === "24w") return weeks.slice(-24);
+  // Filtered weeks for Hero Bluefin chart
+  const heroFilteredWeeks = useMemo(() => {
+    if (heroRange === "12w") return weeks.slice(-12);
+    if (heroRange === "24w") return weeks.slice(-24);
     return weeks;
-  }, [weeks, legacyRange]);
+  }, [weeks, heroRange]);
 
-  // First recorded bluefin count for delta computation
-  const initialBluefin = Number(weeks[0]?.bluefin) || currentBluefin;
+  // Delta calculation for Bluefin fleet
+  const firstWeek = weeks[0] || ({} as CountmeWeek);
+  const initialTotalBluefin =
+    (Number(firstWeek.bluefin) || 0) +
+      (Number(firstWeek["bluefin-lts"]) || 0) +
+      (Number(firstWeek.dakota) || 0) +
+      (Number(firstWeek.utah) || 0) || currentTotalBluefin;
+
   const bluefinDeltaPct =
-    initialBluefin > 0
-      ? (((currentBluefin - initialBluefin) / initialBluefin) * 100).toFixed(1)
+    initialTotalBluefin > 0
+      ? (
+          ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
+          100
+        ).toFixed(1)
       : "0.0";
 
   // Filtered weeks for comparative time-series charts
@@ -99,29 +147,31 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     return weeks;
   }, [weeks, range]);
 
-  // Ecosystem totals (excluding Fedora base)
-  const peerImages = ["bazzite", "bluefin", "aurora", "bluefin-lts"] as const;
+  // Ecosystem totals (Bazzite + Total Bluefin fleet + Aurora)
   const peerTotal = useMemo(() => {
-    return peerImages.reduce(
-      (sum, key) => sum + (Number(latestWeek[key]) || 0),
-      0,
-    );
-  }, [latestWeek]);
+    const bazzite = Number(latestWeek.bazzite) || 0;
+    const aurora = Number(latestWeek.aurora) || 0;
+    return bazzite + currentTotalBluefin + aurora;
+  }, [latestWeek, currentTotalBluefin]);
 
   // Real finite point counts for EChart to prevent bypassing accumulating data
-  const realLegacyPoints = useMemo(() => {
-    return legacyFilteredWeeks.filter(
-      (w) => typeof w.bluefin === "number" && !Number.isNaN(w.bluefin),
+  const realHeroPoints = useMemo(() => {
+    return heroFilteredWeeks.filter(
+      (w) =>
+        (typeof w.bluefin === "number" && !Number.isNaN(w.bluefin)) ||
+        (typeof w["bluefin-lts"] === "number" &&
+          !Number.isNaN(w["bluefin-lts"])),
     ).length;
-  }, [legacyFilteredWeeks]);
+  }, [heroFilteredWeeks]);
 
   const realComparativePoints = useMemo(() => {
-    return filteredWeeks.filter((w) =>
-      peerImages.some(
-        (key) => typeof w[key] === "number" && !Number.isNaN(w[key]),
-      ),
+    return filteredWeeks.filter(
+      (w) =>
+        (typeof w.bazzite === "number" && !Number.isNaN(w.bazzite)) ||
+        (typeof w.bluefin === "number" && !Number.isNaN(w.bluefin)) ||
+        (typeof w.aurora === "number" && !Number.isNaN(w.aurora)),
     ).length;
-  }, [filteredWeeks, peerImages]);
+  }, [filteredWeeks]);
 
   // Shared domain for workstation small multiples
   const workstationDomain = useMemo<[number, number]>(() => {
@@ -140,11 +190,64 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     return [Math.max(0, min), Math.max(100, max)];
   }, [weeks]);
 
-  // 1. "Legacy Bluefins" EChart option
-  const legacyChartOption = useMemo(() => {
-    const labels = legacyFilteredWeeks.map((w) => w.week);
-    const bluefinSeries = gapSafe(
-      legacyFilteredWeeks.map((w) => w.bluefin ?? null),
+  // 1. "Bluefin Systems (Total Fleet)" EChart option
+  const heroChartOption = useMemo(() => {
+    const labels = heroFilteredWeeks.map((w) => w.week);
+
+    if (heroMode === "split") {
+      const flagshipSeries = gapSafe(
+        heroFilteredWeeks.map((w) => w.bluefin ?? null),
+      );
+      const ltsSeries = gapSafe(
+        heroFilteredWeeks.map((w) => w["bluefin-lts"] ?? null),
+      );
+
+      return {
+        xAxis: {
+          type: "category",
+          data: labels,
+        },
+        yAxis: {
+          type: "value",
+          min: "dataMin",
+        },
+        series: [
+          {
+            name: "Bluefin Flagship",
+            type: "line",
+            data: flagshipSeries,
+            smooth: true,
+            showSymbol: true,
+            symbolSize: 6,
+            itemStyle: { color: "#58a6ff" },
+            lineStyle: { width: 3, color: "#58a6ff" },
+            connectNulls: false,
+          },
+          {
+            name: "Bluefin LTS",
+            type: "line",
+            data: ltsSeries,
+            smooth: true,
+            showSymbol: true,
+            symbolSize: 6,
+            itemStyle: { color: "#bc8cff" },
+            lineStyle: { width: 3, color: "#bc8cff", type: [6, 3] },
+            connectNulls: false,
+          },
+        ],
+      };
+    }
+
+    // Unified fleet total series
+    const totalSeries = gapSafe(
+      heroFilteredWeeks.map((w) => {
+        const bf = typeof w.bluefin === "number" ? w.bluefin : 0;
+        const lts = typeof w["bluefin-lts"] === "number" ? w["bluefin-lts"] : 0;
+        const dakota = typeof w.dakota === "number" ? w.dakota : 0;
+        const utah = typeof w.utah === "number" ? w.utah : 0;
+        const sum = bf + lts + dakota + utah;
+        return sum > 0 ? sum : null;
+      }),
     );
 
     return {
@@ -158,9 +261,9 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
       },
       series: [
         {
-          name: "Bluefin",
+          name: "Bluefin Family (All Systems)",
           type: "line",
-          data: bluefinSeries,
+          data: totalSeries,
           smooth: true,
           showSymbol: true,
           symbolSize: 6,
@@ -175,7 +278,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
               y2: 1,
               colorStops: [
                 { offset: 0, color: "rgba(88, 166, 255, 0.45)" },
-                { offset: 1, color: "rgba(88, 166, 255, 0.02)" },
+                { offset: 1, color: "rgba(57, 210, 192, 0.05)" },
               ],
             },
           },
@@ -183,7 +286,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         },
       ],
     };
-  }, [legacyFilteredWeeks]);
+  }, [heroFilteredWeeks, heroMode]);
 
   // 2. Comparative EChart configuration
   const comparativeChartOption = useMemo(() => {
@@ -212,32 +315,54 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
       });
     }
 
-    seriesList.push(
-      {
-        name: "Bluefin",
+    if (viewMode === "workstations") {
+      seriesList.push(
+        {
+          name: "Bluefin Flagship",
+          type: "line",
+          data: gapSafe(filteredWeeks.map((w) => w.bluefin ?? null)),
+          connectNulls: false,
+          itemStyle: { color: seriesColor(0) },
+          lineStyle: { type: seriesDash(0) },
+        },
+        {
+          name: "Bluefin LTS",
+          type: "line",
+          data: gapSafe(filteredWeeks.map((w) => w["bluefin-lts"] ?? null)),
+          connectNulls: false,
+          itemStyle: { color: seriesColor(1) },
+          lineStyle: { type: seriesDash(1) },
+        },
+      );
+    } else {
+      // Total Bluefin family
+      seriesList.push({
+        name: "Bluefin Family",
         type: "line",
-        data: gapSafe(filteredWeeks.map((w) => w.bluefin ?? null)),
+        data: gapSafe(
+          filteredWeeks.map((w) => {
+            const sum =
+              (Number(w.bluefin) || 0) +
+              (Number(w["bluefin-lts"]) || 0) +
+              (Number(w.dakota) || 0) +
+              (Number(w.utah) || 0);
+            return sum > 0 ? sum : null;
+          }),
+        ),
         connectNulls: false,
         itemStyle: { color: seriesColor(0) },
         lineStyle: { type: seriesDash(0) },
-      },
-      {
-        name: "Aurora",
-        type: "line",
-        data: gapSafe(filteredWeeks.map((w) => w.aurora ?? null)),
-        connectNulls: false,
-        itemStyle: { color: seriesColor(2) },
-        lineStyle: { type: seriesDash(2) },
-      },
-      {
-        name: "Bluefin LTS",
-        type: "line",
-        data: gapSafe(filteredWeeks.map((w) => w["bluefin-lts"] ?? null)),
-        connectNulls: false,
-        itemStyle: { color: seriesColor(1) },
-        lineStyle: { type: seriesDash(1) },
-      },
-    );
+      });
+    }
+
+    seriesList.push({
+      name: "Aurora (KDE)",
+      type: "line",
+      data: gapSafe(filteredWeeks.map((w) => w.aurora ?? null)),
+      connectNulls: false,
+      itemStyle: { color: seriesColor(2) },
+      lineStyle: { type: seriesDash(2) },
+    });
 
     return {
       xAxis: { type: "category", data: labels },
@@ -259,25 +384,47 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     );
   }
 
+  // Distribution calculations
+  const bazziteCount = Number(latestWeek.bazzite) || 0;
+  const auroraCount = Number(latestWeek.aurora) || 0;
+  const bazzitePct = peerTotal > 0 ? (bazziteCount / peerTotal) * 100 : 0;
+  const bluefinPct =
+    peerTotal > 0 ? (currentTotalBluefin / peerTotal) * 100 : 0;
+  const auroraPct = peerTotal > 0 ? (auroraCount / peerTotal) * 100 : 0;
+
   return (
     <div className={styles.container}>
-      {/* ── 1. Hero: Legacy Bluefins ────────────────────────────────────────── */}
+      {/* ── 1. Hero: Bluefin Systems (Total Fleet) ─────────────────────────── */}
       <div className={styles.heroCard}>
         <div className={styles.heroHeader}>
           <div className={styles.heroTitleGroup}>
             <Heading as="h3" className={styles.heroTitle}>
-              Legacy Bluefins
-              <span className={styles.heroBadge}>ublue-os historical</span>
+              Bluefin Systems
+              <span className={styles.heroBadge}>Source of Truth</span>
             </Heading>
             <p className={styles.heroSubtitle}>
-              Canonical weekly active systems curve ported from ublue-os/countme
-              methodology
+              Canonical weekly active systems across all Project Bluefin
+              workstation variants
             </p>
+            <div className={styles.heroSubBadges}>
+              <span
+                className={`${styles.heroSubBadge} ${styles.heroSubBadgeHighlight}`}
+              >
+                Flagship: {latestBluefin.toLocaleString()} (
+                {((latestBluefin / currentTotalBluefin) * 100).toFixed(1)}%)
+              </span>
+              <span className={styles.heroSubBadge}>
+                LTS: {latestBluefinLts.toLocaleString()} (
+                {((latestBluefinLts / currentTotalBluefin) * 100).toFixed(1)}%)
+              </span>
+              <span className={styles.heroSubBadge}>Dakota: Bootstrapping</span>
+              <span className={styles.heroSubBadge}>Utah: Provisioning</span>
+            </div>
           </div>
 
           <div className={styles.heroKPI}>
             <div className={styles.heroNumber}>
-              {currentBluefin.toLocaleString()}
+              {currentTotalBluefin.toLocaleString()}
             </div>
             <div className={styles.heroMeta}>
               <span style={{ fontWeight: 700, color: "#39d2c0" }}>
@@ -290,12 +437,29 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
 
         <div className={styles.chartControls}>
           <div className={styles.toggleGroup}>
-            {(["12w", "24w", "all"] as LegacyRange[]).map((r) => (
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${heroMode === "unified" ? styles.toggleBtnActive : ""}`}
+              onClick={() => setHeroMode("unified")}
+            >
+              Unified Fleet
+            </button>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${heroMode === "split" ? styles.toggleBtnActive : ""}`}
+              onClick={() => setHeroMode("split")}
+            >
+              By Edition
+            </button>
+          </div>
+
+          <div className={styles.toggleGroup}>
+            {(["12w", "24w", "all"] as HeroRange[]).map((r) => (
               <button
                 key={r}
                 type="button"
-                className={`${styles.toggleBtn} ${legacyRange === r ? styles.toggleBtnActive : ""}`}
-                onClick={() => setLegacyRange(r)}
+                className={`${styles.toggleBtn} ${heroRange === r ? styles.toggleBtnActive : ""}`}
+                onClick={() => setHeroRange(r)}
               >
                 {r === "12w"
                   ? "12 Weeks"
@@ -308,24 +472,131 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         </div>
 
         <EChart
-          option={legacyChartOption}
-          title="Legacy Bluefins"
-          summary={`Legacy Bluefins historical weekly active systems: currently ${currentBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
-          points={realLegacyPoints}
+          option={heroChartOption}
+          title="Bluefin Systems"
+          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
+          points={realHeroPoints}
           minPoints={2}
           height={320}
-          tableCaption="Legacy Bluefins weekly active systems history"
+          tableCaption="Project Bluefin weekly active systems history"
         />
 
         <div className={styles.chartNote}>
-          <strong>Lineage:</strong> This replaces the legacy matplotlib chart
-          with native interactive rendering while preserving exact numerical
-          parity with <code>ublue-os/countme:growth_bluefins.svg</code> and
-          project README badges.
+          <strong>Lineage:</strong> Single source of truth for Project Bluefin,
+          continuing the canonical baseline from <code>ublue-os/bluefin</code>.
         </div>
       </div>
 
-      {/* ── 2. Cloud-Native Ecosystem Overview ─────────────────────────────── */}
+      {/* ── 2. Project Bluefin Image Family ─────────────────────────────────── */}
+      <div className={styles.familySection}>
+        <div className={styles.sectionHeading}>
+          Project Bluefin Image Family
+        </div>
+        <div className={styles.sectionSubtext}>
+          Workstation operating system images built, maintained, and
+          instrumented by Project Bluefin
+        </div>
+
+        <div className={styles.familyGrid}>
+          {BLUEFIN_FAMILY_IMAGES.map((img) => {
+            const count =
+              img.id === "bluefin"
+                ? latestBluefin
+                : img.id === "bluefin-lts"
+                  ? latestBluefinLts
+                  : img.id === "dakota"
+                    ? latestDakota
+                    : latestUtah;
+
+            const isTracked = count > 0;
+            const history = isTracked
+              ? weeks.slice(-12).map((w) => (w[img.id] as number) ?? null)
+              : [];
+
+            return (
+              <div key={img.id} className={styles.familyCard}>
+                <div className={styles.familyCardHeader}>
+                  <div className={styles.familyCardTitleGroup}>
+                    <Heading as="h4" className={styles.familyName}>
+                      {img.name}
+                    </Heading>
+                    <span className={styles.familyEdition}>{img.edition}</span>
+                  </div>
+                  <span
+                    className={`${styles.statusPill} ${
+                      img.status === "active"
+                        ? styles.statusActive
+                        : styles.statusPending
+                    }`}
+                  >
+                    {img.statusText}
+                  </span>
+                </div>
+
+                <div className={styles.countRow}>
+                  <span className={styles.countValue}>
+                    {isTracked
+                      ? count.toLocaleString()
+                      : img.status === "bootstrapping"
+                        ? "Initial"
+                        : "Pending"}
+                  </span>
+                  {isTracked && currentTotalBluefin > 0 && (
+                    <span className={styles.sharePct}>
+                      {((count / currentTotalBluefin) * 100).toFixed(1)}% fleet
+                    </span>
+                  )}
+                </div>
+
+                <p className={styles.cardDesc}>{img.desc}</p>
+
+                <div className={styles.familyMetaRow}>
+                  <div className={styles.familyMetaItem}>
+                    <span className={styles.familyMetaLabel}>Base Stack</span>
+                    <span className={styles.familyMetaValue}>{img.badge}</span>
+                  </div>
+                  <div className={styles.familyMetaItem}>
+                    <span className={styles.familyMetaLabel}>Streams</span>
+                    <span className={styles.familyMetaValue}>{img.stream}</span>
+                  </div>
+                </div>
+
+                <div className={styles.cardSparkline}>
+                  <span className={styles.sparklineLabel}>
+                    {isTracked ? "12-week trend" : "Telemetry status"}
+                  </span>
+                  <Sparkline
+                    data={history}
+                    variant="line"
+                    domain={workstationDomain}
+                    width={220}
+                    height={32}
+                    color={img.color}
+                    areaColor="currentColor"
+                    areaOpacity={0.12}
+                    showEnd={isTracked}
+                    minPoints={2}
+                    emptyLabel={
+                      img.status === "bootstrapping"
+                        ? "accumulating telemetry"
+                        : "provisioning telemetry"
+                    }
+                    label={`${img.name} 12-week adoption trend: currently ${count.toLocaleString()}`}
+                  />
+                </div>
+
+                <div className={styles.familyFooter}>
+                  <Link to={img.link} className={styles.familyLink}>
+                    View {img.name} Details &rarr;
+                  </Link>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── 3. Cloud-Native Ecosystem Overview ─────────────────────────────── */}
       <div className={styles.shareSection}>
         <div className={styles.sectionHeading}>
           Cloud-Native Desktop Ecosystem
@@ -341,93 +612,56 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
           role="region"
           aria-label={`Desktop ecosystem distribution across ${peerTotal.toLocaleString()} systems`}
         >
-          {IMAGE_CONFIGS.map((cfg) => {
-            const count = Number(latestWeek[cfg.id]) || 0;
-            const pct = peerTotal > 0 ? (count / peerTotal) * 100 : 0;
-            return (
-              <div
-                key={cfg.id}
-                className={styles.segment}
-                style={{
-                  width: `${pct}%`,
-                  backgroundColor: cfg.color,
-                }}
-                title={`${cfg.name}: ${count.toLocaleString()} (${pct.toFixed(1)}%)`}
-              />
-            );
-          })}
+          <div
+            className={styles.segment}
+            style={{ width: `${bazzitePct}%`, backgroundColor: "#f0883e" }}
+            title={`Bazzite (Gaming): ${bazziteCount.toLocaleString()} (${bazzitePct.toFixed(1)}%)`}
+          />
+          <div
+            className={styles.segment}
+            style={{ width: `${bluefinPct}%`, backgroundColor: "#58a6ff" }}
+            title={`Bluefin Family: ${currentTotalBluefin.toLocaleString()} (${bluefinPct.toFixed(1)}%)`}
+          />
+          <div
+            className={styles.segment}
+            style={{ width: `${auroraPct}%`, backgroundColor: "#39d2c0" }}
+            title={`Aurora (KDE): ${auroraCount.toLocaleString()} (${auroraPct.toFixed(1)}%)`}
+          />
         </div>
 
         {/* Legend */}
         <div className={styles.shareLegend}>
-          {IMAGE_CONFIGS.map((cfg) => {
-            const count = Number(latestWeek[cfg.id]) || 0;
-            const pct =
-              peerTotal > 0 ? ((count / peerTotal) * 100).toFixed(1) : "0.0";
-            return (
-              <div key={cfg.id} className={styles.legendItem}>
-                <span
-                  className={styles.legendDot}
-                  style={{ backgroundColor: cfg.color }}
-                />
-                <span className={styles.legendLabel}>{cfg.name}:</span>
-                <span className={styles.legendValue}>
-                  {count.toLocaleString()} ({pct}%)
-                </span>
-              </div>
-            );
-          })}
+          <div className={styles.legendItem}>
+            <span
+              className={styles.legendDot}
+              style={{ backgroundColor: "#f0883e" }}
+            />
+            <span className={styles.legendLabel}>Bazzite (Gaming):</span>
+            <span className={styles.legendValue}>
+              {bazziteCount.toLocaleString()} ({bazzitePct.toFixed(1)}%)
+            </span>
+          </div>
+          <div className={styles.legendItem}>
+            <span
+              className={styles.legendDot}
+              style={{ backgroundColor: "#58a6ff" }}
+            />
+            <span className={styles.legendLabel}>Bluefin Family:</span>
+            <span className={styles.legendValue}>
+              {currentTotalBluefin.toLocaleString()} ({bluefinPct.toFixed(1)}%)
+            </span>
+          </div>
+          <div className={styles.legendItem}>
+            <span
+              className={styles.legendDot}
+              style={{ backgroundColor: "#39d2c0" }}
+            />
+            <span className={styles.legendLabel}>Aurora (KDE):</span>
+            <span className={styles.legendValue}>
+              {auroraCount.toLocaleString()} ({auroraPct.toFixed(1)}%)
+            </span>
+          </div>
         </div>
-      </div>
-
-      {/* ── 3. Image Breakdown Cards ────────────────────────────────────────── */}
-      <div className={styles.kpiGrid}>
-        {IMAGE_CONFIGS.map((cfg) => {
-          const count = Number(latestWeek[cfg.id]) || 0;
-          const pct =
-            peerTotal > 0 ? ((count / peerTotal) * 100).toFixed(1) : "0.0";
-          const history = weeks
-            .slice(-12)
-            .map((w) => (w[cfg.id] as number) ?? null);
-
-          // Shared domain for workstations, separate domain for high-scale gaming
-          const domain = cfg.id === "bazzite" ? undefined : workstationDomain;
-
-          return (
-            <div key={cfg.id} className={styles.kpiCard}>
-              <div className={styles.cardHeader}>
-                <span className={styles.imageTitle}>{cfg.name}</span>
-                <span className={`${styles.badge} ${cfg.badgeClass}`}>
-                  {cfg.badge}
-                </span>
-              </div>
-              <div className={styles.countRow}>
-                <span className={styles.countValue}>
-                  {count.toLocaleString()}
-                </span>
-                <span className={styles.sharePct}>{pct}%</span>
-              </div>
-              <p className={styles.cardDesc}>{cfg.desc}</p>
-              <div className={styles.cardSparkline}>
-                <span className={styles.sparklineLabel}>12-week trend</span>
-                <Sparkline
-                  data={history}
-                  variant="line"
-                  domain={domain}
-                  width={200}
-                  height={32}
-                  color={cfg.color}
-                  areaColor="currentColor"
-                  areaOpacity={0.12}
-                  showEnd={true}
-                  minPoints={2}
-                  emptyLabel="accumulating data"
-                  label={`${cfg.name} 12-week adoption trend: currently ${count.toLocaleString()}`}
-                />
-              </div>
-            </div>
-          );
-        })}
       </div>
 
       {/* ── 4. Interactive Comparative Trajectory ───────────────────────────── */}
@@ -446,7 +680,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
               className={`${styles.toggleBtn} ${viewMode === "workstations" ? styles.toggleBtnActive : ""}`}
               onClick={() => setViewMode("workstations")}
             >
-              Workstations (Bluefin & Aurora)
+              Workstations (Flagship, LTS & Aurora)
             </button>
             <button
               type="button"
@@ -478,7 +712,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         <EChart
           option={comparativeChartOption}
           title="Comparative Image Trajectories"
-          summary={`Comparative adoption trajectories across cloud-native images over ${filteredWeeks.length} weeks. Latest week (${latestWeek.week}): Bazzite ${Number(latestWeek.bazzite || 0).toLocaleString()} (Gaming), Bluefin ${Number(latestWeek.bluefin || 0).toLocaleString()} (Workstation), Aurora ${Number(latestWeek.aurora || 0).toLocaleString()} (KDE), Bluefin LTS ${Number(latestWeek["bluefin-lts"] || 0).toLocaleString()} (CentOS EPEL floor).`}
+          summary={`Comparative adoption trajectories across cloud-native images over ${filteredWeeks.length} weeks. Latest week (${latestWeek.week}): Bazzite ${Number(latestWeek.bazzite || 0).toLocaleString()} (Gaming), Bluefin Family ${currentTotalBluefin.toLocaleString()} (Workstations), Aurora ${Number(latestWeek.aurora || 0).toLocaleString()} (KDE).`}
           points={realComparativePoints}
           minPoints={2}
           height={320}
@@ -486,11 +720,10 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         />
 
         <div className={styles.chartNote}>
-          <strong>Methodology:</strong> Derived from Fedora Countme weekly
-          reporting using the canonical <code>ublue-countme-v1</code> counting
-          rules (one base repository per device, excluding legacy sys_age=-1
-          rows). Bluefin LTS is CentOS Stream based and counted via EPEL, which
-          acts as a lower-bound floor.
+          <strong>Methodology:</strong> Derived from weekly Countme telemetry
+          tracking with <code>ublue-countme-v1</code> baseline aggregation,
+          supplemented by first-party <code>countme.projectbluefin.io</code>{" "}
+          pings.
         </div>
       </div>
     </div>

--- a/workers/countme-proxy/index.mjs
+++ b/workers/countme-proxy/index.mjs
@@ -77,7 +77,9 @@ async function proxyRequest(request) {
   }
 
   if (isProjectBluefinPrimary(pathname)) {
-    return new Response(createPendingProjectbluefinSvg(), {
+    const variantMatch = pathname.match(/^\/([^/]+)\/growth\.svg/);
+    const variant = variantMatch ? variantMatch[1] : "bluefin";
+    return new Response(createPendingProjectbluefinSvg(variant), {
       status: 200,
       headers: baseHeaders({ "content-type": "image/svg+xml; charset=UTF-8" }),
     });

--- a/workers/countme-proxy/routes.mjs
+++ b/workers/countme-proxy/routes.mjs
@@ -11,10 +11,16 @@ export const ROUTES = {
   "/sources/projectbluefin/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
   "/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
   "/bluefin-lts/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/dakota/growth.svg": PROJECTBLUEFIN_CHART_URL,
+  "/utah/growth.svg": PROJECTBLUEFIN_CHART_URL,
   "/badge-endpoints/bluefin.json":
     "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
   "/badge-endpoints/bluefin-lts.json":
     "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
+  "/badge-endpoints/dakota.json":
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/dakota.json",
+  "/badge-endpoints/utah.json":
+    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/utah.json",
 };
 
 export function normalizePathname(pathname) {
@@ -26,13 +32,22 @@ export function mapRequestPath(pathname) {
   return ROUTES[normalizePathname(pathname)] || null;
 }
 
-export function createPendingProjectbluefinSvg() {
+export function createPendingProjectbluefinSvg(variant = "bluefin") {
+  const displayVariant =
+    variant === "dakota"
+      ? "Dakota"
+      : variant === "utah"
+        ? "Utah"
+        : variant === "bluefin-lts"
+          ? "Bluefin LTS"
+          : "Bluefin";
+
   return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="projectbluefin bluefin countme pending">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="projectbluefin ${variant} countme pending">
   <rect width="1280" height="720" fill="#0d1117"/>
   <rect x="30" y="30" width="1220" height="660" rx="12" fill="#161b22" stroke="#30363d" stroke-width="2"/>
-  <text x="70" y="140" fill="#c9d1d9" font-size="40" font-family="Inter, Segoe UI, Arial, sans-serif">projectbluefin/bluefin countme chart pending</text>
-  <text x="70" y="210" fill="#8b949e" font-size="28" font-family="Inter, Segoe UI, Arial, sans-serif">countme.projectbluefin.io configured, waiting for projectbluefin/countme artifacts</text>
+  <text x="70" y="140" fill="#c9d1d9" font-size="40" font-family="Inter, Segoe UI, Arial, sans-serif">projectbluefin/${variant} countme chart pending</text>
+  <text x="70" y="210" fill="#8b949e" font-size="28" font-family="Inter, Segoe UI, Arial, sans-serif">${displayVariant} countme.projectbluefin.io configured, waiting for projectbluefin/countme artifacts</text>
   <line x1="70" y1="560" x2="1210" y2="360" stroke="#58a6ff" stroke-width="4" stroke-dasharray="12 10" opacity="0.75"/>
   <text x="70" y="620" fill="#8b949e" font-size="24" font-family="Inter, Segoe UI, Arial, sans-serif">Legacy data available at /sources/ublue-os/bluefin/growth.svg</text>
 </svg>`;
@@ -46,6 +61,8 @@ export function isProjectBluefinPrimary(pathname) {
     "/sources/projectbluefin/bluefin/growth.svg",
     "/bluefin/growth.svg",
     "/bluefin-lts/growth.svg",
+    "/dakota/growth.svg",
+    "/utah/growth.svg",
   ].includes(normalized);
 }
 


### PR DESCRIPTION
## Summary

- **Single Source of Truth:** Replaces the legacy chart with a unified **Bluefin Systems** hero chart combining all Bluefin editions (Flagship 3,761 + LTS 159 = 3,920 active systems, +23.9% overall growth).
- **Hero Interactivity:** Supports toggling between **Unified Fleet** (single smooth area curve) and **By Edition** (Flagship vs LTS comparison), with 12w, 24w, and All History filters.
- **Project Bluefin Image Family:** Adds dedicated deep-dive catalog cards for all 4 Project Bluefin images:
  - **Bluefin** (Flagship Workstation - Fedora bootc, GNOME 50.1 / Linux 7.0)
  - **Bluefin LTS** (Enterprise Workstation - CentOS Stream 10 bootc, GNOME 47 / Linux 6.12 LTS)
  - **Project Bluefin Dakota** (Next-Gen Workstation - GNOME OS BuildStream bootc)
  - **Project Bluefin Utah** (Next-Gen Workstation - Fedora Hummingbird bootc + GNOME 51)
- **Ecosystem Comparison:** Preserves ecosystem distribution context (Bazzite gaming, Bluefin family workstations, Aurora KDE).
- **EPEL Caveats Removed:** Drops legacy EPEL disclaimers from `docs/analytics.mdx` in favor of Project Bluefin canonical metrics.
- **Worker Routes & Tests:** Adds `/badge-endpoints/{dakota,utah}.json` and `/{dakota,utah}/growth.svg` routes with 11 passing tests.

## Tracking Issues Filed

- projectbluefin/utah#49: Implement weekly countme client reporting
- projectbluefin/dakota#1524: Point countme reporting to countme.projectbluefin.io/metalink
- projectbluefin/bluefin-lts#591: Wire first-party countme reporting to countme.projectbluefin.io
- projectbluefin/bluefin#1216: Enable first-party countme reporting to countme.projectbluefin.io

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>