### PR TITLE
fix(blog): replace Printful CDN hotlinks blocked on five-years-of-bluefin

### DIFF
--- a/blog/2026-07-22-seven-days-to-the-wolves.mdx
+++ b/blog/2026-07-22-seven-days-to-the-wolves.mdx
@@ -252,7 +252,7 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/dakotaraptor-forever" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/13377675699888df1bfc2__825"
+        src="/img/store/dakotaraptor-forever-0.jpg"
         alt="Dakotaraptor Forever shirt"
         loading="lazy"
       />
@@ -267,7 +267,7 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/bluefin-official-shirt-68b3b18f23f1a" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/890372068c75e06281d0__825"
+        src="/img/store/bluefin-shirt-1.jpg"
         alt="Bluefin Official Shirt"
         loading="lazy"
       />
@@ -280,24 +280,9 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   </article>
 
   <article className="merch-card">
-    <a href="https://projectbluefin.printful.me/product/flock-of-raptors" target="_blank" rel="noopener noreferrer">
-      <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/876146868ae61b19790a__825"
-        alt="Flock of Raptors pin set"
-        loading="lazy"
-      />
-    </a>
-    <div className="merch-card__body">
-      <h3>Flock of Raptors</h3>
-      <p>A set of five glossy, scratch-resistant raptor pins for your jacket, bag, or battle vest.</p>
-      <a className="merch-card__link" href="https://projectbluefin.printful.me/product/flock-of-raptors" target="_blank" rel="noopener noreferrer">Shop the pin set - $9.50</a>
-    </div>
-  </article>
-
-  <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/bluefin-womens-rawr" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/876121968c75cec0c967__825"
+        src="/img/store/bluefin-womens-rawr-0.jpg"
         alt="Bluefin Women's Rawr shirt"
         loading="lazy"
       />


### PR DESCRIPTION
## Problem
`blog/2026-07-22-seven-days-to-the-wolves.mdx` hotlinked four merchandise images from the Printful CDN. Each `cdn.printful.me` URL now returns HTTP 403 with a Cloudflare mitigation challenge, producing broken merchandise images on the deployed Five Years of Bluefin page.

## Fix
- Dakotaraptor Forever, Bluefin Official Shirt, and Bluefin Women's Rawr now use the store assets already committed under `static/img/store/`, matching how the same products are referenced from other blog posts (e.g. `2026-05-14-making-our-own-fate.mdx`, `2026-05-12-bluefin-spring-2026.mdx`).
- The Flock of Raptors pin set has no approved local asset committed anywhere in the repo, and the CDN image can't be fetched, so that merch card is removed rather than shipped with a broken or invented image. It can be re-added once an approved local asset is provided.

Closes #1098

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `679e5e61`