### PR TITLE
fix(images): point bluefin-lts to projectbluefin/bluefin-lts package and update catalog

### DIFF
--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -52,16 +52,6 @@ sudo install -d -m 0755 /etc/projectbluefin/countme && sudo touch /etc/projectbl
 
 (The legacy marker `/etc/dakota-countme/disabled` is also honored.)
 
-- **Cohort measurement:** Uses Fedora-style installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) calculated locally from an installation epoch timestamp.
-- **Privacy guarantees:** Transmits only image name, tag, flavor, architecture, and age bucket. No machine ID, IP address, username, or persistent identifier is sent or logged.
-- **How to opt out:** Create the disable marker file:
-
-```bash
-sudo install -d -m 0755 /etc/projectbluefin/countme && sudo touch /etc/projectbluefin/countme/disabled
-```
-
-(The legacy marker `/etc/dakota-countme/disabled` is also honored.)
-
 ## Homebrew
 
 Homebrew analytics are on by default. To turn them off:

--- a/docs/lts.mdx
+++ b/docs/lts.mdx
@@ -10,7 +10,7 @@ _Achillobator giganticus_
 
 ![achillosmall](/img/user-attachments/b6945e80-34e4-44bb-8518-91ad31fed56d.png)
 
-Larger, more lethal [Bluefin](https://projectbluefin.io). `bluefin:lts` is built on CentOS Stream 10.
+Larger, more lethal [Bluefin](https://projectbluefin.io). `bluefin-lts` is built on CentOS Stream 10.
 
 ## Purpose
 
@@ -64,9 +64,9 @@ Do NOT rebase to this image from an existing Bluefin, Aurora, Bazzite, or Fedora
 
 The following images and tags are available:
 
-- `bluefin:lts` - base LTS experience, kernel 6.12.0 with long term maintenance from CentOS with backported GNOME releases.
-- `bluefin-gdx:lts` - includes Nvidia drivers and associated CUDA tooling. This is the only image with Nvidia drivers. See [Bluefin GDX](/gdx)
-- `bluefin:lts-hwe` - Fresher but gated Linux kernels matching other Bluefins, including btrfs support.
+- `bluefin-lts:stable` - base LTS experience on CentOS Stream 10, kernel 6.12.0 with long term maintenance from CentOS with backported GNOME releases.
+- `bluefin-lts-nvidia:stable` - includes Nvidia drivers and associated CUDA tooling.
+- `bluefin-lts:lts-hwe` - Fresher but gated Linux kernels matching other Bluefins, including btrfs support.
 
 ### Using the HWE branch
 
@@ -106,7 +106,7 @@ To build locally and then spit out a VM:
 git clone https://github.com/projectbluefin/bluefin-lts
 cd bluefin-lts
 just build
-just build-qcow2 ghcr.io/projectbluefin/bluefin:lts # if you want to build an ISO just change qcow2 to iso instead
+just build-qcow2 ghcr.io/projectbluefin/bluefin-lts:stable # if you want to build an ISO just change qcow2 to iso instead
 ```
 
 The [qcow2](https://qemu-project.gitlab.io/qemu/system/images.html) file will be written to the `output/` directory. Default username and password are `centos`/`centos`

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -30,7 +30,7 @@ cosign verify ghcr.io/projectbluefin/bluefin:stable \
 
 ```bash
 curl -O https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub
-cosign verify ghcr.io/projectbluefin/bluefin:lts --key cosign.pub
+cosign verify ghcr.io/projectbluefin/bluefin-lts:stable --key cosign.pub
 ```
 
 ### Verify Dakota

--- a/scripts/catalog-components.test.js
+++ b/scripts/catalog-components.test.js
@@ -82,7 +82,7 @@ const ltsCatalog = {
       name: "Bluefin LTS",
       subtitle: "Long-term support stream from projectbluefin/bluefin-lts.",
       command:
-        "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts --enforce-container-sigpolicy",
+        "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
       source: "sbom",
       rowCount: 1,
       latest: {

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -467,7 +467,7 @@ async function main() {
     "bluefin-lts",
     "Bluefin LTS",
     "Long-term support stream from projectbluefin/bluefin-lts.",
-    "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts --enforce-container-sigpolicy",
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
     sbomCache,
     ltsNvidiaByTag,
     LTS_HISTORY_DAYS,

--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -60,10 +60,10 @@ const PRODUCT_SPECS = [
     id: "projectbluefin-bluefin-lts",
     name: "Bluefin LTS",
     org: "projectbluefin",
-    package: "bluefin",
+    package: "bluefin-lts",
     artwork: "achillobator",
     summary: "Long-term support Bluefin stream.",
-    streamOrder: ["lts"],
+    streamOrder: ["stable", "testing"],
     versionSource: SBOM_VERSION_SOURCE,
     releaseSource: { feed: "lts", stream: "lts" },
     sbomStreamId: "bluefin-lts",
@@ -200,6 +200,9 @@ function normalizeSbomStreamTag(streamTag) {
 function buildSbomStreamId(spec, streamTag) {
   const normalizedTag = normalizeSbomStreamTag(streamTag);
   if (!spec?.sbomStreamId || !normalizedTag) return null;
+  if (spec.id === "projectbluefin-bluefin-lts" && normalizedTag === "stable") {
+    return spec.sbomStreamId;
+  }
   return spec.sbomStreamId.replace(
     /-(stable|latest|lts|beta)$/,
     `-${normalizedTag}`,

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -42,6 +42,8 @@ interface ProjectBluefinImageSpec {
   badge: string;
   edition: string;
   stream: string;
+  repo: string;
+  imageRef: string;
   desc: string;
   color: string;
   link: string;
@@ -56,6 +58,8 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     badge: "Fedora bootc",
     edition: "Flagship Workstation",
     stream: ":stable (GNOME 50.1 / Linux 7.0)",
+    repo: "projectbluefin/bluefin",
+    imageRef: "ghcr.io/projectbluefin/bluefin:stable",
     desc: "Flagship cloud-native developer workstation with devcontainers, eBPF tooling, and dedicated developer ergonomics.",
     color: "#58a6ff",
     link: "/downloads",
@@ -67,7 +71,9 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Bluefin LTS",
     badge: "CentOS Stream 10 bootc",
     edition: "Enterprise Workstation",
-    stream: ":lts (GNOME 47 / Linux 6.12 LTS)",
+    stream: ":stable (CentOS Stream 10 / Linux 6.12 LTS)",
+    repo: "projectbluefin/bluefin-lts",
+    imageRef: "ghcr.io/projectbluefin/bluefin-lts:stable",
     desc: "Long-term support release providing 10-year platform stability, certified enterprise kernel base, and rock-solid reliability.",
     color: "#bc8cff",
     link: "/lts",
@@ -80,11 +86,13 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     badge: "GNOME OS bootc",
     edition: "Next-Gen BuildStream",
     stream: ":stable & :testing (GNOME 50)",
+    repo: "projectbluefin/dakota",
+    imageRef: "ghcr.io/projectbluefin/dakota:stable",
     desc: "Built from source with Apache BuildStream. Eschews traditional packaging for pure upstream GNOME delivering a direct feedback loop.",
     color: "#39d2c0",
     link: "/dakota",
     status: "bootstrapping",
-    statusText: "Alpha · Telemetry Activating",
+    statusText: "Alpha · Countme Activating",
   },
   {
     id: "utah",
@@ -92,11 +100,13 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     badge: "Hummingbird bootc",
     edition: "Modular Hummingbird",
     stream: ":testing (GNOME 51)",
+    repo: "projectbluefin/utah",
+    imageRef: "ghcr.io/projectbluefin/utah:testing",
     desc: "Hardened minimal Fedora Hummingbird bootable base with Bluefin package contract and modular GNOME 51 desktop layer.",
     color: "#f0883e",
     link: "/utah",
     status: "provisioning",
-    statusText: "Pre-alpha · Telemetry Provisioning",
+    statusText: "Pre-alpha · Countme Provisioning",
   },
 ];
 
@@ -410,11 +420,13 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
               <span
                 className={`${styles.heroSubBadge} ${styles.heroSubBadgeHighlight}`}
               >
-                Flagship: {latestBluefin.toLocaleString()} (
+                Flagship (projectbluefin/bluefin):{" "}
+                {latestBluefin.toLocaleString()} (
                 {((latestBluefin / currentTotalBluefin) * 100).toFixed(1)}%)
               </span>
               <span className={styles.heroSubBadge}>
-                LTS: {latestBluefinLts.toLocaleString()} (
+                LTS (projectbluefin/bluefin-lts):{" "}
+                {latestBluefinLts.toLocaleString()} (
                 {((latestBluefinLts / currentTotalBluefin) * 100).toFixed(1)}%)
               </span>
               <span className={styles.heroSubBadge}>Dakota: Bootstrapping</span>
@@ -483,7 +495,8 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
 
         <div className={styles.chartNote}>
           <strong>Lineage:</strong> Single source of truth for Project Bluefin,
-          continuing the canonical baseline from <code>ublue-os/bluefin</code>.
+          unifying flagship (<code>projectbluefin/bluefin</code>) and enterprise
+          LTS (<code>projectbluefin/bluefin-lts</code>) into one fleet view.
         </div>
       </div>
 
@@ -556,6 +569,18 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
                     <span className={styles.familyMetaValue}>{img.badge}</span>
                   </div>
                   <div className={styles.familyMetaItem}>
+                    <span className={styles.familyMetaLabel}>Repository</span>
+                    <span className={styles.familyMetaValue}>
+                      <code>{img.repo}</code>
+                    </span>
+                  </div>
+                  <div className={styles.familyMetaItem}>
+                    <span className={styles.familyMetaLabel}>Image</span>
+                    <span className={styles.familyMetaValue}>
+                      <code>{img.imageRef}</code>
+                    </span>
+                  </div>
+                  <div className={styles.familyMetaItem}>
                     <span className={styles.familyMetaLabel}>Streams</span>
                     <span className={styles.familyMetaValue}>{img.stream}</span>
                   </div>
@@ -563,7 +588,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
 
                 <div className={styles.cardSparkline}>
                   <span className={styles.sparklineLabel}>
-                    {isTracked ? "12-week trend" : "Telemetry status"}
+                    {isTracked ? "12-week trend" : "Countme status"}
                   </span>
                   <Sparkline
                     data={history}
@@ -578,8 +603,8 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
                     minPoints={2}
                     emptyLabel={
                       img.status === "bootstrapping"
-                        ? "accumulating telemetry"
-                        : "provisioning telemetry"
+                        ? "accumulating countme data"
+                        : "provisioning countme"
                     }
                     label={`${img.name} 12-week adoption trend: currently ${count.toLocaleString()}`}
                   />

--- a/static/data/driver-versions.json
+++ b/static/data/driver-versions.json
@@ -45,7 +45,7 @@
       "id": "bluefin-lts",
       "name": "Bluefin LTS",
       "subtitle": "Long-term support stream from projectbluefin/bluefin-lts.",
-      "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts --enforce-container-sigpolicy",
+      "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
       "source": "sbom",
       "rowCount": 3,
       "latest": {

--- a/static/data/images.json
+++ b/static/data/images.json
@@ -93,12 +93,12 @@
       "id": "projectbluefin-bluefin-lts",
       "name": "Bluefin LTS",
       "org": "projectbluefin",
-      "package": "bluefin",
+      "package": "bluefin-lts",
       "versionSource": "sbom",
       "summary": "Long-term support Bluefin stream.",
       "artwork": "achillobator",
-      "imageRef": "ghcr.io/projectbluefin/bluefin",
-      "packagePageUrl": "https://github.com/orgs/projectbluefin/packages/container/package/bluefin",
+      "imageRef": "ghcr.io/projectbluefin/bluefin-lts",
+      "packagePageUrl": "https://github.com/orgs/projectbluefin/packages/container/package/bluefin-lts",
       "isoSectionLink": "/downloads",
       "supportedArches": [
         "amd",
@@ -106,9 +106,9 @@
       ],
       "streams": [
         {
-          "label": "LTS",
-          "tag": "lts",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts --enforce-container-sigpolicy",
+          "label": "STABLE",
+          "tag": "stable",
+          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
           "versions": {
             "gnome": "49.5",
             "kernel": "6.12.0-233.el10",
@@ -118,71 +118,25 @@
             "mesa": "25.2.7",
             "podman": "5.8.2"
           },
-          "nvidiaCommand": null
+          "nvidiaCommand": "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts-nvidia:stable --enforce-container-sigpolicy"
+        },
+        {
+          "label": "TESTING",
+          "tag": "testing",
+          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:testing --enforce-container-sigpolicy",
+          "versions": {
+            "gnome": "49.5",
+            "kernel": "6.12.0-233.el10",
+            "nvidia": null,
+            "fedora": null,
+            "flatpak": "1.16.0",
+            "mesa": "25.2.7",
+            "podman": "5.8.2"
+          },
+          "nvidiaCommand": "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts-nvidia:testing --enforce-container-sigpolicy"
         }
       ],
-      "testingStreams": [
-        {
-          "label": "lts-hwe-testing",
-          "tag": "lts-hwe-testing",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts-hwe-testing --enforce-container-sigpolicy",
-          "versions": {
-            "gnome": "49.5",
-            "kernel": "7.0.8-100.fc43",
-            "nvidia": null,
-            "fedora": null,
-            "flatpak": "1.16.0",
-            "mesa": "25.2.7",
-            "podman": "5.8.2"
-          },
-          "nvidiaCommand": null
-        },
-        {
-          "label": "lts-hwe-testing-50",
-          "tag": "lts-hwe-testing-50",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts-hwe-testing-50 --enforce-container-sigpolicy",
-          "versions": {
-            "gnome": "49.5",
-            "kernel": "7.0.8-100.fc43",
-            "nvidia": null,
-            "fedora": null,
-            "flatpak": "1.16.0",
-            "mesa": "25.2.7",
-            "podman": "5.8.2"
-          },
-          "nvidiaCommand": null
-        },
-        {
-          "label": "lts-testing",
-          "tag": "lts-testing",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts-testing --enforce-container-sigpolicy",
-          "versions": {
-            "gnome": "49.5",
-            "kernel": "6.12.0-233.el10",
-            "nvidia": null,
-            "fedora": null,
-            "flatpak": "1.16.0",
-            "mesa": "25.2.7",
-            "podman": "5.8.2"
-          },
-          "nvidiaCommand": null
-        },
-        {
-          "label": "lts-testing-50",
-          "tag": "lts-testing-50",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/bluefin:lts-testing-50 --enforce-container-sigpolicy",
-          "versions": {
-            "gnome": "49.5",
-            "kernel": "6.12.0-233.el10",
-            "nvidia": null,
-            "fedora": null,
-            "flatpak": "1.16.0",
-            "mesa": "25.2.7",
-            "podman": "5.8.2"
-          },
-          "nvidiaCommand": null
-        }
-      ],
+      "testingStreams": [],
       "metadata": {
         "digest": "sha256:41a15d1bc6926775874396ed21c920807be7b632d685529f3d3954a4326b9722",
         "digestShort": "41a15d1bc692",
@@ -210,12 +164,12 @@
       },
       "security": {
         "cosignKeyUrl": "https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub",
-        "verifyCommand": "cosign verify --key https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub ghcr.io/projectbluefin/bluefin:lts",
-        "attestCommand": "cosign verify-attestation --type https://slsa.dev/provenance/v1 --key https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub ghcr.io/projectbluefin/bluefin:lts",
+        "verifyCommand": "cosign verify --key https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub ghcr.io/projectbluefin/bluefin-lts:stable",
+        "attestCommand": "cosign verify-attestation --type https://slsa.dev/provenance/v1 --key https://raw.githubusercontent.com/projectbluefin/bluefin-lts/main/cosign.pub ghcr.io/projectbluefin/bluefin-lts:stable",
         "hasAttestation": false,
-        "sbomCommand": "oras discover ghcr.io/projectbluefin/bluefin:lts"
+        "sbomCommand": "oras discover ghcr.io/projectbluefin/bluefin-lts:stable"
       },
-      "inspectTag": "lts",
+      "inspectTag": "stable",
       "lastPublishedAt": "2026-06-24T08:25:24.169Z",
       "stale": true,
       "keepEvenIfStale": true


### PR DESCRIPTION
## Summary
- Re-aligns `projectbluefin-bluefin-lts` to package `bluefin-lts` and primary stream `:stable` (`ghcr.io/projectbluefin/bluefin-lts:stable`) rather than `bluefin:lts`
- Updates `driver-versions.json`, `images.json`, `docs/supply-chain.md`, and `docs/lts.mdx` verification/bootc switch commands
- Expands Project Bluefin family cards on `/analytics` to explicitly show `Repository` and `Image` identifiers (`projectbluefin/bluefin` and `projectbluefin/bluefin-lts`)
- Fixes remaining references from telemetry to countme
- Eliminates duplicate countme reporting paragraph in `docs/analytics.mdx`