### PR TITLE
fix(repos): repair moved GitHub slugs and preserve partial repository-stat cache

### DIFF
--- a/docs/donations/projects.mdx
+++ b/docs/donations/projects.mdx
@@ -221,13 +221,11 @@ These are the [CNCF](https://www.cncf.io/) and [OpenSSF](https://openssf.org/) p
     description="Simple backup utility for GNOME"
     sponsorUrl="https://liberapay.com/DejaDup"
     icon="https://github.com/deja-dup.png"
-    githubRepo="deja-dup/deja-dup"
   />
   <ProjectCard
     name="Mission Center"
     description="Monitor your CPU, Memory, Disk, Network and GPU usage"
-    icon="https://github.com/Flavius42.png"
-    githubRepo="Flavius42/mission-center"
+    icon="https://github.com/mission-center-devs.png"
   />
   <ProjectCard
     name="Impression"
@@ -251,8 +249,8 @@ These are the [CNCF](https://www.cncf.io/) and [OpenSSF](https://openssf.org/) p
   <ProjectCard
     name="Refine"
     description="GNOME tweaking tool"
-    icon="https://github.com/tesk-g.png"
-    githubRepo="tesk-g/refine"
+    icon="https://github.com/TheEvilSkeleton.png"
+    githubRepo="TheEvilSkeleton/Refine"
   />
   <ProjectCard
     name="Smile"

--- a/scripts/fetch-github-repos.js
+++ b/scripts/fetch-github-repos.js
@@ -35,12 +35,14 @@ const GITHUB_REPOS = [
   "flattool/ignition",
   "tchx84/Flatseal",
   "mjakeman/extension-manager",
-  "deja-dup/deja-dup",
-  "Flavius42/mission-center",
+  // deja-dup/deja-dup and Flavius42/mission-center have no canonical GitHub
+  // repo: both projects moved development to GNOME GitLab and no longer
+  // publish an equivalent GitHub repository, so they are intentionally
+  // omitted here (see docs/donations/projects.mdx).
   "adhami3310/impression",
   "PintaProject/Pinta",
   "GNOME/Showtime",
-  "tesk-g/refine",
+  "TheEvilSkeleton/Refine", // formerly tesk-g/refine; account renamed
   "mijorus/smile",
 
   // Homebrew CLI Tools (bluefin-cli)
@@ -140,6 +142,18 @@ async function fetchAllRepos() {
 
   console.log(`Fetching ${GITHUB_REPOS.length} GitHub repos...`);
 
+  // Load whatever cache already exists on disk so a failed fetch for one
+  // repo (rate limiting, transient network error, etc.) doesn't erase stats
+  // that were previously fetched successfully for that same repo.
+  let existingCache = {};
+  if (fs.existsSync(OUTPUT_FILE)) {
+    try {
+      existingCache = JSON.parse(fs.readFileSync(OUTPUT_FILE, "utf-8"));
+    } catch (error) {
+      console.warn(`⚠️  Could not parse existing cache: ${error.message}`);
+    }
+  }
+
   const resultsMap = await sequentialFetchWithDelay(
     GITHUB_REPOS,
     async (repoPath) => {
@@ -148,11 +162,30 @@ async function fetchAllRepos() {
     },
   );
 
-  const repos = Object.fromEntries(resultsMap);
+  const freshRepos = Object.fromEntries(resultsMap);
 
+  // Merge: start from cached entries for repos still tracked (dropping any
+  // that were removed from GITHUB_REPOS), then overlay this run's
+  // successes. A repo that failed this run keeps its last-known-good stats
+  // instead of disappearing entirely.
+  const repos = {};
+  for (const repoPath of GITHUB_REPOS) {
+    if (existingCache[repoPath]) {
+      repos[repoPath] = existingCache[repoPath];
+    }
+  }
+  Object.assign(repos, freshRepos);
+
+  const failedCount = GITHUB_REPOS.length - Object.keys(freshRepos).length;
   console.log(
-    `\nSuccessfully fetched ${Object.keys(repos).length}/${GITHUB_REPOS.length} repos`,
+    `\nSuccessfully fetched ${Object.keys(freshRepos).length}/${GITHUB_REPOS.length} repos`,
   );
+  if (failedCount > 0) {
+    const recoveredFromCache = Object.keys(repos).length - Object.keys(freshRepos).length;
+    console.log(
+      `  ${recoveredFromCache} of the ${failedCount} failures were preserved from the existing cache.`,
+    );
+  }
 
   // Don't fail build if no repos fetched - the component will just not show stats
   if (Object.keys(repos).length === 0) {


### PR DESCRIPTION
Fixes projectbluefin/documentation#1093

### Problem
`fetch-github-repos.js` tracked three GitHub slugs that now 404:
- `deja-dup/deja-dup`
- `Flavius42/mission-center`
- `tesk-g/refine`

Since the script overwrites its cache file with only the successful results of each run, every fetch failure (dead slug or transient) permanently erased that project's stats from `static/data/github-repos.json`, and `ProjectCard` then fell back to visitor-side GitHub API requests for the missing entries.

### Investigation
- `deja-dup/deja-dup` and `Flavius42/mission-center` have fully moved development to GNOME GitLab. Neither has a canonical GitHub repository anymore (the `deja-dup` org only owns an unrelated `snap` packaging repo, and the `mission-center-devs` org has zero public GitHub repos), so there's nothing to fetch — these are dropped from `GITHUB_REPOS` and their `githubRepo` props removed from `docs/donations/projects.mdx`.
- `tesk-g` renamed to `TheEvilSkeleton`, and `tesk-g/refine` → `TheEvilSkeleton/Refine` is the current canonical GitHub slug, so that one is repointed (icon updated to match).

### Fix
- Repair/remove the moved slugs as above.
- `fetch-github-repos.js` now reads the existing cache before fetching and merges this run's successful results on top of it, instead of overwriting the file wholesale. A transient failure for a still-tracked repo now keeps its last-known-good stats rather than disappearing; repos no longer in `GITHUB_REPOS` are pruned from the merged cache.

### Testing
- `node --test scripts/fetch-github-repos.test.js` (existing tests pass)
- Manually verified the merge logic in isolation (fresh data wins, cached data survives a failed fetch, removed repos are dropped)

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7c2b2ca2`