### PR TITLE
fix(feed-items): supply NVIDIA versions at the data shape the release feed consumes

### DIFF
--- a/scripts/fetch-firehose.js
+++ b/scripts/fetch-firehose.js
@@ -1,10 +1,39 @@
 const fs = require("fs");
 const path = require("path");
 
+const {
+  buildNvidiaMapFromSbomStream,
+  buildLtsNvidiaByTagFromSbom,
+  resolveCompanionNvidia,
+} = require("./fetch-github-driver-versions.js");
+
 const OUTPUT_DIR = path.join(__dirname, "..", "static", "data");
 const OUTPUT_FILE = path.join(OUTPUT_DIR, "firehose-apps.json");
 const SBOM_FILE = path.join(OUTPUT_DIR, "sbom-attestations.json");
 const SOURCE_URL = "https://castrojo.github.io/bluefin-releases/apps.json";
+
+/**
+ * Per-OS-stream builders for the companion NVIDIA release map.
+ * NVIDIA ships as an akmod built outside the OS image (not in Syft scans),
+ * so its version has to be looked up from a companion SBOM stream — same
+ * approach fetch-github-driver-versions.js uses for the Driver Versions page.
+ */
+const NVIDIA_MAP_BUILDER_BY_STREAM = {
+  "bluefin-stable": (sbomCache) =>
+    buildNvidiaMapFromSbomStream(sbomCache, "bluefin-nvidia-open-stable"),
+  "bluefin-lts": (sbomCache) => buildLtsNvidiaByTagFromSbom(sbomCache),
+};
+
+/**
+ * Resolve the NVIDIA driver version for a release entry of a given OS stream.
+ * Returns null when the stream has no companion NVIDIA map or no match is found.
+ */
+function resolveNvidiaVersion(streamId, sbomCache, releaseEntry, cacheKey) {
+  const buildMap = NVIDIA_MAP_BUILDER_BY_STREAM[streamId];
+  if (!buildMap) return null;
+  const nvidiaByTag = buildMap(sbomCache);
+  return resolveCompanionNvidia(nvidiaByTag, releaseEntry, cacheKey);
+}
 
 // Cache configuration — match the 6h pipeline schedule of bluefin-releases.
 // Set FIREHOSE_CACHE_HOURS=0 to always fetch (used in CI via pages.yml).
@@ -69,7 +98,7 @@ function sortedReleases(stream) {
  * Build a FirehoseOsInfo object from a SBOM packageVersions record.
  * Returns null if packageVersions is absent.
  */
-function buildOsInfo(streamId, packageVersions) {
+function buildOsInfo(streamId, packageVersions, nvidiaVersion = null) {
   if (!packageVersions) return null;
 
   const info = { stream: streamId };
@@ -83,6 +112,8 @@ function buildOsInfo(streamId, packageVersions) {
   if (packageVersions.podman) majorPackages["Podman"] = packageVersions.podman;
   if (packageVersions.systemd) majorPackages["systemd"] = packageVersions.systemd;
   if (packageVersions.bootc) majorPackages["bootc"] = packageVersions.bootc;
+  const nvidia = packageVersions.nvidia || nvidiaVersion;
+  if (nvidia) majorPackages["NVIDIA"] = nvidia;
 
   if (Object.keys(majorPackages).length > 0) {
     info.majorPackages = majorPackages;
@@ -157,7 +188,13 @@ function buildOsApp(spec, sbomCache) {
       currentReleaseDate = `${currentReleaseVersion}T00:00:00Z`;
       updatedAt = currentReleaseDate;
     }
-    osInfo = buildOsInfo(spec.streamId, latestWithVersions.packageVersions);
+    const nvidiaVersion = resolveNvidiaVersion(
+      spec.streamId,
+      sbomCache,
+      latestWithVersions,
+      latestWithVersions.cacheKey,
+    );
+    osInfo = buildOsInfo(spec.streamId, latestWithVersions.packageVersions, nvidiaVersion);
   } else if (releases.length > 0) {
     // Have releases but none with packageVersions yet (SBOM not populated for this entry)
     const first = releases[0];

--- a/scripts/fetch-firehose.test.js
+++ b/scripts/fetch-firehose.test.js
@@ -42,6 +42,61 @@ test("buildOsInfo keeps core OS versions and major packages", () => {
   });
 });
 
+test("buildOsInfo includes NVIDIA when packageVersions has it directly", () => {
+  const info = buildOsInfo("bluefin-stable", {
+    kernel: "6.14.0",
+    podman: "5.4",
+    nvidia: "580.65.06",
+  });
+
+  assert.equal(info.majorPackages.NVIDIA, "580.65.06");
+});
+
+test("buildOsInfo includes NVIDIA from the companion-stream lookup fallback", () => {
+  const info = buildOsInfo(
+    "bluefin-stable",
+    { kernel: "6.14.0", podman: "5.4" },
+    "580.65.06",
+  );
+
+  assert.equal(info.majorPackages.NVIDIA, "580.65.06");
+});
+
+test("buildOsApp resolves NVIDIA for bluefin-stable from the bluefin-nvidia-open-stable companion stream", () => {
+  const spec = {
+    streamId: "bluefin-stable",
+    appId: "bluefin-os-stable",
+    name: "Bluefin OS (Stable)",
+    summary: "Stable track",
+    ghReleasesUrl: "https://github.com/projectbluefin/bluefin/releases",
+  };
+  const sbomCache = {
+    streams: {
+      "bluefin-stable": {
+        releases: {
+          "stable-20260402": {
+            tag: "stable-20260402",
+            packageVersions: { kernel: "6.14.1", podman: "5.8.2", systemd: "259.5", bootc: "1.15.2" },
+          },
+        },
+      },
+      "bluefin-nvidia-open-stable": {
+        releases: {
+          "nvidia-open-stable-20260402": {
+            tag: "nvidia-open-stable-20260402",
+            packageVersions: { nvidia: "580.65.06" },
+          },
+        },
+      },
+    },
+  };
+
+  const app = buildOsApp(spec, sbomCache);
+
+  assert.equal(app.osInfo.majorPackages.NVIDIA, "580.65.06");
+  assert.equal(app.osInfo.majorPackages.Podman, "5.8.2");
+});
+
 test("buildOsApp picks the newest populated release and computes package diffs", () => {
   const spec = {
     streamId: "bluefin-stable",


### PR DESCRIPTION
## Problem

`FeedItems.tsx` reads `app.osInfo.majorPackages.NVIDIA` to build the release-summary NVIDIA line, but `fetch-firehose.js` only ever populated `majorPackages` with `Podman`, `systemd`, and `bootc`. NVIDIA ships as an akmod built outside the OS image, so it never appears in the Syft SBOM scan for `bluefin-stable`/`bluefin-lts` themselves — the accessor always returned `null`.

## Fix

`fetch-github-driver-versions.js` already solves this exact problem for the Driver Versions page: it resolves the NVIDIA version for a release by looking it up in a companion SBOM stream (`bluefin-nvidia-open-stable` for stable, the dedicated LTS NVIDIA stream with legacy fallbacks for LTS).

This reuses that same logic (`buildNvidiaMapFromSbomStream`, `buildLtsNvidiaByTagFromSbom`, `resolveCompanionNvidia`) inside `fetch-firehose.js`'s `buildOsApp`, so the latest `bluefin-stable`/`bluefin-lts` entry now gets its NVIDIA version resolved and written into `osInfo.majorPackages.NVIDIA` — the exact data shape `FeedItems.tsx` already expects.

## Testing

- `node --test scripts/fetch-firehose.test.js scripts/fetch-github-driver-versions.test.js` — added 3 new tests covering direct `packageVersions.nvidia`, the companion-lookup fallback, and an end-to-end `buildOsApp` case.
- `npm test` — full suite (488 tests) passes.
- `npx eslint scripts/fetch-firehose.js scripts/fetch-firehose.test.js` — clean.

Fixes #1096

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `1249f00d`