### PR TITLE
fix(gnome-extensions): render missing and unavailable extension data states

### DIFF
--- a/scripts/fetch-gnome-extensions.js
+++ b/scripts/fetch-gnome-extensions.js
@@ -125,6 +125,23 @@ async function fetchExtensionData(pk) {
   return buildExtensionRecord(pk, data, localScreenshot);
 }
 
+/**
+ * Per the repo's data-pipeline rules (AGENTS.md), a fetch script must never
+ * fail the build: no throw, no non-zero exit, no silently empty file. On
+ * error it writes this explicit unavailable payload instead, so consumers
+ * (e.g. GnomeExtensions.tsx) can render a visible reason rather than hang at
+ * "Loading...".
+ */
+function unavailablePayload(reason) {
+  return { unavailable: true, stateReason: reason };
+}
+
+function writeUnavailable(reason) {
+  console.warn(`fetch-gnome-extensions: ${reason} — writing unavailable payload`);
+  fs.mkdirSync(path.dirname(OUTPUT_JSON), { recursive: true });
+  fs.writeFileSync(OUTPUT_JSON, JSON.stringify(unavailablePayload(reason), null, 2));
+}
+
 async function main() {
   if (!isStale(OUTPUT_JSON)) return;
 
@@ -140,8 +157,8 @@ async function main() {
   }
 
   if (extensions.length === 0) {
-    console.error("All extension fetches failed — aborting.");
-    process.exit(1);
+    writeUnavailable("All GNOME extension fetches failed");
+    return;
   }
   if (extensions.length < EXTENSION_IDS.length) {
     console.warn(`Warning: only ${extensions.length}/${EXTENSION_IDS.length} extensions fetched.`);
@@ -152,10 +169,14 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().catch((e) => { console.error(e); process.exit(1); });
+  main().catch((e) => {
+    console.error(e);
+    writeUnavailable(`GNOME extension data could not be generated: ${e.message}`);
+  });
 }
 
 module.exports = {
   buildExtensionRecord,
   isStale,
+  unavailablePayload,
 };

--- a/scripts/fetch-gnome-extensions.test.js
+++ b/scripts/fetch-gnome-extensions.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const {
   buildExtensionRecord,
   isStale,
+  unavailablePayload,
 } = require("./fetch-gnome-extensions.js");
 
 test("buildExtensionRecord normalizes remote GNOME extension fields", () => {
@@ -40,4 +41,11 @@ test("isStale returns true when the cache file does not exist", () => {
     isStale(path.join(__dirname, "..", "static", "data", "missing-gnome-extensions.json")),
     true,
   );
+});
+
+test("unavailablePayload emits the documented unavailable-object shape", () => {
+  assert.deepEqual(unavailablePayload("All GNOME extension fetches failed"), {
+    unavailable: true,
+    stateReason: "All GNOME extension fetches failed",
+  });
 });

--- a/src/components/GnomeExtensions.tsx
+++ b/src/components/GnomeExtensions.tsx
@@ -15,43 +15,86 @@ interface ExtensionData {
   donateUrl: string | null;
 }
 
+/**
+ * scripts/fetch-gnome-extensions.js never fails the build: on error it writes
+ * `{ unavailable: true, stateReason }` instead of the extension array (see
+ * AGENTS.md → Data pipelines). This must be checked before treating the
+ * payload as an array, or a plain `.find()` throws.
+ */
+interface UnavailablePayload {
+  unavailable: true;
+  stateReason: string;
+}
+
+type ExtensionsResponse = ExtensionData[] | UnavailablePayload;
+
+function isUnavailablePayload(
+  data: ExtensionsResponse,
+): data is UnavailablePayload {
+  return !Array.isArray(data) && data?.unavailable === true;
+}
+
 interface GnomeExtensionsProps {
   extensionId: number;
 }
 
+type LoadState =
+  | { status: "loading" }
+  | { status: "found"; extension: ExtensionData }
+  | { status: "not-found" }
+  | { status: "unavailable"; reason: string };
+
 const GnomeExtensions: React.FC<GnomeExtensionsProps> = ({ extensionId }) => {
-  const [extension, setExtension] = useState<ExtensionData | null>(null);
+  const [state, setState] = useState<LoadState>({ status: "loading" });
   const [imageError, setImageError] = useState(false);
-  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     fetch("/data/gnome-extensions.json")
       .then((response) => response.json())
-      .then((data: ExtensionData[]) => {
-        const ext = data.find((item) => item.id === extensionId);
-        if (ext) {
-          setExtension(ext);
+      .then((data: ExtensionsResponse) => {
+        if (isUnavailablePayload(data)) {
+          setState({ status: "unavailable", reason: data.stateReason });
+          return;
         }
+        const ext = data.find((item) => item.id === extensionId);
+        setState(ext ? { status: "found", extension: ext } : { status: "not-found" });
       })
       .catch((error) => {
         console.error("Error loading extension metadata:", error);
-        setLoadError(true);
+        setState({
+          status: "unavailable",
+          reason: "Extension data could not be loaded.",
+        });
       });
   }, [extensionId]);
 
-  if (loadError) {
+  if (state.status === "unavailable") {
     return (
       <div className={styles.extensionBox}>
         <div className={styles.extensionInfo}>
-          <p className={styles.extensionDescription}>Extension data unavailable.</p>
+          <p className={styles.extensionDescription}>{state.reason}</p>
         </div>
       </div>
     );
   }
 
-  if (!extension) {
+  if (state.status === "not-found") {
+    return (
+      <div className={styles.extensionBox}>
+        <div className={styles.extensionInfo}>
+          <p className={styles.extensionDescription}>
+            Extension data unavailable.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "loading") {
     return <div className={styles.extensionBox}>Loading...</div>;
   }
+
+  const extension = state.extension;
 
   const thumbnailUrl = extension.screenshot || extension.remoteScreenshot;
   // Truncate to first line, then cap at 150 chars if still too long


### PR DESCRIPTION
## Summary

Fixes #1095.

`GnomeExtensions.tsx` (the single-extension card used in docs like `tips.mdx`)
never transitioned out of `Loading...` when the requested `extensionId` was
absent from the generated array, and it would throw if the fetch script ever
emitted the repo's documented unavailable payload (`{ unavailable: true,
stateReason }`, per `AGENTS.md` → Data pipelines) instead of an array, since
`.find()` isn't defined on that shape.

Separately, `scripts/fetch-gnome-extensions.js` violated that same documented
rule: when every extension fetch failed it called `console.error` +
`process.exit(1)`, failing the build, instead of writing the unavailable
payload and exiting 0 like every other `fetch-*.js` script in this repo.

## Changes

- `src/components/GnomeExtensions.tsx`: replaced the single nullable
  `extension` state with an explicit `loading | found | not-found |
  unavailable` state machine. The unavailable payload is now detected via a
  type guard *before* calling `.find()`, and a not-found id renders a message
  instead of hanging at `Loading...` forever.
- `scripts/fetch-gnome-extensions.js`: added `unavailablePayload()` /
  `writeUnavailable()`, used both when all extension fetches fail and in the
  top-level `catch`, so the script never exits non-zero and always leaves a
  valid, visible-reason JSON file behind.
- `scripts/fetch-gnome-extensions.test.js`: added a test for the new
  `unavailablePayload()` export.

## Verification

- [x] `npm test` (486/486 passing)
- [x] `npx tsc --noEmit` — no new errors (one pre-existing, unrelated error in
      `MusicPlaylist.tsx`)
- [x] `npx eslint src/components/GnomeExtensions.tsx
      scripts/fetch-gnome-extensions.js scripts/fetch-gnome-extensions.test.js`
      — 0 errors, only pre-existing Docusaurus-link/heading warnings

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `2a8eefab`