### PR TITLE
fix(sbom): add Bluefin LTS NVIDIA stream and retire dx/gdx package queries

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -32,7 +32,7 @@
  *    parsed for RPM artifacts to extract packageVersions.
  *  - SBOM cache: keyed by image digest — if the digest hasn't changed AND
  *    packageVersions is non-null, the existing cache entry is reused.
- *  - NVIDIA: present in GDX (bluefin-gdx-lts) SBOM as nvidia-driver RPM.
+ *  - NVIDIA: present in bluefin-lts-nvidia SBOM as nvidia-driver RPM.
  *    Absent from base bluefin-stable/lts SBOMs (akmod, built separately).
  *    fetch-github-driver-versions.js uses null for nvidia on stable/lts streams.
  *  - Atomic write: output is written to a temp file then renamed to avoid
@@ -203,76 +203,13 @@ const RAW_STREAM_SPECS = [
     keyRepo: "projectbluefin/bluefin-lts",
   },
   {
-    id: "bluefin-dx-stable",
-    label: "Bluefin DX Stable",
+    id: "bluefin-lts-nvidia",
+    label: "Bluefin LTS Nvidia",
     org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin",
+    package: "bluefin-lts-nvidia",
+    releasesRepo: "projectbluefin/bluefin-lts",
     streamPrefix: "stable",
-    keyRepo: "projectbluefin/bluefin",
-  },
-  {
-    id: "bluefin-dx-latest",
-    label: "Bluefin DX Latest",
-    org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin",
-    streamPrefix: "latest",
-    keyRepo: "projectbluefin/bluefin",
-  },
-  {
-    id: "bluefin-dx-lts",
-    label: "Bluefin DX LTS",
-    org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin-lts",
-    streamPrefix: "lts",
     keyRepo: "projectbluefin/bluefin-lts",
-  },
-  {
-    id: "bluefin-dx-lts-hwe-testing",
-    label: "Bluefin DX LTS HWE Testing",
-    org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin-lts",
-    streamPrefix: "lts-hwe-testing",
-    keyRepo: "projectbluefin/bluefin-lts",
-  },
-  {
-    id: "bluefin-dx-lts-hwe-testing-50",
-    label: "Bluefin DX LTS HWE Testing 50",
-    org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin-lts",
-    streamPrefix: "lts-hwe-testing-50",
-    keyRepo: "projectbluefin/bluefin-lts",
-  },
-  {
-    id: "bluefin-dx-lts-testing-50",
-    label: "Bluefin DX LTS Testing 50",
-    org: "projectbluefin",
-    package: "bluefin-dx",
-    releasesRepo: "projectbluefin/bluefin-lts",
-    streamPrefix: "lts-testing-50",
-    keyRepo: "projectbluefin/bluefin-lts",
-  },
-  {
-    id: "bluefin-gdx-lts",
-    label: "Bluefin GDX LTS",
-    org: "projectbluefin",
-    package: "bluefin-gdx",
-    releasesRepo: "projectbluefin/bluefin-lts",
-    streamPrefix: "lts",
-    keyRepo: "projectbluefin/bluefin-lts",
-  },
-  {
-    id: "bluefin-gdx-latest",
-    label: "Bluefin GDX Latest",
-    org: "projectbluefin",
-    package: "bluefin-gdx",
-    releasesRepo: "projectbluefin/bluefin",
-    streamPrefix: "latest",
-    keyRepo: "projectbluefin/bluefin",
   },
   {
     id: "bluefin-nvidia-open-stable",


### PR DESCRIPTION
## Summary

Fixes #1078.

`STREAM_SPECS` in `scripts/fetch-github-sbom.js` queried the retired `bluefin-dx` and `bluefin-gdx` GHCR packages (confirmed 404 on GHCR) across eight stream entries, but never defined a `bluefin-lts-nvidia` stream — even though `fetch-github-images.js` (`nvidiaSbomStreamId: "bluefin-lts-nvidia"`) and `fetch-github-driver-versions.js` (`buildNvidiaMapFromSbomStream(sbomCache, "bluefin-lts-nvidia")`) already look up that stream id. The LTS NVIDIA driver version therefore had no SBOM source.

## Changes

- `scripts/fetch-github-sbom.js`: replace the eight retired `bluefin-dx-stable`, `bluefin-dx-latest`, `bluefin-dx-lts`, `bluefin-dx-lts-hwe-testing`, `bluefin-dx-lts-hwe-testing-50`, `bluefin-dx-lts-testing-50`, `bluefin-gdx-lts`, and `bluefin-gdx-latest` entries (querying the dead `bluefin-dx`/`bluefin-gdx` packages) with a single `bluefin-lts-nvidia` entry using package `bluefin-lts-nvidia` and stream prefix `stable`.
- Updated a stale doc comment referencing the retired GDX stream.

## Verification

- Confirmed `ghcr.io/projectbluefin/bluefin-dx` and `ghcr.io/projectbluefin/bluefin-gdx` both 404 on GHCR (anonymous token + tags/list).
- Confirmed `ghcr.io/projectbluefin/bluefin-lts-nvidia` carries a live `stable` tag on GHCR.
- Confirmed via `projectbluefin/bluefin-lts`'s `execute-release.yml` that `bluefin-lts-nvidia:testing` → `:stable` is the promotion path, matching the `bluefin-lts` entry's existing convention in this file.
- `node --test scripts/fetch-github-sbom.test.js scripts/fetch-github-driver-versions.test.js scripts/fetch-github-images.test.js` — 65 passed.
- `npx eslint scripts/fetch-github-sbom.js` — clean.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `cee1b0c6`