### PR TITLE
fix(factory): replace the Hive snapshot CTA hostname with a valid TLS endpoint

### DIFF
--- a/src/components/factory/panels/HiveSnapshot.tsx
+++ b/src/components/factory/panels/HiveSnapshot.tsx
@@ -4,7 +4,7 @@ import styles from "./HiveSnapshot.module.css";
 
 /** The hive instance whose read-only snapshot this links to. */
 const SNAPSHOT_URL =
-  "https://hosted-projectbluefin-common-nmq5.hive.kubestellar.io/snapshot";
+  "https://hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot";
 
 /**
  * A link to the hive's own read-only dashboard snapshot.


### PR DESCRIPTION
## Problem

`src/components/factory/panels/HiveSnapshot.tsx` linked to `hosted-projectbluefin-common-nmq5.hive.kubestellar.io`, whose TLS certificate does not cover that hostname (SAN only covers `hive.hivecommons.dev`), so `curl -I` fails certificate verification.

## Fix

Point the CTA at `hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot`, the same hosted instance served under a hostname that matches its certificate. Verified with `curl -I` that this endpoint returns `HTTP/2 200` with a valid TLS handshake.

Fixes #1089

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `fcef4bb9`