### PR TITLE
fix(catalog): generate Bluefin LTS rebases against the bluefin-lts package

### DIFF
--- a/scripts/catalog-components.test.js
+++ b/scripts/catalog-components.test.js
@@ -289,3 +289,21 @@ test("DriverVersionsCatalog showRebootStep prop controls reboot banner", () => {
   });
   assert.ok(!withoutReboot.includes("Final Step: Reboot"));
 });
+
+test("DriverVersionsCatalog generates rebase commands using the correct package for bluefin-lts", () => {
+  const html = render(DriverVersionsCatalog, {
+    streamId: "bluefin-lts",
+    catalogOverride: ltsCatalog,
+  });
+
+  assert.ok(
+    html.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin-lts:lts-20260906",
+    ),
+  );
+  assert.ok(
+    !html.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin:lts-20260906",
+    ),
+  );
+});

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -181,9 +181,17 @@ function UserspaceMarker({
   );
 }
 
+const STREAM_PACKAGES: Record<string, string> = {
+  "bluefin-stable": "bluefin",
+  "bluefin-lts": "bluefin-lts",
+  "dakota-latest": "dakota",
+  "utah-testing": "utah",
+};
+
 function buildRebaseCommand(stream: DriverStream, tag: string): string {
   const safeTag = tag.replace(/[^a-zA-Z0-9_.-]/g, "");
-  return `sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/${stream.id.replace(/-.*/, "")}:${safeTag}`;
+  const pkg = STREAM_PACKAGES[stream.id] ?? stream.id.replace(/-.*/, "");
+  return `sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/${pkg}:${safeTag}`;
 }
 
 function ReleaseNode({


### PR DESCRIPTION
### Problem
`buildRebaseCommand` in `src/components/DriverVersionsCatalog.tsx` derived the package name via `stream.id.replace(/-.*/, "")`. For the `bluefin-lts` stream, this stripped `-lts` and resolved to `bluefin`, generating rebase commands pointing to `ghcr.io/projectbluefin/bluefin:<tag>` instead of `ghcr.io/projectbluefin/bluefin-lts:<tag>`.

### Solution
- Added explicit `STREAM_PACKAGES` mapping in `src/components/DriverVersionsCatalog.tsx` to map `bluefin-lts` to `bluefin-lts` (and preserve explicit mappings for other streams).
- Added unit test in `scripts/catalog-components.test.js` to assert that `DriverVersionsCatalog` emits rebase commands against `bluefin-lts` for the `bluefin-lts` stream.

Fixes #1079

— hive: backend=goose model=gemini-3.8-flash