### PR TITLE
feat(analytics): modernize analytics charts and streamline page layout

### DIFF
--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -6,125 +6,68 @@ slug: /analytics
 import CountmeAnalyticsCharts from "@site/src/components/analytics/CountmeAnalyticsCharts";
 import ImageChurnCharts from "@site/src/components/analytics/ImageChurnCharts";
 
-[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=ublue-os-bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin)
-
-Bluefin is a high-performance predator. The team believes in instrumentation and countme as a means to improve software — but that information must be privacy-respecting via an open process so we can verify what is being shared.
-
-> Data, for me, is the foundation of F1. There's no human judgment involved. You've got to get your foundation right in data.
->
-> — [James Vowles](https://www.youtube.com/watch?v=nYzwvTSffiY&t=1025s)
-
-## Countme Statistics
+Adoption metrics and active system telemetry across the Project Bluefin workstation family.
 
 <CountmeAnalyticsCharts />
 
-The Fedora countme service is on by default in Fedora, and Bluefin inherits that behavior:
+## Update Churn & Compression Analytics
 
-- [countme](https://github.com/wgwoods/fedora-countme-data)
-- [How to turn it off](https://coreos.github.io/rpm-ostree/countme/)
+Project Bluefin measures download byte delta, layer reuse efficiency, and compression statistics between consecutive stable releases.
+Cloud-native bootc updates take advantage of OCI layer caching: layers whose SHA-256 digests
+remain unchanged between releases require zero download bandwidth.
 
-### Single Source of Truth
+Using [Chunkah](https://github.com/coreos/chunkah) and the `zstd-chunked` container layer format,
+operating system updates are segmented into fine-grained package intervals so clients download only specific chunks containing changed packages.
+
+<ImageChurnCharts />
+
+<details>
+<summary><strong>Methodology, Privacy & Opt-Out</strong></summary>
+
+### Counting Methodology
 
 The charts above serve as the single source of truth for the entire Project Bluefin
-workstation family, preserving direct historical continuity with the canonical
-baseline from `ublue-os/bluefin`.
+workstation family, preserving direct continuity with the canonical baseline from
+[`ublue-os/countme`](https://github.com/ublue-os/countme).
 
-Active systems across all Project Bluefin images are combined into the unified
-Bluefin fleet view:
+- **Method:** Evaluated according to ADR 0004 (`ublue-countme-v1` baseline) using base repository queries.
+- **Enterprise LTS:** Bluefin LTS runs on CentOS Stream 10 and reaches Fedora counters through EPEL mirrors, which undercounts relative to standard Fedora repos.
+- **Next-Gen Variants:** Dakota (BuildStream) and Utah (Hummingbird) are activating first-party reporting via `projectbluefin/common`.
 
-- **Bluefin (Flagship Workstation):** Standard Fedora bootc cloud-native developer workstation.
-- **Bluefin LTS (Enterprise Workstation):** CentOS Stream 10 bootc long-term support release with 10-year platform stability.
-- **Project Bluefin Dakota (Next-Gen Workstation):** Assembled from source with Apache BuildStream on GNOME OS bootc.
-- **Project Bluefin Utah (Next-Gen Workstation):** Modular workstation on minimal Fedora Hummingbird bootc with GNOME 51 desktop layer.
+### First-party Countme Service & Privacy Guarantees
 
-### First-party Countme Service
-
-Project Bluefin images (`bluefin`, `bluefin-lts`, `dakota`, and `utah`) participate
-in direct weekly countme reporting via `projectbluefin/common` systemd services targeting
+Project Bluefin images participate in direct weekly countme reporting via systemd services targeting
 `https://countme.projectbluefin.io/metalink`.
 
 - **Cohort measurement:** Uses installation age buckets (1: first week, 2: 2–4 weeks, 3: 5–24 weeks, 4: >24 weeks) calculated locally from an installation epoch timestamp.
 - **Privacy guarantees:** Transmits only image name, tag, flavor, architecture, and age bucket. No machine ID, IP address, username, or persistent identifier is sent or logged.
-- **How to opt out:** Create the disable marker file:
+
+### Opt-Out Instructions
+
+To disable Project Bluefin countme reporting, create the disable marker file:
 
 ```bash
 sudo install -d -m 0755 /etc/projectbluefin/countme && sudo touch /etc/projectbluefin/countme/disabled
 ```
 
-(The legacy marker `/etc/dakota-countme/disabled` is also honored.)
+_(The legacy marker `/etc/dakota-countme/disabled` is also honored.)_
 
-## Update Churn & Compression Analytics
+To disable upstream Fedora countme:
 
-Project Bluefin measures the download byte delta, layer reuse efficiency, and compression statistics between consecutive stable releases.
-Cloud-native bootc updates take advantage of OCI layer caching: layers whose SHA-256 digests
-remain unchanged between releases are already present on the client system and require zero download bandwidth.
+- [Fedora countme documentation](https://coreos.github.io/rpm-ostree/countme/)
 
-Using [Chunkah](https://github.com/coreos/chunkah) and the `zstd-chunked` container layer format,
-operating system updates are segmented into fine-grained package intervals. Rather than downloading a multi-gigabyte
-monolithic system image on every update, clients download only the specific chunks containing changed packages.
+To disable Homebrew analytics:
 
-<ImageChurnCharts />
-
-## Homebrew
-
-Homebrew analytics are on by default. To turn them off:
-
-```
+```bash
 brew analytics off
 ```
 
-See the [Homebrew documentation](https://docs.brew.sh/Analytics) for more information. You can also check the [operating system rankings](https://formulae.brew.sh/analytics/os-version/30d/).
+See the [Homebrew analytics documentation](https://docs.brew.sh/Analytics) for additional details.
 
-## Contributor Metrics
+</details>
 
-The charts below are sourced from [Linux Foundation Insights](https://insights.linuxfoundation.org/project/ublue-os-bluefin) and track the `projectbluefin/bluefin` repository. For org-wide metrics across all 15 factory repos, see the [Factory metrics view](/factory/metrics).
+### Contributor Metrics
 
-<div
-  className="lfx-chart"
-  style={{ overflow: "hidden", borderRadius: "8px", height: "488px" }}
->
-  <iframe
-    src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=active-contributors"
-    style={{
-      transform: "scale(0.75)",
-      transformOrigin: "top left",
-      width: "133%",
-      height: "800px",
-      border: "none",
-    }}
-  />
-</div>
+For real-time development and organizational velocity metrics across all 15 factory repositories, see the [Factory metrics view](/factory/metrics).
 
-<div
-  className="lfx-chart"
-  style={{ overflow: "hidden", borderRadius: "8px", height: "503px" }}
->
-  <iframe
-    src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=commit-activities"
-    style={{
-      transform: "scale(0.75)",
-      transformOrigin: "top left",
-      width: "133%",
-      height: "820px",
-      border: "none",
-    }}
-  />
-</div>
-
-<div
-  className="lfx-chart"
-  style={{ overflow: "hidden", borderRadius: "8px", height: "645px" }}
->
-  <iframe
-    src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=pull-requests"
-    style={{
-      transform: "scale(0.75)",
-      transformOrigin: "top left",
-      width: "133%",
-      height: "1010px",
-      border: "none",
-    }}
-  />
-</div>
-
-For the full picture across all factory repositories, visit the [Factory metrics view](/factory/metrics).
+Upstream repository metrics for `projectbluefin/bluefin` are also tracked on [Linux Foundation Insights](https://insights.linuxfoundation.org/project/ublue-os-bluefin).

--- a/docs/skills/factory-dashboard-content.md
+++ b/docs/skills/factory-dashboard-content.md
@@ -1,35 +1,35 @@
 ---
 name: factory-dashboard-content
-version: "1.1"
-last_updated: "2026-09-06"
+version: "1.2"
+last_updated: "2026-09-08"
 id: factory-dashboard-content
-one_line_purpose: Write and verify copy, data, and charts on /factory.
+one_line_purpose: Write and verify copy, data, and charts on /factory and /analytics.
 entry_point: docs/skills/factory-dashboard-content.md
 category: meta
 status: active
-tags: [factory, dashboard, echarts, theming]
+tags: [factory, dashboard, echarts, theming, analytics]
 description: >-
-  Write and verify copy, data, and charts on the /factory dashboard. Use when
-  editing a factory panel title or summary, adding a lane or image to the
-  dashboard, touching countme adoption numbers, or styling an ECharts chart in
-  src/components/factory/.
+  Write and verify copy, data, and charts on the /factory dashboard and /analytics page.
+  Use when editing panel titles or summaries, adding an image lane, touching countme
+  adoption numbers, or styling ECharts components and KPI strips.
 metadata:
   type: procedure
 ---
 
-# Factory dashboard content
+# Factory and Analytics Dashboard Content
 
-The `/factory` dashboard (`src/components/HiveFactoryDashboard.tsx` and the panels
-under `src/components/factory/panels/`) reports on Bluefin with live data. Chart
-titles, summaries and captions are public-facing copy, so they follow the same
-rules as any other page — plus a few that are specific to this data.
+The `/factory` dashboard and `/analytics` page report on Bluefin with live data.
+Chart titles, summaries, captions, and KPI metrics are public-facing copy, so
+they follow the same rules as any other page — plus a few that are specific to
+this data.
 
 ## When to Use
 
 - Editing a panel title, summary, caption, or `Unavailable` reason.
+- Updating `/analytics` charts, KPI strips, or workstation family cards.
 - Adding or removing an image lane on the dashboard.
 - Changing countme adoption numbers or their labels.
-- Styling an ECharts chart under `src/components/factory/`.
+- Styling an ECharts chart under `src/components/factory/` or `src/components/analytics/`.
 
 ## When NOT to Use
 
@@ -140,6 +140,16 @@ Rules:
 
 **Check both themes before claiming a visual fix.** A dashboard that is only
 ever opened in dark mode hides half its contrast bugs.
+
+### Analytics page (`/analytics`) design conventions
+
+The `/analytics` page uses modern, Astro-inspired visual density:
+
+- **Top KPI strip:** 4 primary metrics (Fleet Total, 12-week Delta, Ecosystem Share, Coverage) using tabular numerals, uppercase tracked eyebrows (`0.08em`), and compact trend pills (`↑`/`↓`).
+- **Dominant chart panels:** Feature clean uppercase eyebrows (`WEEKLY ACTIVE SYSTEMS`), prominent headlines, and compact segmented pill buttons (`Unified Fleet` / `By Edition`, `12w` / `24w` / `All`).
+- **Family cards:** Minimalist cards focused strictly on KPI, edition eyebrow, status pill, shared-domain sparkline, and a direct link. Avoid paragraph narratives or Base Stack / Repo / Image / Streams key-value lists directly in card surfaces.
+- **Unified comparison:** Fold ecosystem share distributions directly into comparative chart headers/legends rather than rendering duplicate standalone distribution bars.
+- **Clean disclosure:** Move technical counting methodology (ADR 0004), first-party service details, and opt-out commands into a collapsed `<details>` disclosure to keep the primary view scannable.
 
 ### Tests pin the copy
 

--- a/src/components/analytics/CountmeAnalyticsCharts.module.css
+++ b/src/components/analytics/CountmeAnalyticsCharts.module.css
@@ -2,31 +2,99 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  margin: 1.5rem 0 2.5rem;
+  margin: 1.5rem 0 3rem;
+  font-family: inherit;
 }
 
-/* Legacy Bluefins Hero Chart */
-.heroCard {
-  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.75));
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-  border-radius: 12px;
+/* ── Top KPI Summary Strip ──────────────────────────────────────────────── */
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1rem;
+}
+
+.kpiCard {
+  background: var(--ifm-card-background-color, rgba(15, 23, 42, 0.5));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.08));
+  border-radius: 16px;
+  padding: 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 120px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.kpiCard:hover {
+  border-color: var(--ifm-color-primary, #38bdf8);
+  transform: translateY(-2px);
+}
+
+.kpiEyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-600, #94a3b8);
+}
+
+.kpiValueRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.kpiValue {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--ifm-heading-color, #f8fafc);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  margin: 0.35rem 0;
+}
+
+.trendBadge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.trendUp {
+  background: rgba(57, 210, 192, 0.15);
+  color: #39d2c0;
+}
+
+.trendDown {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+}
+
+.kpiMeta {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500, #64748b);
+  line-height: 1.3;
+}
+
+/* ── Panel Cards (Charts) ────────────────────────────────────────────────── */
+.panelCard {
+  background: var(--ifm-card-background-color, rgba(15, 23, 42, 0.45));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.07));
+  border-radius: 18px;
   padding: 1.5rem;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
-  position: relative;
-  overflow: hidden;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
 }
 
-.heroCard::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, #58a6ff, #39d2c0);
-}
-
-.heroHeader {
+.panelHeader {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -35,439 +103,249 @@
   margin-bottom: 1.25rem;
 }
 
-.heroTitleGroup {
+.titleGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
 }
 
-.heroTitle {
-  font-size: 1.4rem;
+.eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-600, #94a3b8);
+}
+
+.panelTitle {
+  font-size: 1.25rem;
   font-weight: 800;
-  color: var(--ifm-heading-color, #e6edf3);
+  color: var(--ifm-heading-color, #f8fafc);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.controlsRow {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.6rem;
-  margin: 0;
 }
 
-.heroSubtitle {
-  font-size: 0.85rem;
-  color: var(--ifm-color-emphasis-600, #8b949e);
-  margin: 0;
-}
-
-.heroKPI {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.heroNumber {
-  font-size: 2.25rem;
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  color: #58a6ff;
-  line-height: 1;
-}
-
-.heroMeta {
-  display: flex;
-  flex-direction: column;
-  font-size: 0.75rem;
-  color: var(--ifm-color-emphasis-600, #8b949e);
-}
-
-.heroBadge {
+.segmentedGroup {
   display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  background: rgba(88, 166, 255, 0.15);
-  color: #58a6ff;
-}
-
-.heroSubBadges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.heroSubBadge {
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 0.15rem 0.5rem;
-  border-radius: 4px;
-  background: rgba(48, 54, 61, 0.5);
-  color: var(--ifm-color-emphasis-700, #c9d1d9);
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-}
-
-.heroSubBadgeHighlight {
-  color: #58a6ff;
-  border-color: rgba(88, 166, 255, 0.4);
-}
-
-.kpiGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.kpiCard {
-  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-  border-radius: 10px;
-  padding: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  transition:
-    transform 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.kpiCard:hover {
-  border-color: var(--ifm-color-primary);
-  transform: translateY(-2px);
-}
-
-.cardHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.imageTitle {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--ifm-heading-color, #e6edf3);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.badge {
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  background: rgba(88, 166, 255, 0.15);
-  color: var(--ifm-color-primary, #58a6ff);
-}
-
-.badgeGaming {
-  background: rgba(240, 136, 62, 0.15);
-  color: #f0883e;
-}
-
-.badgeEnterprise {
-  background: rgba(188, 140, 255, 0.15);
-  color: #bc8cff;
-}
-
-.badgeDesktop {
-  background: rgba(57, 210, 192, 0.15);
-  color: #39d2c0;
-}
-
-.countRow {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
-}
-
-.countValue {
-  font-size: 1.85rem;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  color: var(--ifm-heading-color, #e6edf3);
-}
-
-.sharePct {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--ifm-color-emphasis-700, #8b949e);
-}
-
-.cardDesc {
-  font-size: 0.85rem;
-  line-height: 1.4;
-  color: var(--ifm-color-emphasis-600, #8b949e);
-  margin: 0;
-}
-
-.cardSparkline {
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px dashed var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.6));
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.sparklineLabel {
-  font-size: 0.75rem;
-  color: var(--ifm-color-emphasis-500, #808893);
-}
-
-/* Distribution bar */
-.shareSection {
-  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-  border-radius: 10px;
-  padding: 1.25rem;
-}
-
-.sectionHeading {
-  font-size: 1rem;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-  color: var(--ifm-heading-color, #e6edf3);
-}
-
-.sectionSubtext {
-  font-size: 0.85rem;
-  color: var(--ifm-color-emphasis-600, #8b949e);
-  margin-bottom: 1rem;
-}
-
-.distributionBar {
-  display: flex;
-  height: 20px;
-  border-radius: 6px;
-  overflow: hidden;
-  background: rgba(48, 54, 61, 0.5);
-  margin-bottom: 1rem;
-}
-
-.segment {
-  height: 100%;
-  transition: width 0.3s ease;
-}
-
-.shareLegend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.25rem;
-}
-
-.legendItem {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-}
-
-.legendDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.legendLabel {
-  color: var(--ifm-heading-color, #e6edf3);
-  font-weight: 600;
-}
-
-.legendValue {
-  color: var(--ifm-color-emphasis-600, #8b949e);
-}
-
-/* Chart Card */
-.chartCard {
-  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.7));
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-  border-radius: 10px;
-  padding: 1.25rem;
-}
-
-.chartControls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.toggleGroup {
-  display: inline-flex;
-  border: 1px solid var(--ifm-color-emphasis-300, #30363d);
-  border-radius: 6px;
-  overflow: hidden;
+  background: var(--ifm-color-emphasis-100, rgba(15, 23, 42, 0.55));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  padding: 0.2rem;
+  gap: 0.15rem;
 }
 
 .toggleBtn {
   background: transparent;
   border: none;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--ifm-color-emphasis-700, #8b949e);
+  border-radius: 6px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-700, #94a3b8);
   cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s;
-}
-
-.toggleBtn:not(:last-child) {
-  border-right: 1px solid var(--ifm-color-emphasis-300, #30363d);
-}
-
-.toggleBtnActive {
-  background: var(--ifm-color-primary, #58a6ff);
-  color: #fff !important;
+  transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .toggleBtn:hover:not(.toggleBtnActive) {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--ifm-heading-color, #e6edf3);
+  color: var(--ifm-heading-color, #f8fafc);
+  background: rgba(255, 255, 255, 0.04);
 }
 
-.chartNote {
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-600, #8b949e);
-  margin-top: 0.75rem;
+.toggleBtnActive {
+  background: var(--ifm-color-primary, #38bdf8);
+  color: #fff !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.panelFooter {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500, #64748b);
+  margin-top: 0.85rem;
   line-height: 1.4;
+  border-top: 1px solid var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.05));
+  padding-top: 0.6rem;
 }
 
-/* Family section */
+/* ── Ecosystem Chips ─────────────────────────────────────────────────────── */
+.ecosystemChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.4rem;
+}
+
+.chipBazzite,
+.chipBluefin,
+.chipAurora {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid transparent;
+}
+
+.chipBazzite {
+  background: rgba(240, 136, 62, 0.12);
+  color: #f0883e;
+  border-color: rgba(240, 136, 62, 0.25);
+}
+
+.chipBluefin {
+  background: rgba(88, 166, 255, 0.12);
+  color: #58a6ff;
+  border-color: rgba(88, 166, 255, 0.25);
+}
+
+.chipAurora {
+  background: rgba(57, 210, 192, 0.12);
+  color: #39d2c0;
+  border-color: rgba(57, 210, 192, 0.25);
+}
+
+/* ── Family Section ──────────────────────────────────────────────────────── */
 .familySection {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--ifm-heading-color, #f8fafc);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
 .familyGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
 }
 
 .familyCard {
-  background: var(--ifm-card-background-color, rgba(22, 27, 34, 0.75));
-  border: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.8));
-  border-radius: 12px;
+  background: var(--ifm-card-background-color, rgba(15, 23, 42, 0.45));
+  border: 1px solid var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.07));
+  border-radius: 16px;
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  position: relative;
-  overflow: hidden;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.12);
   transition:
-    transform 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .familyCard:hover {
+  border-color: var(--ifm-color-primary, #38bdf8);
   transform: translateY(-2px);
-  border-color: var(--ifm-color-primary, #58a6ff);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 }
 
-.familyCardHeader {
+.familyTopRow {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  margin-bottom: 0.35rem;
 }
 
-.familyCardTitleGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
-
-.familyName {
-  font-size: 1.15rem;
+.cardEyebrow {
+  font-size: 0.7rem;
   font-weight: 700;
-  color: var(--ifm-heading-color, #e6edf3);
-  margin: 0;
-}
-
-.familyEdition {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--ifm-color-emphasis-600, #8b949e);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
+  color: var(--ifm-color-emphasis-600, #94a3b8);
 }
 
 .statusPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 0.15rem 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.12rem 0.45rem;
   border-radius: 999px;
   white-space: nowrap;
 }
 
 .statusActive {
-  background: rgba(57, 210, 192, 0.15);
+  background: rgba(57, 210, 192, 0.14);
   color: #39d2c0;
 }
 
 .statusPending {
-  background: rgba(188, 140, 255, 0.15);
+  background: rgba(188, 140, 255, 0.14);
   color: #bc8cff;
 }
 
-.familyMetaRow {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.6rem 0.75rem;
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 6px;
-  font-size: 0.75rem;
+.familyName {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color, #f8fafc);
+  margin: 0 0 0.5rem 0;
 }
 
-.familyMetaItem {
+.countRow {
   display: flex;
-  justify-content: space-between;
+  align-items: baseline;
   gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
-.familyMetaLabel {
-  color: var(--ifm-color-emphasis-500, #8b949e);
+.countValue {
+  font-size: 1.65rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--ifm-heading-color, #f8fafc);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
 }
 
-.familyMetaValue {
-  color: var(--ifm-color-emphasis-800, #e6edf3);
+.sharePct {
+  font-size: 0.85rem;
   font-weight: 600;
-  font-family: var(--ifm-font-family-monospace, monospace);
-  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600, #94a3b8);
+  font-variant-numeric: tabular-nums;
 }
 
-.familyFooter {
+.sparklineContainer {
+  margin-top: auto;
+  padding-top: 0.6rem;
+  border-top: 1px dashed
+    var(--ifm-color-emphasis-200, rgba(255, 255, 255, 0.06));
+}
+
+.familyCardFooter {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  margin-top: auto;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--ifm-color-emphasis-200, rgba(48, 54, 61, 0.6));
+  justify-content: flex-end;
+  margin-top: 0.6rem;
 }
 
-.familyLink {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--ifm-color-primary, #58a6ff);
+.cardLink {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary, #38bdf8);
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
+  transition: gap 0.15s ease;
 }
 
-.familyLink:hover {
+.cardLink:hover {
   text-decoration: underline;
+  gap: 0.4rem;
 }

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -34,17 +34,12 @@ export interface CountmeDataset {
 type HeroRange = "12w" | "24w" | "all";
 type HeroMode = "unified" | "split";
 type RangeOption = "4w" | "12w" | "all";
-type ViewMode = "workstations" | "all-ecosystem" | "with-fedora";
+type ViewMode = "all-ecosystem" | "workstations" | "with-fedora";
 
 interface ProjectBluefinImageSpec {
   id: "bluefin" | "bluefin-lts" | "dakota" | "utah";
   name: string;
-  badge: string;
   edition: string;
-  stream: string;
-  repo: string;
-  imageRef: string;
-  desc: string;
   color: string;
   link: string;
   status: "active" | "bootstrapping" | "provisioning";
@@ -55,12 +50,7 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
   {
     id: "bluefin",
     name: "Bluefin",
-    badge: "Fedora bootc",
     edition: "Flagship Workstation",
-    stream: ":stable (GNOME 50.1 / Linux 7.0)",
-    repo: "projectbluefin/bluefin",
-    imageRef: "ghcr.io/projectbluefin/bluefin:stable",
-    desc: "Flagship cloud-native developer workstation with devcontainers, eBPF tooling, and dedicated developer ergonomics.",
     color: "#58a6ff",
     link: "/downloads",
     status: "active",
@@ -69,44 +59,29 @@ const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
   {
     id: "bluefin-lts",
     name: "Bluefin LTS",
-    badge: "CentOS Stream 10 bootc",
     edition: "Enterprise Workstation",
-    stream: ":stable (CentOS Stream 10 / Linux 6.12 LTS)",
-    repo: "projectbluefin/bluefin-lts",
-    imageRef: "ghcr.io/projectbluefin/bluefin-lts:stable",
-    desc: "Long-term support release providing 10-year platform stability, certified enterprise kernel base, and rock-solid reliability.",
     color: "#bc8cff",
     link: "/lts",
     status: "active",
-    statusText: "Active Tracking",
+    statusText: "Active · EPEL",
   },
   {
     id: "dakota",
     name: "Project Bluefin Dakota",
-    badge: "GNOME OS bootc",
     edition: "Next-Gen BuildStream",
-    stream: ":stable & :testing (GNOME 50)",
-    repo: "projectbluefin/dakota",
-    imageRef: "ghcr.io/projectbluefin/dakota:stable",
-    desc: "Built from source with Apache BuildStream. Eschews traditional packaging for pure upstream GNOME delivering a direct feedback loop.",
     color: "#39d2c0",
     link: "/dakota",
     status: "bootstrapping",
-    statusText: "Alpha · Countme Activating",
+    statusText: "Alpha · Collecting",
   },
   {
     id: "utah",
     name: "Project Bluefin Utah",
-    badge: "Hummingbird bootc",
     edition: "Modular Hummingbird",
-    stream: ":testing (GNOME 51)",
-    repo: "projectbluefin/utah",
-    imageRef: "ghcr.io/projectbluefin/utah:testing",
-    desc: "Hardened minimal Fedora Hummingbird bootable base with Bluefin package contract and modular GNOME 51 desktop layer.",
     color: "#f0883e",
     link: "/utah",
     status: "provisioning",
-    statusText: "Pre-alpha · Countme Provisioning",
+    statusText: "Pre-alpha · Provisioning",
   },
 ];
 
@@ -134,21 +109,19 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     return weeks;
   }, [weeks, heroRange]);
 
-  // Delta calculation for Bluefin fleet
-  const firstWeek = weeks[0] || ({} as CountmeWeek);
-  const initialTotalBluefin =
-    (Number(firstWeek.bluefin) || 0) +
-      (Number(firstWeek["bluefin-lts"]) || 0) +
-      (Number(firstWeek.dakota) || 0) +
-      (Number(firstWeek.utah) || 0) || currentTotalBluefin;
+  // 12-week delta calculation
+  const week12wAgo = weeks.length > 12 ? weeks[weeks.length - 13] : weeks[0];
+  const total12wAgo =
+    (Number(week12wAgo?.bluefin) || 0) +
+    (Number(week12wAgo?.["bluefin-lts"]) || 0) +
+    (Number(week12wAgo?.dakota) || 0) +
+    (Number(week12wAgo?.utah) || 0);
 
-  const bluefinDeltaPct =
-    initialTotalBluefin > 0
-      ? (
-          ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
-          100
-        ).toFixed(1)
+  const delta12wPct =
+    total12wAgo > 0
+      ? (((currentTotalBluefin - total12wAgo) / total12wAgo) * 100).toFixed(1)
       : "0.0";
+  const isPositiveDelta = Number(delta12wPct) >= 0;
 
   // Filtered weeks for comparative time-series charts
   const filteredWeeks = useMemo(() => {
@@ -158,13 +131,16 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
   }, [weeks, range]);
 
   // Ecosystem totals (Bazzite + Total Bluefin fleet + Aurora)
-  const peerTotal = useMemo(() => {
-    const bazzite = Number(latestWeek.bazzite) || 0;
-    const aurora = Number(latestWeek.aurora) || 0;
-    return bazzite + currentTotalBluefin + aurora;
-  }, [latestWeek, currentTotalBluefin]);
+  const bazziteCount = Number(latestWeek.bazzite) || 0;
+  const auroraCount = Number(latestWeek.aurora) || 0;
+  const peerTotal = bazziteCount + currentTotalBluefin + auroraCount;
 
-  // Real finite point counts for EChart to prevent bypassing accumulating data
+  const bazzitePct = peerTotal > 0 ? (bazziteCount / peerTotal) * 100 : 0;
+  const bluefinPct =
+    peerTotal > 0 ? (currentTotalBluefin / peerTotal) * 100 : 0;
+  const auroraPct = peerTotal > 0 ? (auroraCount / peerTotal) * 100 : 0;
+
+  // Point counts for EChart to prevent bypassing accumulating data
   const realHeroPoints = useMemo(() => {
     return heroFilteredWeeks.filter(
       (w) =>
@@ -227,7 +203,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
             type: "line",
             data: flagshipSeries,
             smooth: true,
-            showSymbol: true,
+            showSymbol: false,
             symbolSize: 6,
             itemStyle: { color: "#58a6ff" },
             lineStyle: { width: 3, color: "#58a6ff" },
@@ -238,7 +214,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
             type: "line",
             data: ltsSeries,
             smooth: true,
-            showSymbol: true,
+            showSymbol: false,
             symbolSize: 6,
             itemStyle: { color: "#bc8cff" },
             lineStyle: { width: 3, color: "#bc8cff", type: [6, 3] },
@@ -271,11 +247,11 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
       },
       series: [
         {
-          name: "Bluefin Family (All Systems)",
+          name: "Bluefin Family",
           type: "line",
           data: totalSeries,
           smooth: true,
-          showSymbol: true,
+          showSymbol: false,
           symbolSize: 6,
           itemStyle: { color: "#58a6ff" },
           lineStyle: { width: 3, color: "#58a6ff" },
@@ -287,8 +263,8 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
               x2: 0,
               y2: 1,
               colorStops: [
-                { offset: 0, color: "rgba(88, 166, 255, 0.45)" },
-                { offset: 1, color: "rgba(57, 210, 192, 0.05)" },
+                { offset: 0, color: "rgba(88, 166, 255, 0.4)" },
+                { offset: 1, color: "rgba(57, 210, 192, 0.02)" },
               ],
             },
           },
@@ -345,7 +321,6 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         },
       );
     } else {
-      // Total Bluefin family
       seriesList.push({
         name: "Bluefin Family",
         type: "line",
@@ -394,120 +369,133 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     );
   }
 
-  // Distribution calculations
-  const bazziteCount = Number(latestWeek.bazzite) || 0;
-  const auroraCount = Number(latestWeek.aurora) || 0;
-  const bazzitePct = peerTotal > 0 ? (bazziteCount / peerTotal) * 100 : 0;
-  const bluefinPct =
-    peerTotal > 0 ? (currentTotalBluefin / peerTotal) * 100 : 0;
-  const auroraPct = peerTotal > 0 ? (auroraCount / peerTotal) * 100 : 0;
-
   return (
     <div className={styles.container}>
-      {/* ── 1. Hero: Bluefin Systems (Total Fleet) ─────────────────────────── */}
-      <div className={styles.heroCard}>
-        <div className={styles.heroHeader}>
-          <div className={styles.heroTitleGroup}>
-            <Heading as="h3" className={styles.heroTitle}>
-              Bluefin Systems
-              <span className={styles.heroBadge}>Source of Truth</span>
+      {/* ── 1. Top KPI Summary Strip ────────────────────────────────────── */}
+      <section className={styles.kpiGrid} aria-label="Key adoption indicators">
+        <article className={styles.kpiCard}>
+          <span className={styles.kpiEyebrow}>Bluefin Fleet</span>
+          <div className={styles.kpiValue}>
+            {currentTotalBluefin.toLocaleString()}
+          </div>
+          <span className={styles.kpiMeta}>
+            Weekly active systems · {latestWeek.week}
+          </span>
+        </article>
+
+        <article className={styles.kpiCard}>
+          <span className={styles.kpiEyebrow}>12-Week Growth</span>
+          <div className={styles.kpiValueRow}>
+            <span className={styles.kpiValue}>{delta12wPct}%</span>
+            <span
+              className={`${styles.trendBadge} ${
+                isPositiveDelta ? styles.trendUp : styles.trendDown
+              }`}
+            >
+              {isPositiveDelta ? "↑" : "↓"} {Math.abs(Number(delta12wPct))}%
+            </span>
+          </div>
+          <span className={styles.kpiMeta}>vs 12 weeks ago</span>
+        </article>
+
+        <article className={styles.kpiCard}>
+          <span className={styles.kpiEyebrow}>Ecosystem Share</span>
+          <div className={styles.kpiValue}>{bluefinPct.toFixed(1)}%</div>
+          <span className={styles.kpiMeta}>
+            Of {peerTotal.toLocaleString()} desktop devices
+          </span>
+        </article>
+
+        <article className={styles.kpiCard}>
+          <span className={styles.kpiEyebrow}>Fleet Coverage</span>
+          <div className={styles.kpiValue}>2 of 4 Active</div>
+          <span className={styles.kpiMeta}>Dakota & Utah onboarding</span>
+        </article>
+      </section>
+
+      {/* ── 2. Dominant Fleet Chart Panel ─────────────────────────────────── */}
+      <section
+        className={styles.panelCard}
+        aria-label="Bluefin weekly active systems"
+      >
+        <div className={styles.panelHeader}>
+          <div className={styles.titleGroup}>
+            <span className={styles.eyebrow}>Weekly Active Systems</span>
+            <Heading as="h3" className={styles.panelTitle}>
+              Project Bluefin Fleet
             </Heading>
-            <p className={styles.heroSubtitle}>
-              Canonical weekly active systems across all Project Bluefin
-              workstation variants
-            </p>
-            <div className={styles.heroSubBadges}>
-              <span
-                className={`${styles.heroSubBadge} ${styles.heroSubBadgeHighlight}`}
-              >
-                Flagship (projectbluefin/bluefin):{" "}
-                {latestBluefin.toLocaleString()} (
-                {((latestBluefin / currentTotalBluefin) * 100).toFixed(1)}%)
-              </span>
-              <span className={styles.heroSubBadge}>
-                LTS (projectbluefin/bluefin-lts):{" "}
-                {latestBluefinLts.toLocaleString()} (
-                {((latestBluefinLts / currentTotalBluefin) * 100).toFixed(1)}%)
-              </span>
-              <span className={styles.heroSubBadge}>Dakota: Bootstrapping</span>
-              <span className={styles.heroSubBadge}>Utah: Provisioning</span>
-            </div>
           </div>
 
-          <div className={styles.heroKPI}>
-            <div className={styles.heroNumber}>
-              {currentTotalBluefin.toLocaleString()}
-            </div>
-            <div className={styles.heroMeta}>
-              <span style={{ fontWeight: 700, color: "#39d2c0" }}>
-                +{bluefinDeltaPct}% overall
-              </span>
-              <span>latest week ({latestWeek.week})</span>
-            </div>
-          </div>
-        </div>
-
-        <div className={styles.chartControls}>
-          <div className={styles.toggleGroup}>
-            <button
-              type="button"
-              className={`${styles.toggleBtn} ${heroMode === "unified" ? styles.toggleBtnActive : ""}`}
-              onClick={() => setHeroMode("unified")}
+          <div className={styles.controlsRow}>
+            <div
+              className={styles.segmentedGroup}
+              role="group"
+              aria-label="Fleet view mode"
             >
-              Unified Fleet
-            </button>
-            <button
-              type="button"
-              className={`${styles.toggleBtn} ${heroMode === "split" ? styles.toggleBtnActive : ""}`}
-              onClick={() => setHeroMode("split")}
-            >
-              By Edition
-            </button>
-          </div>
-
-          <div className={styles.toggleGroup}>
-            {(["12w", "24w", "all"] as HeroRange[]).map((r) => (
               <button
-                key={r}
                 type="button"
-                className={`${styles.toggleBtn} ${heroRange === r ? styles.toggleBtnActive : ""}`}
-                onClick={() => setHeroRange(r)}
+                className={`${styles.toggleBtn} ${heroMode === "unified" ? styles.toggleBtnActive : ""}`}
+                onClick={() => setHeroMode("unified")}
+                aria-pressed={heroMode === "unified"}
               >
-                {r === "12w"
-                  ? "12 Weeks"
-                  : r === "24w"
-                    ? "6 Months"
-                    : `All History (${weeks.length}w)`}
+                Unified Fleet
               </button>
-            ))}
+              <button
+                type="button"
+                className={`${styles.toggleBtn} ${heroMode === "split" ? styles.toggleBtnActive : ""}`}
+                onClick={() => setHeroMode("split")}
+                aria-pressed={heroMode === "split"}
+              >
+                By Edition
+              </button>
+            </div>
+
+            <div
+              className={styles.segmentedGroup}
+              role="group"
+              aria-label="Fleet time range"
+            >
+              {(["12w", "24w", "all"] as HeroRange[]).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  className={`${styles.toggleBtn} ${heroRange === r ? styles.toggleBtnActive : ""}`}
+                  onClick={() => setHeroRange(r)}
+                  aria-pressed={heroRange === r}
+                >
+                  {r === "12w" ? "12w" : r === "24w" ? "24w" : "All"}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
         <EChart
           option={heroChartOption}
           title="Bluefin Systems"
-          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
+          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, ${delta12wPct}% 12-week change across ${weeks.length} tracked weeks.`}
           points={realHeroPoints}
           minPoints={2}
           height={320}
           tableCaption="Project Bluefin weekly active systems history"
         />
 
-        <div className={styles.chartNote}>
-          <strong>Lineage:</strong> Single source of truth for Project Bluefin,
-          unifying flagship (<code>projectbluefin/bluefin</code>) and enterprise
-          LTS (<code>projectbluefin/bluefin-lts</code>) into one fleet view.
+        <div className={styles.panelFooter}>
+          Canonical weekly active systems across Project Bluefin workstation
+          variants (ADR 0004).
         </div>
-      </div>
+      </section>
 
-      {/* ── 2. Project Bluefin Image Family ─────────────────────────────────── */}
-      <div className={styles.familySection}>
-        <div className={styles.sectionHeading}>
-          Project Bluefin Image Family
-        </div>
-        <div className={styles.sectionSubtext}>
-          Workstation operating system images built, maintained, and
-          instrumented by Project Bluefin
+      {/* ── 3. Family Cards Grid ─────────────────────────────────────────── */}
+      <section
+        className={styles.familySection}
+        aria-label="Project Bluefin image family"
+      >
+        <div className={styles.sectionHeader}>
+          <span className={styles.eyebrow}>Image Editions</span>
+          <Heading as="h3" className={styles.sectionTitle}>
+            Workstation Family
+          </Heading>
         </div>
 
         <div className={styles.familyGrid}>
@@ -527,14 +515,9 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
               : [];
 
             return (
-              <div key={img.id} className={styles.familyCard}>
-                <div className={styles.familyCardHeader}>
-                  <div className={styles.familyCardTitleGroup}>
-                    <Heading as="h4" className={styles.familyName}>
-                      {img.name}
-                    </Heading>
-                    <span className={styles.familyEdition}>{img.edition}</span>
-                  </div>
+              <article key={img.id} className={styles.familyCard}>
+                <div className={styles.familyTopRow}>
+                  <span className={styles.cardEyebrow}>{img.edition}</span>
                   <span
                     className={`${styles.statusPill} ${
                       img.status === "active"
@@ -546,13 +529,17 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
                   </span>
                 </div>
 
+                <Heading as="h4" className={styles.familyName}>
+                  {img.name}
+                </Heading>
+
                 <div className={styles.countRow}>
                   <span className={styles.countValue}>
                     {isTracked
                       ? count.toLocaleString()
                       : img.status === "bootstrapping"
-                        ? "Initial"
-                        : "Pending"}
+                        ? "Alpha"
+                        : "Pre-alpha"}
                   </span>
                   {isTracked && currentTotalBluefin > 0 && (
                     <span className={styles.sharePct}>
@@ -561,41 +548,13 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
                   )}
                 </div>
 
-                <p className={styles.cardDesc}>{img.desc}</p>
-
-                <div className={styles.familyMetaRow}>
-                  <div className={styles.familyMetaItem}>
-                    <span className={styles.familyMetaLabel}>Base Stack</span>
-                    <span className={styles.familyMetaValue}>{img.badge}</span>
-                  </div>
-                  <div className={styles.familyMetaItem}>
-                    <span className={styles.familyMetaLabel}>Repository</span>
-                    <span className={styles.familyMetaValue}>
-                      <code>{img.repo}</code>
-                    </span>
-                  </div>
-                  <div className={styles.familyMetaItem}>
-                    <span className={styles.familyMetaLabel}>Image</span>
-                    <span className={styles.familyMetaValue}>
-                      <code>{img.imageRef}</code>
-                    </span>
-                  </div>
-                  <div className={styles.familyMetaItem}>
-                    <span className={styles.familyMetaLabel}>Streams</span>
-                    <span className={styles.familyMetaValue}>{img.stream}</span>
-                  </div>
-                </div>
-
-                <div className={styles.cardSparkline}>
-                  <span className={styles.sparklineLabel}>
-                    {isTracked ? "12-week trend" : "Countme status"}
-                  </span>
+                <div className={styles.sparklineContainer}>
                   <Sparkline
                     data={history}
                     variant="line"
                     domain={workstationDomain}
                     width={220}
-                    height={32}
+                    height={36}
                     color={img.color}
                     areaColor="currentColor"
                     areaOpacity={0.12}
@@ -606,131 +565,96 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
                         ? "accumulating countme data"
                         : "provisioning countme"
                     }
-                    label={`${img.name} 12-week adoption trend: currently ${count.toLocaleString()}`}
+                    label={`${img.name} adoption trend: currently ${count.toLocaleString()}`}
                   />
                 </div>
 
-                <div className={styles.familyFooter}>
-                  <Link to={img.link} className={styles.familyLink}>
-                    View {img.name} Details &rarr;
+                <div className={styles.familyCardFooter}>
+                  <Link to={img.link} className={styles.cardLink}>
+                    View Details &rarr;
                   </Link>
                 </div>
-              </div>
+              </article>
             );
           })}
         </div>
-      </div>
+      </section>
 
-      {/* ── 3. Cloud-Native Ecosystem Overview ─────────────────────────────── */}
-      <div className={styles.shareSection}>
-        <div className={styles.sectionHeading}>
-          Cloud-Native Desktop Ecosystem
-        </div>
-        <div className={styles.sectionSubtext}>
-          Share of {peerTotal.toLocaleString()} total estimated active
-          cloud-native desktop devices (latest week: {latestWeek.week})
-        </div>
-
-        {/* Distribution Bar */}
-        <div
-          className={styles.distributionBar}
-          role="region"
-          aria-label={`Desktop ecosystem distribution across ${peerTotal.toLocaleString()} systems`}
-        >
-          <div
-            className={styles.segment}
-            style={{ width: `${bazzitePct}%`, backgroundColor: "#f0883e" }}
-            title={`Bazzite (Gaming): ${bazziteCount.toLocaleString()} (${bazzitePct.toFixed(1)}%)`}
-          />
-          <div
-            className={styles.segment}
-            style={{ width: `${bluefinPct}%`, backgroundColor: "#58a6ff" }}
-            title={`Bluefin Family: ${currentTotalBluefin.toLocaleString()} (${bluefinPct.toFixed(1)}%)`}
-          />
-          <div
-            className={styles.segment}
-            style={{ width: `${auroraPct}%`, backgroundColor: "#39d2c0" }}
-            title={`Aurora (KDE): ${auroraCount.toLocaleString()} (${auroraPct.toFixed(1)}%)`}
-          />
-        </div>
-
-        {/* Legend */}
-        <div className={styles.shareLegend}>
-          <div className={styles.legendItem}>
-            <span
-              className={styles.legendDot}
-              style={{ backgroundColor: "#f0883e" }}
-            />
-            <span className={styles.legendLabel}>Bazzite (Gaming):</span>
-            <span className={styles.legendValue}>
-              {bazziteCount.toLocaleString()} ({bazzitePct.toFixed(1)}%)
-            </span>
+      {/* ── 4. Comparative Trajectory Panel ──────────────────────────────── */}
+      <section
+        className={styles.panelCard}
+        aria-label="Comparative adoption trajectories"
+      >
+        <div className={styles.panelHeader}>
+          <div className={styles.titleGroup}>
+            <span className={styles.eyebrow}>Cloud-Native Ecosystem</span>
+            <Heading as="h3" className={styles.panelTitle}>
+              Comparative Adoption Trajectories
+            </Heading>
+            <div className={styles.ecosystemChips}>
+              <span className={styles.chipBazzite}>
+                Bazzite: {bazziteCount.toLocaleString()} (
+                {bazzitePct.toFixed(1)}%)
+              </span>
+              <span className={styles.chipBluefin}>
+                Bluefin: {currentTotalBluefin.toLocaleString()} (
+                {bluefinPct.toFixed(1)}%)
+              </span>
+              <span className={styles.chipAurora}>
+                Aurora: {auroraCount.toLocaleString()} ({auroraPct.toFixed(1)}%)
+              </span>
+            </div>
           </div>
-          <div className={styles.legendItem}>
-            <span
-              className={styles.legendDot}
-              style={{ backgroundColor: "#58a6ff" }}
-            />
-            <span className={styles.legendLabel}>Bluefin Family:</span>
-            <span className={styles.legendValue}>
-              {currentTotalBluefin.toLocaleString()} ({bluefinPct.toFixed(1)}%)
-            </span>
-          </div>
-          <div className={styles.legendItem}>
-            <span
-              className={styles.legendDot}
-              style={{ backgroundColor: "#39d2c0" }}
-            />
-            <span className={styles.legendLabel}>Aurora (KDE):</span>
-            <span className={styles.legendValue}>
-              {auroraCount.toLocaleString()} ({auroraPct.toFixed(1)}%)
-            </span>
-          </div>
-        </div>
-      </div>
 
-      {/* ── 4. Interactive Comparative Trajectory ───────────────────────────── */}
-      <div className={styles.chartCard}>
-        <div className={styles.chartControls}>
-          <div className={styles.toggleGroup}>
-            <button
-              type="button"
-              className={`${styles.toggleBtn} ${viewMode === "all-ecosystem" ? styles.toggleBtnActive : ""}`}
-              onClick={() => setViewMode("all-ecosystem")}
+          <div className={styles.controlsRow}>
+            <div
+              className={styles.segmentedGroup}
+              role="group"
+              aria-label="Comparative scope"
             >
-              All Desktop Images
-            </button>
-            <button
-              type="button"
-              className={`${styles.toggleBtn} ${viewMode === "workstations" ? styles.toggleBtnActive : ""}`}
-              onClick={() => setViewMode("workstations")}
-            >
-              Workstations (Flagship, LTS & Aurora)
-            </button>
-            <button
-              type="button"
-              className={`${styles.toggleBtn} ${viewMode === "with-fedora" ? styles.toggleBtnActive : ""}`}
-              onClick={() => setViewMode("with-fedora")}
-            >
-              Include Fedora Base
-            </button>
-          </div>
-
-          <div className={styles.toggleGroup}>
-            {(["4w", "12w", "all"] as RangeOption[]).map((r) => (
               <button
-                key={r}
                 type="button"
-                className={`${styles.toggleBtn} ${range === r ? styles.toggleBtnActive : ""}`}
-                onClick={() => setRange(r)}
+                className={`${styles.toggleBtn} ${viewMode === "all-ecosystem" ? styles.toggleBtnActive : ""}`}
+                onClick={() => setViewMode("all-ecosystem")}
+                aria-pressed={viewMode === "all-ecosystem"}
               >
-                {r === "4w"
-                  ? "4 Weeks"
-                  : r === "12w"
-                    ? "12 Weeks"
-                    : "All Weeks"}
+                All Desktops
               </button>
-            ))}
+              <button
+                type="button"
+                className={`${styles.toggleBtn} ${viewMode === "workstations" ? styles.toggleBtnActive : ""}`}
+                onClick={() => setViewMode("workstations")}
+                aria-pressed={viewMode === "workstations"}
+              >
+                Workstations
+              </button>
+              <button
+                type="button"
+                className={`${styles.toggleBtn} ${viewMode === "with-fedora" ? styles.toggleBtnActive : ""}`}
+                onClick={() => setViewMode("with-fedora")}
+                aria-pressed={viewMode === "with-fedora"}
+              >
+                + Fedora
+              </button>
+            </div>
+
+            <div
+              className={styles.segmentedGroup}
+              role="group"
+              aria-label="Comparative time range"
+            >
+              {(["4w", "12w", "all"] as RangeOption[]).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  className={`${styles.toggleBtn} ${range === r ? styles.toggleBtnActive : ""}`}
+                  onClick={() => setRange(r)}
+                  aria-pressed={range === r}
+                >
+                  {r === "4w" ? "4w" : r === "12w" ? "12w" : "All"}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -744,13 +668,11 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
           tableCaption="Weekly estimated active systems by image variant"
         />
 
-        <div className={styles.chartNote}>
-          <strong>Methodology:</strong> Derived from weekly Countme telemetry
-          tracking with <code>ublue-countme-v1</code> baseline aggregation,
-          supplemented by first-party <code>countme.projectbluefin.io</code>{" "}
-          pings.
+        <div className={styles.panelFooter}>
+          Derived from weekly Countme telemetry tracking via{" "}
+          <code>ublue-countme-v1</code> baseline aggregation.
         </div>
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Modernizes the analytics charts on `/analytics` with a data-dense, Astro-inspired visual design and removes excessive wordiness across the page.

## Key Changes
- **Top KPI Summary Strip**: Added 4 concise metrics (Fleet Total, 12-week Delta, Ecosystem Share %, and Fleet Coverage) with tabular numbers and trend badges.
- **Dominant Fleet Chart**: Upgraded to glassmorphic dark surface styling, uppercase tracking eyebrow, and segmented pill controls (`Unified` / `By Edition`, `12w` / `24w` / `All`), eliminating wordy lineage paragraphs and repeated sub-badges.
- **Streamlined Family Cards**: Refactored workstation cards into clean KPI + status pill + sparklines + link, removing bulky 4-row metadata tables (Base Stack, Repo, Image, Streams) and narrative descriptions.
- **Merged Ecosystem Comparison**: Folded cloud-native desktop distribution stats (Bazzite, Bluefin, Aurora) directly into the comparative chart's header chips; eliminated the duplicate standalone distribution bar section.
- **Streamlined `docs/analytics.mdx`**: Dropped 3 heavy embedded LFX iframes (~2000px height) and fluff quotes; moved ADR 0004 methodology, first-party countme service guarantees, and opt-out commands into a collapsible `<details>` disclosure.
- **Skill Doc**: Updated `docs/skills/factory-dashboard-content.md` with analytics chart conventions.

## Validation
- `npm run typecheck` passed (0 errors)
- `npm run lint` passed (0 errors)
- `npm test` passed
- `npm run build:ci` passed with 0 errors
- Net diff: -247 lines of bloat removed