### PR TITLE
fix(factory): use a public queue-data fallback for anonymous visitors

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
           "style-src 'self' 'unsafe-inline'",
           "img-src 'self' data: https:",
           "font-src 'self' data:",
-          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://queue.projectbluefin.io https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io https://hive.kubestellar.io",
+          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://projectbluefin.github.io https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io https://hive.kubestellar.io",
           "frame-src https://giscus.app https://www.youtube.com https://youtube.com https://insights.linuxfoundation.org",
         ].join("; "),
       },

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -541,9 +541,12 @@ const HOSTED_INSTANCE_URL =
 // The old raw.githubusercontent.com HTML snapshot is no longer published.
 const SNAPSHOT_API_URL = `${HOSTED_INSTANCE_URL}/api/status`;
 
-// Queue data: try the hosted instance first (credentials:include), fall back to public mirror
+// Queue data: try the hosted instance first (credentials:include), fall back to public mirror.
+// The public mirror is the queue-feed skill's canonical endpoint (see
+// projectbluefin/common docs/skills/queue-feed.md) — queue.projectbluefin.io/data.json
+// 404s, so anonymous visitors need this URL instead.
 const QUEUE_URL_HOSTED = `${HOSTED_INSTANCE_URL}/data.json`;
-const QUEUE_URL_FALLBACK = "https://queue.projectbluefin.io/data.json";
+const QUEUE_URL_FALLBACK = "https://projectbluefin.github.io/review/queue.json";
 const GH_API = "https://api.github.com";
 const DAKOTA = "projectbluefin/dakota";
 const BUILD_WORKFLOW = "246164114";
@@ -917,6 +920,44 @@ async function fetchTimeout(
   }
 }
 
+// Shape of the public queue-feed mirror (projectbluefin/common docs/skills/queue-feed.md):
+// a flat list of PR review-queue items. It carries no P0/P1 issue triage or victory-log
+// data, so those QueueData sections stay empty when only this fallback is available.
+interface PublicQueueItem {
+  repository: string;
+  url: string;
+  title: string;
+  updated_at: string;
+  labels?: string[];
+}
+
+interface PublicQueueFeed {
+  generated_at: string;
+  items: PublicQueueItem[];
+}
+
+function normalizePublicQueueFeed(feed: PublicQueueFeed): QueueData {
+  const prs: QueuePR[] = (feed.items ?? []).map((item) => ({
+    title: item.title,
+    html_url: item.url,
+    repository_url: `https://api.github.com/repos/${item.repository}`,
+    updated_at: item.updated_at,
+    labels: (item.labels ?? []).map((name) => ({ name, color: "" })),
+  }));
+  return {
+    generated: feed.generated_at,
+    repos: Array.from(new Set((feed.items ?? []).map((i) => i.repository))),
+    issues: { p0: [], p1: [] },
+    prs: { approved: [], required: prs, none: [] },
+    victories: {
+      startDate: feed.generated_at,
+      dreams: { count: 0, recent: [] },
+      relief: { count: 0, recent: [] },
+      toil: { count: 0, recent: [] },
+    },
+  };
+}
+
 // Fetch queue data from the hosted instance first (works when the user has an active
 // hive.kubestellar.io session), falling back to the public mirror.
 async function fetchQueueData(): Promise<QueueData | null> {
@@ -930,7 +971,8 @@ async function fetchQueueData(): Promise<QueueData | null> {
   }
   try {
     const r = await fetchTimeout(QUEUE_URL_FALLBACK, 10000);
-    if (r.ok) return (await r.json()) as QueueData;
+    if (r.ok)
+      return normalizePublicQueueFeed((await r.json()) as PublicQueueFeed);
   } catch {
     // both sources unavailable
   }


### PR DESCRIPTION
## Problem

`HiveFactoryDashboard.tsx` falls back to `https://queue.projectbluefin.io/data.json` when the hosted Hive instance requires login, but that URL 404s — anonymous visitors get no queue data at all.

## Fix

- Point `QUEUE_URL_FALLBACK` at the queue-feed skill's canonical public mirror, `https://projectbluefin.github.io/review/queue.json` (documented in `projectbluefin/common` `docs/skills/queue-feed.md`), which returns 200.
- That feed's schema is a flat PR list, not the hosted instance's `QueueData` shape, so add `normalizePublicQueueFeed()` to convert it and avoid crashing the dashboard on the mismatched shape. The public feed has no P0/P1 issue triage or victory-log data, so those sections stay empty when only this fallback is available (no regression — they render the same as when `queueData` is `null`).
- Update the CSP `connect-src` allowlist to permit `https://projectbluefin.github.io` instead of the dead `https://queue.projectbluefin.io` origin.

## Verification

- `npm run typecheck` — no new errors (one pre-existing, unrelated error for a build-time generated data file).
- `npx eslint src/components/HiveFactoryDashboard.tsx docusaurus.config.ts` — no new warnings/errors.
- Confirmed via `curl` that `queue.projectbluefin.io/data.json` returns 404 and `https://projectbluefin.github.io/review/queue.json` returns 200.

Fixes #1090

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `33b5b318`