### PR TITLE
fix(analytics): calculate and format hero deltas for the selected range

### DIFF
--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -134,21 +134,24 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
     return weeks;
   }, [weeks, heroRange]);
 
-  // Delta calculation for Bluefin fleet
-  const firstWeek = weeks[0] || ({} as CountmeWeek);
+  // Delta calculation for Bluefin fleet, baselined to the first week of the
+  // currently selected hero range (not the entire history).
+  const firstHeroWeek = heroFilteredWeeks[0] || ({} as CountmeWeek);
   const initialTotalBluefin =
-    (Number(firstWeek.bluefin) || 0) +
-      (Number(firstWeek["bluefin-lts"]) || 0) +
-      (Number(firstWeek.dakota) || 0) +
-      (Number(firstWeek.utah) || 0) || currentTotalBluefin;
+    (Number(firstHeroWeek.bluefin) || 0) +
+      (Number(firstHeroWeek["bluefin-lts"]) || 0) +
+      (Number(firstHeroWeek.dakota) || 0) +
+      (Number(firstHeroWeek.utah) || 0) || currentTotalBluefin;
 
-  const bluefinDeltaPct =
+  const bluefinDeltaPctValue =
     initialTotalBluefin > 0
-      ? (
-          ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
-          100
-        ).toFixed(1)
-      : "0.0";
+      ? ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
+        100
+      : 0;
+
+  const bluefinDeltaPct = bluefinDeltaPctValue.toFixed(1);
+  const bluefinDeltaPctSigned =
+    bluefinDeltaPctValue >= 0 ? `+${bluefinDeltaPct}` : bluefinDeltaPct;
 
   // Filtered weeks for comparative time-series charts
   const filteredWeeks = useMemo(() => {
@@ -440,7 +443,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
             </div>
             <div className={styles.heroMeta}>
               <span style={{ fontWeight: 700, color: "#39d2c0" }}>
-                +{bluefinDeltaPct}% overall
+                {bluefinDeltaPctSigned}% overall
               </span>
               <span>latest week ({latestWeek.week})</span>
             </div>
@@ -486,7 +489,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
         <EChart
           option={heroChartOption}
           title="Bluefin Systems"
-          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
+          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, ${bluefinDeltaPctValue >= 0 ? "up" : "down"} ${Math.abs(bluefinDeltaPctValue).toFixed(1)}% across ${heroFilteredWeeks.length} tracked weeks.`}
           points={realHeroPoints}
           minPoints={2}
           height={320}


### PR DESCRIPTION
## Problem
The analytics hero formats deltas as `+${bluefinDeltaPct}%` and calculates the starting total from the all-time first week rather than the first displayed week.

A negative delta rendered as `+-4.2%`, and switching between the 12-week/24-week ranges left the delta baseline tied to the complete history instead of the selected range.

## Fix
- Baseline `bluefinDeltaPct` on `heroFilteredWeeks[0]` (the first week of the selected hero range) instead of `weeks[0]` (all-time first week).
- Format the sign conditionally: prepend `+` only when the delta is non-negative, so negative deltas render as `-4.2%` instead of `+-4.2%`.
- Updated the chart summary text to use direction-aware wording (`up`/`down`) and the selected range's week count.

Fixes #1087

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b7347107`