### PR TITLE
fix(analytics): align Countme family sparkline domains with rendered images

### DIFF
--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -183,11 +183,11 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     ).length;
   }, [filteredWeeks]);
 
-  // Shared domain for workstation small multiples
+  // Shared domain for workstation family small multiples (derived from rendered family images)
   const workstationDomain = useMemo<[number, number]>(() => {
     let min = Infinity;
     let max = -Infinity;
-    const workstationKeys = ["bluefin", "aurora", "bluefin-lts"] as const;
+    const workstationKeys = BLUEFIN_FAMILY_IMAGES.map((img) => img.id);
     for (const w of weeks) {
       for (const k of workstationKeys) {
         const val = w[k];


### PR DESCRIPTION
### Summary
Derive the workstation small-multiples domain keys directly from `BLUEFIN_FAMILY_IMAGES` instead of the hardcoded list `["bluefin", "aurora", "bluefin-lts"]`.

### Problem
`CountmeAnalyticsCharts.tsx` previously calculated the workstation shared chart domain using `["bluefin", "aurora", "bluefin-lts"]`. This included external Aurora while omitting Project Bluefin workstation family members Dakota and Utah, causing domain divergence from the rendered family image cards.

### Solution
Map `BLUEFIN_FAMILY_IMAGES.map((img) => img.id)` so the sparkline domain matches the exact workstation variants rendered across the family cards.

Closes #1085

— hive: backend=goose model=gemini-3.8-flash