### PR TITLE
feat(portal): generate bootc switch terminal command and copy button in PortalImageChooser

### DIFF
--- a/scripts/portal-chooser-model.test.js
+++ b/scripts/portal-chooser-model.test.js
@@ -57,6 +57,7 @@ test("flow: Stable -> x86 -> AMD yields regular kernel and correct URLs", () => 
     formatIsoFilename,
     formatIsoUrl,
     formatChecksumUrl,
+    formatBootcCommand,
   } = loadTsModule(modelPath);
 
   let state = selectRelease(INITIAL_CHOOSER_STATE, "stable", true);
@@ -82,6 +83,10 @@ test("flow: Stable -> x86 -> AMD yields regular kernel and correct URLs", () => 
     formatChecksumUrl(state.selection),
     "https://download.projectbluefin.io/bluefin-stable-x86_64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(state.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin:stable --enforce-container-sigpolicy",
+  );
 });
 
 test("flow: Stable -> x86 -> Nvidia yields nvidia-open suffix", () => {
@@ -93,6 +98,7 @@ test("flow: Stable -> x86 -> Nvidia yields nvidia-open suffix", () => {
     formatIsoFilename,
     formatIsoUrl,
     formatChecksumUrl,
+    formatBootcCommand,
   } = loadTsModule(modelPath);
 
   let state = selectRelease(INITIAL_CHOOSER_STATE, "stable", true);
@@ -111,6 +117,10 @@ test("flow: Stable -> x86 -> Nvidia yields nvidia-open suffix", () => {
     formatChecksumUrl(state.selection),
     "https://download.projectbluefin.io/bluefin-nvidia-open-stable-x86_64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(state.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-nvidia:stable --enforce-container-sigpolicy",
+  );
 });
 
 test("flow: LTS -> x86 -> AMD requires kernel selection", () => {
@@ -123,6 +133,7 @@ test("flow: LTS -> x86 -> AMD requires kernel selection", () => {
     formatIsoFilename,
     formatIsoUrl,
     formatChecksumUrl,
+    formatBootcCommand,
   } = loadTsModule(modelPath);
 
   let state = selectRelease(INITIAL_CHOOSER_STATE, "lts", true);
@@ -145,6 +156,10 @@ test("flow: LTS -> x86 -> AMD requires kernel selection", () => {
     formatChecksumUrl(regularState.selection),
     "https://download.projectbluefin.io/bluefin-lts-x86_64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(regularState.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
+  );
 
   const hweState = selectKernel(state, "hwe");
   assert.equal(hweState.step, "download");
@@ -160,6 +175,10 @@ test("flow: LTS -> x86 -> AMD requires kernel selection", () => {
     formatChecksumUrl(hweState.selection),
     "https://download.projectbluefin.io/bluefin-lts-hwe-x86_64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(hweState.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:lts-hwe --enforce-container-sigpolicy",
+  );
 });
 
 test("flow: LTS -> x86 -> Nvidia creates GDX and skips kernel step", () => {
@@ -171,6 +190,7 @@ test("flow: LTS -> x86 -> Nvidia creates GDX and skips kernel step", () => {
     formatIsoFilename,
     formatIsoUrl,
     formatChecksumUrl,
+    formatBootcCommand,
   } = loadTsModule(modelPath);
 
   let state = selectRelease(INITIAL_CHOOSER_STATE, "lts", true);
@@ -190,6 +210,10 @@ test("flow: LTS -> x86 -> Nvidia creates GDX and skips kernel step", () => {
     formatChecksumUrl(state.selection),
     "https://download.projectbluefin.io/bluefin-gdx-lts-x86_64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(state.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts-nvidia:stable --enforce-container-sigpolicy",
+  );
 });
 
 test("flow: ARM architecture switches to LTS and jumps directly to download", () => {
@@ -200,6 +224,7 @@ test("flow: ARM architecture switches to LTS and jumps directly to download", ()
     formatIsoFilename,
     formatIsoUrl,
     formatChecksumUrl,
+    formatBootcCommand,
   } = loadTsModule(modelPath);
 
   let state = selectRelease(INITIAL_CHOOSER_STATE, "stable", true);
@@ -218,6 +243,10 @@ test("flow: ARM architecture switches to LTS and jumps directly to download", ()
     formatChecksumUrl(state.selection),
     "https://download.projectbluefin.io/bluefin-lts-aarch64.iso-CHECKSUM",
   );
+  assert.equal(
+    formatBootcCommand(state.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
+  );
 
   let ltsArmState = selectArchitecture(
     selectRelease(INITIAL_CHOOSER_STATE, "lts", true),
@@ -228,6 +257,10 @@ test("flow: ARM architecture switches to LTS and jumps directly to download", ()
   assert.equal(
     formatIsoFilename(ltsArmState.selection),
     "bluefin-lts-aarch64.iso",
+  );
+  assert.equal(
+    formatBootcCommand(ltsArmState.selection),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
   );
 });
 
@@ -292,4 +325,75 @@ test("back navigation retreats step-by-step and clears downstream choices", () =
   assert.equal(ltsNvidiaState.selection.gpu, undefined);
 
   assert.deepEqual(resetChooser(), INITIAL_CHOOSER_STATE);
+});
+
+test("formatBootcCommand generates expected commands across all hardware and stream selections", () => {
+  const { formatBootcCommand } = loadTsModule(modelPath);
+
+  // Defaults and fallbacks
+  assert.equal(
+    formatBootcCommand({}),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin:stable --enforce-container-sigpolicy",
+  );
+  assert.equal(
+    formatBootcCommand({ stream: "stable" }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin:stable --enforce-container-sigpolicy",
+  );
+
+  // Stable permutations
+  assert.equal(
+    formatBootcCommand({
+      stream: "stable",
+      arch: "x86",
+      gpu: "amd",
+      kernel: "regular",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin:stable --enforce-container-sigpolicy",
+  );
+  assert.equal(
+    formatBootcCommand({
+      stream: "stable",
+      arch: "x86",
+      gpu: "nvidia",
+      kernel: "regular",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-nvidia:stable --enforce-container-sigpolicy",
+  );
+
+  // LTS permutations
+  assert.equal(
+    formatBootcCommand({
+      stream: "lts",
+      arch: "x86",
+      gpu: "amd",
+      kernel: "regular",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
+  );
+  assert.equal(
+    formatBootcCommand({
+      stream: "lts",
+      arch: "x86",
+      gpu: "amd",
+      kernel: "hwe",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:lts-hwe --enforce-container-sigpolicy",
+  );
+  assert.equal(
+    formatBootcCommand({
+      stream: "lts",
+      arch: "x86",
+      gpu: "nvidia",
+      kernel: "regular",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts-nvidia:stable --enforce-container-sigpolicy",
+  );
+  assert.equal(
+    formatBootcCommand({
+      stream: "lts",
+      arch: "arm",
+      kernel: "regular",
+    }),
+    "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:stable --enforce-container-sigpolicy",
+  );
 });

--- a/scripts/portal-image-chooser-render.test.js
+++ b/scripts/portal-image-chooser-render.test.js
@@ -317,6 +317,15 @@ test("image chooser renders download step with exact ISO and checksum URLs and d
   );
   assert.ok(
     html.includes(
+      "sudo bootc switch ghcr.io/projectbluefin/bluefin:stable --enforce-container-sigpolicy",
+    ),
+  );
+  assert.match(
+    html,
+    /<button[^>]*class="[^"]*copyButton[^"]*"[^>]*aria-label="Copy terminal command"/,
+  );
+  assert.ok(
+    html.includes(
       "https://github.com/orgs/ublue-os/packages?repo_name=bluefin",
     ),
   );
@@ -637,4 +646,63 @@ test("regression: chooser render tests remain stable when rendered with differen
   assert.ok(primaryHtml.includes("Fedora 44"));
   assert.ok(primaryHtml.includes("1.17.7"));
   assert.ok(primaryHtml.includes("5.8.2"));
+});
+
+test("image chooser renders terminal command box with CopyButton across stream variants", () => {
+  const { default: PortalImageChooser, CopyButton } = loadModule(chooserPath);
+  const catalog = deterministicCatalog;
+
+  // Standalone CopyButton rendering
+  const copyBtnHtml = renderToStaticMarkup(
+    React.createElement(CopyButton, {
+      command: "sudo bootc switch test",
+    }),
+  );
+  assert.match(
+    copyBtnHtml,
+    /<button[^>]*class="[^"]*copyButton[^"]*"[^>]*aria-label="Copy terminal command"[^>]*title="Copy to clipboard"/,
+  );
+
+  // LTS Nvidia (GDX)
+  const ltsNvidiaHtml = renderToStaticMarkup(
+    React.createElement(PortalImageChooser, {
+      catalog,
+      initialState: {
+        step: "download",
+        selection: {
+          stream: "lts",
+          arch: "x86",
+          gpu: "nvidia",
+          kernel: "regular",
+        },
+      },
+    }),
+  );
+  assert.ok(
+    ltsNvidiaHtml.includes(
+      "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts-nvidia:stable --enforce-container-sigpolicy",
+    ),
+  );
+  assert.ok(ltsNvidiaHtml.includes("Terminal Rebase Command:"));
+
+  // LTS HWE
+  const ltsHweHtml = renderToStaticMarkup(
+    React.createElement(PortalImageChooser, {
+      catalog,
+      initialState: {
+        step: "download",
+        selection: {
+          stream: "lts",
+          arch: "x86",
+          gpu: "amd",
+          kernel: "hwe",
+        },
+      },
+    }),
+  );
+  assert.ok(
+    ltsHweHtml.includes(
+      "sudo bootc switch ghcr.io/projectbluefin/bluefin-lts:lts-hwe --enforce-container-sigpolicy",
+    ),
+  );
 });

--- a/src/components/portal/PortalImageChooser.tsx
+++ b/src/components/portal/PortalImageChooser.tsx
@@ -1,5 +1,11 @@
-import React, { useState, useRef, useEffect } from "react";
-import { FaDownload, FaCheckCircle, FaGithub } from "react-icons/fa";
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import {
+  FaDownload,
+  FaCheckCircle,
+  FaGithub,
+  FaCopy,
+  FaCheck,
+} from "react-icons/fa";
 import styles from "./PortalSectionPicker.module.css";
 import {
   INITIAL_CHOOSER_STATE,
@@ -13,6 +19,7 @@ import {
   formatIsoFilename,
   formatIsoUrl,
   formatChecksumUrl,
+  formatBootcCommand,
   type ChooserState,
 } from "./portalChooserModel";
 import type { ChooserCatalog } from "./portalStreamAdapter";
@@ -20,6 +27,38 @@ import type { ChooserCatalog } from "./portalStreamAdapter";
 export interface PortalImageChooserProps {
   catalog: ChooserCatalog;
   initialState?: ChooserState;
+}
+
+export function CopyButton({
+  command,
+}: {
+  command: string;
+}): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(command);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  }, [command]);
+
+  return (
+    <button
+      type="button"
+      className={`${styles.copyButton} ${copied ? styles.copied : ""}`}
+      onClick={handleCopy}
+      aria-label={copied ? "Copied!" : "Copy terminal command"}
+      title={copied ? "Copied!" : "Copy to clipboard"}
+    >
+      {copied ? <FaCheck size={14} /> : <FaCopy size={14} />}
+    </button>
+  );
 }
 
 export function getStepAnnouncement(
@@ -354,6 +393,7 @@ export default function PortalImageChooser({
     const filename = formatIsoFilename(selection);
     const isoUrl = formatIsoUrl(selection);
     const checksumUrl = formatChecksumUrl(selection);
+    const bootcCommand = formatBootcCommand(selection);
 
     const displayReleaseTitle =
       selection.gpu === "nvidia" && selection.stream === "lts"
@@ -432,6 +472,16 @@ export default function PortalImageChooser({
             <div className={styles.generatedFilename}>
               <span className={styles.filenameLabel}>Installation ISO:</span>
               <span className={styles.filenameValue}>{filename}</span>
+            </div>
+
+            <div className={styles.terminalCommandBox}>
+              <span className={styles.commandLabel}>
+                Terminal Rebase Command:
+              </span>
+              <div className={styles.commandRow}>
+                <code className={styles.commandValue}>{bootcCommand}</code>
+                <CopyButton command={bootcCommand} />
+              </div>
             </div>
           </div>
 

--- a/src/components/portal/PortalSectionPicker.module.css
+++ b/src/components/portal/PortalSectionPicker.module.css
@@ -493,6 +493,74 @@
   word-break: break-all;
 }
 
+.terminalCommandBox {
+  margin-top: 15px;
+  padding: 10px;
+  background: rgba(79, 156, 249, 0.1);
+  border: 1px solid rgba(79, 156, 249, 0.2);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.commandLabel {
+  display: block;
+  font-size: 17.5px;
+  font-weight: 600;
+  color: #93c5fd;
+  margin-bottom: 5px;
+}
+
+.commandRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 5px 10px;
+  border-radius: 4px;
+}
+
+.commandValue {
+  font-family: monospace;
+  font-size: 15px;
+  font-weight: 600;
+  color: white;
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  word-break: break-all;
+  text-align: left;
+  flex: 1;
+}
+
+.copyButton {
+  background: rgba(74, 144, 226, 0.2);
+  border: 1px solid rgba(74, 144, 226, 0.4);
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  color: #93c5fd;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.copyButton:hover {
+  background: rgba(74, 144, 226, 0.35);
+  color: white;
+}
+
+.copyButton.copied {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #4ade80;
+}
+
 .downloadActions {
   text-align: center;
   margin: 30px 0;
@@ -627,7 +695,8 @@
   .optionButton,
   .downloadButton,
   .btnSecondary,
-  .startOverButton {
+  .startOverButton,
+  .copyButton {
     transition: none !important;
     transform: none !important;
   }

--- a/src/components/portal/portalChooserModel.ts
+++ b/src/components/portal/portalChooserModel.ts
@@ -233,3 +233,23 @@ export function formatIsoUrl(selection: ChooserSelection): string {
 export function formatChecksumUrl(selection: ChooserSelection): string {
   return `${BASE_DOWNLOAD_URL}/${formatIsoFilename(selection)}-CHECKSUM`;
 }
+
+export function formatBootcCommand(selection: ChooserSelection): string {
+  let image = "bluefin";
+  if (selection.stream === "lts") {
+    image = selection.gpu === "nvidia" ? "bluefin-lts-nvidia" : "bluefin-lts";
+  } else if (selection.gpu === "nvidia") {
+    image = "bluefin-nvidia";
+  }
+
+  let tag = "stable";
+  if (
+    selection.stream === "lts" &&
+    selection.kernel === "hwe" &&
+    selection.gpu !== "nvidia"
+  ) {
+    tag = "lts-hwe";
+  }
+
+  return `sudo bootc switch ghcr.io/projectbluefin/${image}:${tag} --enforce-container-sigpolicy`;
+}


### PR DESCRIPTION
### Summary
Fixes #1143

In parity with documentation components (`ImagesCatalog.tsx` & `FirehoseCard.tsx`), adds an interactive terminal rebase command snippet and copy-to-clipboard button to the download step in `PortalImageChooser`:
- Implements `formatBootcCommand(selection)` in `portalChooserModel.ts` to generate `sudo bootc switch ghcr.io/projectbluefin/<image>:<tag> --enforce-container-sigpolicy` matching stream and hardware configuration.
- Adds terminal command box and `<CopyButton />` with clipboard support and accessible status/labels in `PortalImageChooser.tsx`.
- Adds scoped styling with reduced-motion support in `PortalSectionPicker.module.css`.
- Adds comprehensive unit test coverage in `scripts/portal-chooser-model.test.js` and rendering verification in `scripts/portal-image-chooser-render.test.js`.

### Verification
- `npm run typecheck` passes cleanly.
- `npm test` passes all tests across the repository.
- `scripts/portal-chooser-model.test.js` and `scripts/portal-image-chooser-render.test.js` verified.
- Prettier check clean on all modified files.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b26868b1`