### PR TITLE
fix(pin-state): replace removed Bluefin LTS HWE workflow paths

### DIFF
--- a/scripts/fetch-pin-state.js
+++ b/scripts/fetch-pin-state.js
@@ -1,8 +1,9 @@
 /**
  * fetch-pin-state.js
  *
- * Reads bluefin-lts HWE workflow YAML files from the GitHub Contents API
- * and extracts any `kernel-pin` (or future `*-pin`) workflow inputs.
+ * Reads the active bluefin-lts build workflow YAML from the GitHub Contents
+ * API and extracts any `kernel_pin` (or future `*_pin`) input passed to the
+ * shared projectbluefin/actions reusable-build.yml workflow.
  * Writes static/data/stream-pins.json consumed by the docs UI to render
  * 📌 "Pinned" badges next to intentionally-held component versions.
  *
@@ -17,12 +18,10 @@ const OUTPUT_FILE = path.join(__dirname, "..", "static", "data", "stream-pins.js
 const WORKFLOWS_TO_CHECK = [
   {
     repo: "projectbluefin/bluefin-lts",
-    path: ".github/workflows/build-regular-hwe.yml",
-    stream: "bluefin-lts",
-  },
-  {
-    repo: "projectbluefin/bluefin-lts",
-    path: ".github/workflows/build-dx-hwe.yml",
+    // bluefin-lts is HWE-only (no separate build-regular-hwe.yml/build-dx-hwe.yml
+    // since #437); build-regular.yml is the active workflow and passes an optional
+    // `kernel_pin` input to the shared reusable-build.yml when a kernel is pinned.
+    path: ".github/workflows/build-regular.yml",
     stream: "bluefin-lts",
   },
 ];
@@ -47,11 +46,11 @@ async function fetchWorkflowContent(repo, filePath) {
 }
 
 /**
- * Extract `kernel-pin` value from a workflow YAML string.
- * Matches the pattern:   kernel-pin: <version>
+ * Extract `kernel_pin` value from a workflow YAML string.
+ * Matches the pattern:   kernel_pin: <version>
  */
 function extractKernelPin(yamlContent) {
-  const match = yamlContent.match(/kernel-pin:\s*([^\s\n#]+)/);
+  const match = yamlContent.match(/kernel_pin:\s*([^\s\n#]+)/);
   return match ? match[1].trim() : null;
 }
 
@@ -89,7 +88,7 @@ async function main() {
       if (kernelPin) {
         console.log(`  ${stream} hweKernel pin: ${kernelPin}`);
       } else {
-        console.log(`  ${stream}: no kernel-pin found (floating)`);
+        console.log(`  ${stream}: no kernel_pin found (floating)`);
       }
     } catch (err) {
       console.warn(`  Warning: could not fetch ${repo}/${filePath}: ${err.message}`);

--- a/scripts/fetch-pin-state.test.js
+++ b/scripts/fetch-pin-state.test.js
@@ -6,21 +6,21 @@ const {
   extractKernelPin,
 } = require("./fetch-pin-state.js");
 
-test("extractKernelPin reads kernel-pin values and ignores missing pins", () => {
-  assert.equal(extractKernelPin("kernel-pin: 6.12.30-204 # comment"), "6.12.30-204");
-  assert.equal(extractKernelPin("name: build-regular-hwe"), null);
+test("extractKernelPin reads kernel_pin values and ignores missing pins", () => {
+  assert.equal(extractKernelPin("kernel_pin: 6.12.30-204 # comment"), "6.12.30-204");
+  assert.equal(extractKernelPin("name: build-regular"), null);
 });
 
 test("applyKernelPin stores a stream pin and rejects conflicting values", () => {
   const streamPins = {};
 
-  applyKernelPin(streamPins, "bluefin-lts", "6.12.30-204", "build-regular-hwe.yml");
+  applyKernelPin(streamPins, "bluefin-lts", "6.12.30-204", "build-regular.yml");
   assert.deepEqual(streamPins, {
     "bluefin-lts": { hweKernel: "6.12.30-204" },
   });
 
   assert.throws(
-    () => applyKernelPin(streamPins, "bluefin-lts", "6.12.31-204", "build-dx-hwe.yml"),
+    () => applyKernelPin(streamPins, "bluefin-lts", "6.12.31-204", "build-regular.yml"),
     /Conflicting hweKernel pins/,
   );
 });

--- a/static/data/stream-pins.json
+++ b/static/data/stream-pins.json
@@ -1,6 +1,7 @@
 {
-  "generatedAt": "2026-07-21T05:48:34.788Z",
+  "generatedAt": "2026-09-08T15:03:46.365Z",
   "streams": {
+    "bluefin-lts": {},
     "bluefin-stable": {}
   }
 }


### PR DESCRIPTION
## Problem

`scripts/fetch-pin-state.js` requested `build-regular-hwe.yml` and `build-dx-hwe.yml` from `projectbluefin/bluefin-lts`. Both paths were deleted when bluefin-lts went all-in on the HWE/coreos-stable kernel for every build variant (`ublue-os/bluefin-lts#437`, "This straight up removes the `-hwe` images and makes it so all images are now `-hwe`"). Every script run hit a 404 for both paths and the `bluefin-lts` stream never populated in `static/data/stream-pins.json`.

## Fix

- Point the script at `build-regular.yml`, the currently active build workflow in `bluefin-lts`, which calls the shared `projectbluefin/actions` `reusable-build.yml` workflow.
- That reusable workflow's optional pin input is `kernel_pin` (underscore), not `kernel-pin` (hyphen) as the old HWE-era workflows used — updated the extraction regex and doc comments to match.
- Updated `fetch-pin-state.test.js` to cover the new key name and current workflow filename.
- Regenerated `static/data/stream-pins.json`: the `bluefin-lts` stream now correctly appears (empty/floating, since `build-regular.yml` currently passes no `kernel_pin`) instead of silently failing to populate at all.

## Verification

- `node --test scripts/fetch-pin-state.test.js` passes.
- Ran `node scripts/fetch-pin-state.js` live against the real GitHub API — no more 404s, `bluefin-lts` stream correctly reports as floating.
- `npx eslint scripts/fetch-pin-state.js scripts/fetch-pin-state.test.js` is clean.

Fixes #1092.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `2529b59b`