### PR TITLE
fix(profiles): remove nonexistent chandeleer1698 GitHub username

### DIFF
--- a/scripts/fetch-github-profiles.js
+++ b/scripts/fetch-github-profiles.js
@@ -57,7 +57,6 @@ const HARDCODED_USERNAMES = [
   "tulilirockz",
 
   // Artists
-  "chandeleer1698",
   "delphicmelody",
 
   // Bluefin Maintainers (Emeritus)

--- a/static/data/github-profiles.json
+++ b/static/data/github-profiles.json
@@ -107,18 +107,6 @@
     "sponsorable": true,
     "donationUrl": null
   },
-  "chandeleer1698": {
-    "login": "chandeleer1698",
-    "name": "Chandler",
-    "avatar_url": "https://avatars.githubusercontent.com/u/202515295?v=4",
-    "bio": "Art Director for Universal Blue & Aurora,\r\n\r\nI also take commissions on my Ko-Fi!",
-    "html_url": "https://github.com/chandeleer1698",
-    "public_repos": 9,
-    "followers": 8,
-    "company": "@ublue-os",
-    "sponsorable": false,
-    "donationUrl": null
-  },
   "delphicmelody": {
     "login": "delphicmelody",
     "name": "M. Gopal",


### PR DESCRIPTION
## Problem

The GitHub account `chandeleer1698` no longer exists (returns 404 from the GitHub API).

## Solution

Remove the nonexistent username from:
- `scripts/fetch-github-profiles.js` — removed from `HARDCODED_USERNAMES`
- `static/data/github-profiles.json` — removed the cached profile entry

The profile fetch script will no longer attempt to fetch this account.

 hive: backend=copilot
---
🐝 **Hive Agent**: `contributor` | **SHA:** `45543902`

— hive: backend=copilot model=claude-haiku-4.5 copilot=GitHub Copilot CLI 1.0.59.