### PR TITLE
fix(analytics): include Dakota and Utah in edition and workstation chart series

### DIFF
--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -211,6 +211,12 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
       const ltsSeries = gapSafe(
         heroFilteredWeeks.map((w) => w["bluefin-lts"] ?? null),
       );
+      const dakotaSeries = gapSafe(
+        heroFilteredWeeks.map((w) => w.dakota ?? null),
+      );
+      const utahSeries = gapSafe(
+        heroFilteredWeeks.map((w) => w.utah ?? null),
+      );
 
       return {
         xAxis: {
@@ -242,6 +248,28 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
             symbolSize: 6,
             itemStyle: { color: "#bc8cff" },
             lineStyle: { width: 3, color: "#bc8cff", type: [6, 3] },
+            connectNulls: false,
+          },
+          {
+            name: "Dakota",
+            type: "line",
+            data: dakotaSeries,
+            smooth: true,
+            showSymbol: true,
+            symbolSize: 6,
+            itemStyle: { color: "#39d2c0" },
+            lineStyle: { width: 3, color: "#39d2c0", type: [2, 2] },
+            connectNulls: false,
+          },
+          {
+            name: "Utah",
+            type: "line",
+            data: utahSeries,
+            smooth: true,
+            showSymbol: true,
+            symbolSize: 6,
+            itemStyle: { color: "#f0883e" },
+            lineStyle: { width: 3, color: "#f0883e", type: [1, 2] },
             connectNulls: false,
           },
         ],
@@ -342,6 +370,22 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
           connectNulls: false,
           itemStyle: { color: seriesColor(1) },
           lineStyle: { type: seriesDash(1) },
+        },
+        {
+          name: "Dakota",
+          type: "line",
+          data: gapSafe(filteredWeeks.map((w) => w.dakota ?? null)),
+          connectNulls: false,
+          itemStyle: { color: "#39d2c0" },
+          lineStyle: { type: seriesDash(3) },
+        },
+        {
+          name: "Utah",
+          type: "line",
+          data: gapSafe(filteredWeeks.map((w) => w.utah ?? null)),
+          connectNulls: false,
+          itemStyle: { color: "#f0883e" },
+          lineStyle: { type: seriesDash(4) },
         },
       );
     } else {


### PR DESCRIPTION
## Problem
The `/analytics` hero `By Edition` split mode and comparative `Workstations` mode only defined chart series for Bluefin Flagship and Bluefin LTS, even though the unified fleet total calculation already includes Dakota and Utah data.

## Fix
Added Dakota and Utah series to:
- The hero chart's split mode (`heroChartOption`)
- The comparative chart's `workstations` view mode (`comparativeChartOption`)

Both split-mode series sets now reconcile with the unified fleet totals shown elsewhere in the same component.

Fixes #1084

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `c8c24416`