### PR TITLE
fix(countme): recognize Dakota and Utah without misclassifying Bluefin variants

### DIFF
--- a/scripts/fetch-countme.js
+++ b/scripts/fetch-countme.js
@@ -52,7 +52,15 @@ const OUT = resolve(__dirname, "../static/data/countme-history.json");
 const CSV_URL =
   "https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv";
 
-const VARIANTS = ["bluefin", "bluefin-lts", "aurora", "bazzite", "fedora"];
+const VARIANTS = [
+  "bluefin",
+  "bluefin-lts",
+  "dakota",
+  "utah",
+  "aurora",
+  "bazzite",
+  "fedora",
+];
 
 /**
  * How a weekly number is derived from the CSV. Stamped into the payload so a
@@ -71,9 +79,11 @@ const BASE_REPO = /^fedora-\d+$/;
 /**
  * Variants with no fedora-N repo, counted across their own repos instead.
  * Bluefin LTS is CentOS Stream based and reaches Fedora's counter only through
- * EPEL. ublue-os/countme has this same carve-out.
+ * EPEL. ublue-os/countme has this same carve-out. Dakota is GNOME OS based,
+ * assembled from source with Apache BuildStream — there are no RPMs, so it has
+ * no fedora-N repo either.
  */
-const NON_FEDORA_VARIANTS = new Set(["bluefin-lts"]);
+const NON_FEDORA_VARIANTS = new Set(["bluefin-lts", "dakota"]);
 
 /**
  * Weeks upstream got wrong, skipped exactly as ublue-os/countme skips them.
@@ -169,7 +179,10 @@ export function parseCsvLine(line) {
  * Returns null for unrecognised names — bucketing an unknown OS into a variant
  * would inflate the headline number.
  *
- * ORDER MATTERS: LTS checks before generic bluefin.
+ * ORDER MATTERS: LTS, Dakota, and Utah check before generic bluefin. Dakota and
+ * Utah are Bluefin variants whose os_name carries a "bluefin-" prefix (e.g.
+ * "bluefin-dakota", "bluefin-utah"), so the broad startsWith("bluefin") branch
+ * would otherwise fold them into flagship Bluefin.
  */
 export function normalizeVariant(osName) {
   if (osName == null) return null;
@@ -183,6 +196,22 @@ export function normalizeVariant(osName) {
     s.startsWith("bluefin-lts")
   )
     return "bluefin-lts";
+
+  // Dakota — GNOME OS / Apache BuildStream distroless prototype.
+  if (
+    s.includes("dakotaraptor") ||
+    s.startsWith("bluefin-dakota") ||
+    s.startsWith("dakota")
+  )
+    return "dakota";
+
+  // Utah — Fedora Hummingbird base with the GNOME 51 desktop stack.
+  if (
+    s.includes("utahraptor") ||
+    s.startsWith("bluefin-utah") ||
+    s.startsWith("utah")
+  )
+    return "utah";
 
   if (s.startsWith("bluefin")) return "bluefin";
   if (s.startsWith("aurora")) return "aurora";

--- a/scripts/fetch-countme.test.js
+++ b/scripts/fetch-countme.test.js
@@ -123,6 +123,20 @@ test("normalizeVariant returns bluefin-lts for Bluefin LTS, not bluefin", () => 
   assert.notEqual(normalizeVariant("Bluefin LTS"), "bluefin");
 });
 
+test("normalizeVariant recognises Dakota without folding it into flagship Bluefin", () => {
+  assert.equal(normalizeVariant("Dakota"), "dakota");
+  assert.equal(normalizeVariant("bluefin-dakota"), "dakota");
+  assert.equal(normalizeVariant("Dakotaraptor"), "dakota");
+  assert.notEqual(normalizeVariant("bluefin-dakota"), "bluefin");
+});
+
+test("normalizeVariant recognises Utah without folding it into flagship Bluefin", () => {
+  assert.equal(normalizeVariant("Utah"), "utah");
+  assert.equal(normalizeVariant("bluefin-utah"), "utah");
+  assert.equal(normalizeVariant("Utahraptor"), "utah");
+  assert.notEqual(normalizeVariant("bluefin-utah"), "bluefin");
+});
+
 // ── aggregateWeeks ───────────────────────────────────────────────────────
 //
 // The rules under test are ported from ublue-os/countme:data_processing.py.
@@ -177,6 +191,29 @@ test("aggregateWeeks counts Bluefin LTS across its own repos, having no fedora-N
   ]);
   const weeks = aggregateWeeks(rows);
   assert.equal(weeks[0]["bluefin-lts"], 159);
+  assert.equal(weeks[0].bluefin, undefined);
+});
+
+test("aggregateWeeks counts Dakota across its own repos, having no fedora-N repo", () => {
+  // Dakota is GNOME OS assembled from source with Apache BuildStream — there
+  // are no RPMs, so it has no fedora-N repo to restrict to.
+  const rows = parseAll([
+    row({ os_name: "bluefin-dakota", repo_tag: "gnome-os", hits: 20 }),
+    row({ os_name: "bluefin-dakota", repo_tag: "gnome-os-testing", hits: 3 }),
+  ]);
+  const weeks = aggregateWeeks(rows);
+  assert.equal(weeks[0].dakota, 23);
+  assert.equal(weeks[0].bluefin, undefined);
+});
+
+test("aggregateWeeks counts Utah restricted to its fedora-N repo", () => {
+  const rows = parseAll([
+    row({ os_name: "bluefin-utah", repo_tag: "fedora-44", hits: 8 }),
+    // A non-base repo hit from the same system must not double count.
+    row({ os_name: "bluefin-utah", repo_tag: "updates-released-f44", hits: 8 }),
+  ]);
+  const weeks = aggregateWeeks(rows);
+  assert.equal(weeks[0].utah, 8);
   assert.equal(weeks[0].bluefin, undefined);
 });
 


### PR DESCRIPTION
## Problem

`scripts/fetch-countme.js`'s `normalizeVariant()` only branched on Bluefin LTS
before falling through to the broad `startsWith("bluefin")` check. That meant:

- `os_name` values like `bluefin-dakota` / `bluefin-utah` were folded into
  flagship Bluefin instead of being counted separately.
- Bare `Dakota` / `Utah` names were dropped entirely as unrecognised.

Closes #1083

## Fix

- Add specific Dakota and Utah matching (`bluefin-dakota`/`dakota`/`dakotaraptor`
  and `bluefin-utah`/`utah`/`utahraptor`) ahead of the generic `bluefin` branch,
  same pattern already used for Bluefin LTS.
- Mark `dakota` as a non-Fedora source in `NON_FEDORA_VARIANTS`: Dakota is
  GNOME OS assembled from source with Apache BuildStream, so it has no
  `fedora-N` repo to restrict counting to (same carve-out as Bluefin LTS).
- Add `dakota` and `utah` to the tracked `VARIANTS` list.
- Add unit tests covering normalization and aggregation for both variants.

## Testing

- `node --test scripts/fetch-countme.test.js` — 28/28 passing.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `1f85a196`