### PR TITLE
fix(contributors): prevent visitor-side GitHub requests when contributor data is unavailable

### DIFF
--- a/scripts/fetch-contributors.js
+++ b/scripts/fetch-contributors.js
@@ -10,6 +10,12 @@ const OUTPUT_FILE = path.join(OUTPUT_DIR, "file-contributors.json");
 const DOCS_DIR = path.join(__dirname, "..", "docs");
 const BLOG_DIR = path.join(__dirname, "..", "blog");
 
+// Sentinel key written when a complete fetch run yields zero successful
+// results. Consumers (e.g. PageContributors.tsx) use this to detect a
+// globally unavailable dataset and suppress per-page client-side API
+// fallback requests, instead of treating every missing key as a cache miss.
+const UNAVAILABLE_KEY = "__contributors_unavailable__";
+
 // Cache configuration
 const CACHE_MAX_AGE_HOURS = 24;
 
@@ -143,19 +149,25 @@ async function fetchAllContributors() {
     },
   );
 
-  const contributorsData = Object.fromEntries(resultsMap);
   const successCount = resultsMap.size;
 
   console.log(
     `\nSuccessfully fetched contributors for ${successCount}/${allFiles.length} files`,
   );
 
-  // Don't fail build if no contributors fetched - component will gracefully handle empty data
-  if (successCount === 0) {
+  // Don't fail build if no contributors fetched - component will gracefully handle empty data.
+  // When nothing succeeded (e.g. no token / rate limited / offline), emit a sentinel
+  // payload instead of an empty object so the client knows the whole dataset is
+  // unavailable and can skip its per-page GitHub API fallback requests.
+  let contributorsData;
+  if (allFiles.length > 0 && successCount === 0) {
     console.warn(
       "\n⚠️  No contributors fetched! Contributors will not be displayed.",
     );
     console.warn("   Please set a GitHub token and try again.");
+    contributorsData = { [UNAVAILABLE_KEY]: true };
+  } else {
+    contributorsData = Object.fromEntries(resultsMap);
   }
 
   // Ensure output directory exists
@@ -183,4 +195,5 @@ if (require.main === module) {
 module.exports = {
   getAllMarkdownFiles,
   isBotAccount,
+  UNAVAILABLE_KEY,
 };

--- a/src/components/PageContributors.tsx
+++ b/src/components/PageContributors.tsx
@@ -19,6 +19,15 @@ interface PageContributorsProps {
 const CACHE_KEY_PREFIX = "file_contributors_";
 const CACHE_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+// Must match UNAVAILABLE_KEY in scripts/fetch-contributors.js. When the
+// build-time fetch produced zero successful results, the dataset carries
+// this sentinel instead of per-file entries, signalling that every visitor
+// browser should skip its GitHub API fallback rather than hammering the
+// unauthenticated API on every page load.
+const UNAVAILABLE_KEY = "__contributors_unavailable__";
+const isDatasetGloballyUnavailable =
+  (contributorsData as Record<string, unknown>)[UNAVAILABLE_KEY] === true;
+
 // Global request queue to prevent rate limiting
 class RequestQueue {
   private queue: Array<() => Promise<void>> = [];
@@ -164,6 +173,14 @@ const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
           localStorage.removeItem(cacheKey);
         }
       }
+    }
+
+    // If the build-time dataset is globally unavailable (e.g. the fetch
+    // script had no token or was rate-limited during the build), don't fall
+    // back to per-page client-side API requests - just show nothing.
+    if (isDatasetGloballyUnavailable) {
+      setLoading(false);
+      return;
     }
 
     // Finally, fetch from GitHub API as fallback


### PR DESCRIPTION
## Summary
Closes #1097.

`fetch-contributors.js` previously wrote an empty object to `static/data/file-contributors.json` whenever every commit-fetch request for a build failed (e.g. missing `GITHUB_TOKEN`/`GH_TOKEN`, or rate limiting). `PageContributors.tsx` treats any missing key in that dataset as a per-page cache miss and falls back to an unauthenticated `api.github.com` request from the visitor's browser — meaning every page footer on the site would hit GitHub's API directly when the build-time dataset was globally unavailable.

## Changes
- `scripts/fetch-contributors.js`: when a complete fetch run finishes with zero successful files (and there were files to process), emit a sentinel `__contributors_unavailable__: true` payload instead of `{}`.
- `src/components/PageContributors.tsx`: detect that sentinel on load and skip the client-side GitHub API fallback entirely when the whole dataset is unavailable, instead of issuing a request per page. LocalStorage cache lookups are unaffected.

## Testing
- `npx tsc --noEmit` — no new errors (pre-existing unrelated error in `MusicPlaylist.tsx`).
- `npx eslint src/components/PageContributors.tsx scripts/fetch-contributors.js` — no new warnings/errors.
- `node -c scripts/fetch-contributors.js` — syntax OK.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `cd35e595`