### PR TITLE
fix(profiles): remove nonexistent chandeleer1698 GitHub username

### DIFF
--- a/blog/2026-05-12-bluefin-spring-2026.mdx
+++ b/blog/2026-05-12-bluefin-spring-2026.mdx
@@ -260,7 +260,6 @@ Thanks to our awesome [ISO factory](https://github.com/projectbluefin/iso) we ca
     { login: "carpediem29" },
     { login: "castrojo", roles: ["maintainer", "ublue-emeritus", "bazzite-contributor", "ucore-contributor", "brew-contributor"], nickname: "[ Redacted ]" },
     { login: "CEN90" },
-    { login: "chandeleer1698", roles: ["ublue-contributor", "bluefin-artist", "aurora-artist"] },
     { login: "cmars" },
     { login: "coxde", roles: ["ublue-contributor", "ucore-contributor"] },
     { login: "d3spairx", roles: ["contributor"] },

--- a/docs/contributors.mdx
+++ b/docs/contributors.mdx
@@ -85,18 +85,13 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
   }}
 >
   <GitHubProfileCard
-    username="chandeleer1698"
-    titles={[{ label: "Art Director", color: "#b15e9c" }]}
-    nickname="Telescope Connoisseur"
-    sponsorUrl="https://ko-fi.com/chandeleer"
-    highlight="diamond"
-  />
-  <GitHubProfileCard
     username="delphicmelody"
     titles={[{ label: "Bluefin Artist", color: "#b15e9c" }]}
     highlight="diamond"
   />
 </div>
+
+... and [Chandeleer](https://ko-fi.com/chandeleer) (Art Director and Telescope Connoisseur), who creates wallpapers and artwork for Aurora and Bluefin. Support their work on [Ko-fi](https://ko-fi.com/chandeleer).
 
 ## Maintainers Emeritus
 

--- a/scripts/fetch-github-profiles.js
+++ b/scripts/fetch-github-profiles.js
@@ -57,7 +57,6 @@ const HARDCODED_USERNAMES = [
   "tulilirockz",
 
   // Artists
-  "chandeleer1698",
   "delphicmelody",
 
   // Bluefin Maintainers (Emeritus)

--- a/scripts/fetch-github-profiles.test.js
+++ b/scripts/fetch-github-profiles.test.js
@@ -11,6 +11,7 @@ test("discoverUsernames returns unique GitHub usernames from repo sources", () =
 
   assert.ok(usernames.includes("castrojo"));
   assert.ok(usernames.includes("ahmedadan"));
+  assert.ok(!usernames.includes("chandeleer1698"));
   assert.equal(new Set(usernames).size, usernames.length);
 });
 

--- a/static/data/github-profiles.json
+++ b/static/data/github-profiles.json
@@ -107,18 +107,6 @@
     "sponsorable": true,
     "donationUrl": null
   },
-  "chandeleer1698": {
-    "login": "chandeleer1698",
-    "name": "Chandler",
-    "avatar_url": "https://avatars.githubusercontent.com/u/202515295?v=4",
-    "bio": "Art Director for Universal Blue & Aurora,\r\n\r\nI also take commissions on my Ko-Fi!",
-    "html_url": "https://github.com/chandeleer1698",
-    "public_repos": 9,
-    "followers": 8,
-    "company": "@ublue-os",
-    "sponsorable": false,
-    "donationUrl": null
-  },
   "delphicmelody": {
     "login": "delphicmelody",
     "name": "M. Gopal",


### PR DESCRIPTION
Fixes #1094

### Problem
The GitHub account `chandeleer1698` no longer exists (returns 404 from GitHub API), causing profile fetching to emit failed-profile warnings and attempt redundant delta fetches.

### Solution
- Removed `chandeleer1698` from `HARDCODED_USERNAMES` in `scripts/fetch-github-profiles.js`.
- Removed `chandeleer1698` from `ReleaseContributors` in `blog/2026-05-12-bluefin-spring-2026.mdx` so dynamic username discovery does not re-add it.
- Replaced `<GitHubProfileCard username="chandeleer1698" />` in `docs/contributors.mdx` with credit as Art Director linking to their Ko-fi page to prevent rendering a broken profile card.
- Removed the stale cached profile entry from `static/data/github-profiles.json`.
- Added a regression test in `scripts/fetch-github-profiles.test.js`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7c6b63b1`