### PR TITLE
fix(factory): render an unavailable change-failure rate instead of 0.0 percent

### DIFF
--- a/scripts/metrics-panels.test.js
+++ b/scripts/metrics-panels.test.js
@@ -436,6 +436,21 @@ function render(fixtures) {
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
+test("null change failure rate renders unavailable marker, never 0.0%", () => {
+  const doraNullRate = {
+    ...DORA,
+    current: { ...DORA.current, changeFailureRate: null },
+  };
+  const html = render({
+    countme: COUNTME_FULL,
+    brew: BREW,
+    dora: doraNullRate,
+    scorecard: SCORECARD,
+  });
+  assert.ok(!html.includes("0.0%"));
+  assert.ok(html.includes("—"));
+});
+
 test("lead time renders as not-measured, never as 0", () => {
   const html = render({
     countme: COUNTME_FULL,

--- a/src/components/factory/panels/MetricsPanels.tsx
+++ b/src/components/factory/panels/MetricsPanels.tsx
@@ -61,7 +61,7 @@ interface DoraMonthly {
 }
 interface DoraCurrent {
   deploymentsPerWeek: number;
-  changeFailureRate: number;
+  changeFailureRate: number | null;
   medianLeadTimeHours: number | null;
   leadTimeReason?: string;
 }
@@ -113,7 +113,8 @@ function fmt(n: number | null | undefined): string {
   return n.toLocaleString("en-US");
 }
 
-function pct(n: number): string {
+function pct(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "—";
   return `${(n * 100).toFixed(1)}%`;
 }
 


### PR DESCRIPTION
## Problem

`pct(n)` in `MetricsPanels.tsx` multiplied `null` by 100, so when `fetch-dora.js` deliberately emits `null` for `changeFailureRate` (no terminal runs exist), the UI rendered a misleading `0.0%`.

## Fix

`pct()` now treats `null`/`undefined`/non-finite inputs as unavailable and renders `—`, reserving `0.0%` for real measured values. Updated the `DoraCurrent.changeFailureRate` type to `number | null` to reflect what `fetch-dora.js` actually produces.

## Testing

- Added a test in `scripts/metrics-panels.test.js` asserting a `null` `changeFailureRate` renders `—` and never `0.0%`.
- `node --test scripts/metrics-panels.test.js` — all 12 tests pass.

Fixes #1091

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b8bb3b48`