### PR TITLE
fix(factory): calculate merged-this-week from merged pull requests

### DIFF
--- a/scripts/fetch-hive-live-data.js
+++ b/scripts/fetch-hive-live-data.js
@@ -107,6 +107,7 @@ const [
   openIssuesData,
   openPRsData,
   agentReadyData,
+  mergedWeekData,
 ] = await Promise.all([
   safeSearch(`org:${org} type:pr is:merged`, 30),
   safeSearch(`org:${org} type:issue is:open -label:queue/agent-ready -label:source:agent`, 25),
@@ -121,6 +122,7 @@ const [
   safeSearch(`org:${org} state:open type:issue`, 1),
   safeSearch(`org:${org} state:open type:pr`, 1),
   safeSearch(`org:${org} label:queue/agent-ready state:open`, 1),
+  safeSearch(`org:${org} type:pr is:merged merged:>${weekAgo}`, 1),
 ]);
 
 function mapItem(i) {
@@ -156,7 +158,7 @@ const output = {
     totalRepos: orgData.public_repos ?? 0,
     openIssues: openIssuesData.total_count ?? 0,
     openPRs: openPRsData.total_count ?? 0,
-    mergedThisWeek: closedData.total_count ?? 0,
+    mergedThisWeek: mergedWeekData.total_count ?? 0,
     agentReadyIssues: agentReadyData.total_count ?? 0,
     agentOpenPRs: hivePRData.total_count ?? 0,
     sourceAgentOpen: copilotPRData.total_count ?? 0,


### PR DESCRIPTION
## Problem
`scripts/fetch-hive-live-data.js` populated `mergedThisWeek` from a query for closed issues instead of merged pull requests, causing the dashboard to significantly undercount merges (113 closed issues vs 313 merged PRs in the same window).

## Fix
Add a dedicated `type:pr is:merged merged:>${weekAgo}` search and use its `total_count` for `orgStats.mergedThisWeek`, leaving the existing closed-issues query untouched for `velocity.closed`.

Closes #1088

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d6ad7902`