### PR TITLE
fix: restore Hive leaderboard data and styling

### DIFF
--- a/scripts/fetch-registry-data.js
+++ b/scripts/fetch-registry-data.js
@@ -15,7 +15,7 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, "../static/data/registry-data.json");
-const REGISTRY_URL = "https://hive.kubestellar.io/api/registry";
+const REGISTRY_URL = "https://hive.hivecommons.dev/api/registry";
 const TARGET_ORG = "projectbluefin";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const force = process.argv.includes("--force");
@@ -23,7 +23,9 @@ const force = process.argv.includes("--force");
 if (!force && existsSync(OUT)) {
   const age = Date.now() - statSync(OUT).mtimeMs;
   if (age < CACHE_TTL_MS) {
-    console.log(`fetch-registry-data: cache fresh (${Math.round(age / 60000)}m old), skipping`);
+    console.log(
+      `fetch-registry-data: cache fresh (${Math.round(age / 60000)}m old), skipping`,
+    );
     process.exit(0);
   }
 }
@@ -35,11 +37,15 @@ try {
   const data = await res.json();
   const entry = data.hives?.find((h) => h.org === TARGET_ORG) ?? null;
   if (!entry) {
-    console.warn(`fetch-registry-data: no entry for org=${TARGET_ORG}, writing null`);
+    console.warn(
+      `fetch-registry-data: no entry for org=${TARGET_ORG}, writing null`,
+    );
     writeFileSync(OUT, "null\n");
   } else {
     writeFileSync(OUT, JSON.stringify(entry, null, 2) + "\n");
-    console.log(`fetch-registry-data: wrote ${OUT} (acmmLevel=${entry.acmmLevel}, mode=${entry.governorMode})`);
+    console.log(
+      `fetch-registry-data: wrote ${OUT} (acmmLevel=${entry.acmmLevel}, mode=${entry.governorMode})`,
+    );
   }
 } catch (err) {
   console.error(`fetch-registry-data: fetch failed: ${err.message}`);

--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -2096,6 +2096,21 @@
 
 /* ── Contribution and newcomer landing ─────────────────────────────────── */
 
+.leaderboards .panel {
+  background: var(--ifm-card-background-color);
+  border-color: var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+}
+
+.leaderboards .panelTitle {
+  color: var(--ifm-heading-color);
+  font-size: var(--ifm-h2-font-size);
+  font-weight: var(--ifm-heading-font-weight);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
 .contributionLinks {
   margin-bottom: 1.25rem;
 }

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -4303,7 +4303,7 @@ export function LeaderboardsSection(): React.JSX.Element {
       : null;
 
   return (
-    <>
+    <div className={styles.leaderboards}>
       <ContributionLinks />
       {hiveHistory ? (
         <div className={styles.twoCol}>
@@ -4333,7 +4333,7 @@ export function LeaderboardsSection(): React.JSX.Element {
           </p>
         </section>
       )}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- read the public Hive registry from its current JSON endpoint
- use native documentation card and heading styling on Leaderboards

## Validation
- npm run fetch-registry-data -- --force
- npm run typecheck
- npm run build:ci
- npm test