### PR TITLE
feat(portal): implement PortalNavigation floating dock and section scroll spy

### DIFF
--- a/scripts/portal-navigation-render.test.js
+++ b/scripts/portal-navigation-render.test.js
@@ -1,0 +1,192 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+function loadModule(file) {
+  const { outputText } = ts.transpileModule(fs.readFileSync(file, "utf8"), {
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+    },
+  });
+  const mod = { exports: {} };
+  new Function("require", "module", "exports", outputText)(
+    (id) => {
+      if (id.endsWith(".css")) return {};
+      if (id.startsWith(".")) {
+        const base = path.resolve(path.dirname(file), id);
+        for (const suffix of [".ts", ".tsx", "/index.ts", "/index.tsx"]) {
+          if (fs.existsSync(base + suffix)) return loadModule(base + suffix);
+        }
+      }
+      return require(id);
+    },
+    mod,
+    mod.exports,
+  );
+  return mod.exports;
+}
+
+const portalDir = path.join(__dirname, "..", "src", "components", "portal");
+const componentPath = path.join(portalDir, "PortalNavigation.tsx");
+const hookPath = path.join(portalDir, "useScrollSpy.ts");
+const cssPath = path.join(portalDir, "PortalNavigation.module.css");
+
+test("PortalNavigation statically renders floating dock header and five semantic links", () => {
+  assert.ok(fs.existsSync(componentPath), "PortalNavigation.tsx must exist");
+  assert.ok(fs.existsSync(cssPath), "PortalNavigation.module.css must exist");
+
+  const { default: PortalNavigation, DEFAULT_PORTAL_NAV_LINKS } =
+    loadModule(componentPath);
+  const html = renderToStaticMarkup(React.createElement(PortalNavigation));
+
+  assert.ok(html.includes('id="navigation"'));
+  assert.ok(html.includes('role="navigation"'));
+  assert.ok(html.includes('aria-label="Navigation"'));
+  assert.ok(html.includes('class="'));
+  assert.ok(html.includes("app-navigation"));
+
+  assert.equal(DEFAULT_PORTAL_NAV_LINKS.length, 5);
+  const hrefs = DEFAULT_PORTAL_NAV_LINKS.map((l) => l.id);
+  assert.deepEqual(hrefs, [
+    "#scene-users",
+    "#scene-developers",
+    "#scene-mission",
+    "#scene-picker",
+    "#scene-community",
+  ]);
+
+  const labels = DEFAULT_PORTAL_NAV_LINKS.map((l) => l.label);
+  assert.deepEqual(labels, [
+    "For You",
+    "For Devs",
+    "Our Mission",
+    "Try Out",
+    "Community",
+  ]);
+
+  for (const href of hrefs) {
+    assert.ok(html.includes(`href="${href}"`));
+    assert.ok(html.includes(`data-section="${href}"`));
+  }
+
+  assert.ok(html.includes(">For You<"));
+  assert.ok(html.includes(">For Devs<"));
+  assert.ok(html.includes(">Our Mission<"));
+  assert.ok(html.includes(">Try Out<"));
+  assert.ok(html.includes(">Community<"));
+});
+
+test("PortalNavigation handles activeSection prop and positions sliding indicator", () => {
+  const { default: PortalNavigation } = loadModule(componentPath);
+
+  // When on landing scene, pill indicator fades out (opacity: 0) and no link is active
+  const landingHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { activeSection: "#scene-landing" }),
+  );
+  assert.ok(!landingHtml.includes("active"));
+  assert.ok(landingHtml.includes("opacity:0"));
+
+  // When null or unrecognized, indicator fades out
+  const nullHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { activeSection: "null" }),
+  );
+  assert.ok(!nullHtml.includes("active"));
+  assert.ok(nullHtml.includes("opacity:0"));
+
+  // When on scene-users (index 0)
+  const usersHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { activeSection: "#scene-users" }),
+  );
+  assert.ok(usersHtml.includes("active"));
+  assert.ok(usersHtml.includes("left:0%"));
+  assert.ok(usersHtml.includes("width:20%"));
+  assert.ok(usersHtml.includes("opacity:1"));
+
+  // When on scene-developers (index 1)
+  const devsHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, {
+      activeSection: "#scene-developers",
+    }),
+  );
+  assert.ok(devsHtml.includes("left:20%"));
+  assert.ok(devsHtml.includes("width:20%"));
+  assert.ok(devsHtml.includes("opacity:1"));
+
+  // When on scene-mission (index 2)
+  const missionHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { activeSection: "#scene-mission" }),
+  );
+  assert.ok(missionHtml.includes("left:40%"));
+  assert.ok(missionHtml.includes("width:20%"));
+  assert.ok(missionHtml.includes("opacity:1"));
+
+  // When on scene-picker (index 3)
+  const pickerHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { activeSection: "#scene-picker" }),
+  );
+  assert.ok(pickerHtml.includes("left:60%"));
+  assert.ok(pickerHtml.includes("width:20%"));
+  assert.ok(pickerHtml.includes("opacity:1"));
+
+  // When on scene-community (index 4)
+  const communityHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, {
+      activeSection: "#scene-community",
+    }),
+  );
+  assert.ok(communityHtml.includes("left:80%"));
+  assert.ok(communityHtml.includes("width:20%"));
+  assert.ok(communityHtml.includes("opacity:1"));
+});
+
+test("PortalNavigation renders floating scroll-to-top button only when active", () => {
+  const { default: PortalNavigation } = loadModule(componentPath);
+
+  const hiddenHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { showScrollTop: false }),
+  );
+  assert.ok(!hiddenHtml.includes("btn-up"));
+  assert.ok(!hiddenHtml.includes("Scroll up button"));
+
+  const visibleHtml = renderToStaticMarkup(
+    React.createElement(PortalNavigation, { showScrollTop: true }),
+  );
+  assert.ok(visibleHtml.includes("btn-up"));
+  assert.ok(visibleHtml.includes('aria-label="Scroll up button"'));
+});
+
+test("useScrollSpy exports defaults and tracks defined sections", () => {
+  assert.ok(fs.existsSync(hookPath), "useScrollSpy.ts must exist");
+  const { useScrollSpy, DEFAULT_TRACKED_SECTIONS } = loadModule(hookPath);
+
+  assert.equal(typeof useScrollSpy, "function");
+  assert.deepEqual(DEFAULT_TRACKED_SECTIONS, [
+    "#scene-landing",
+    "#scene-users",
+    "#scene-developers",
+    "#scene-mission",
+    "#scene-picker",
+    "#scene-community",
+  ]);
+});
+
+test("PortalNavigation.module.css defines pill dock, blur, and responsive rules", () => {
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  assert.match(css, /backdrop-filter:\s*blur\(15px\)/);
+  assert.match(css, /border-radius:\s*24px/);
+  assert.match(css, /position:\s*fixed/);
+  assert.match(css, /bottom:\s*1\.5em/);
+  assert.match(css, /@keyframes popup/);
+  assert.match(css, /\.btnUp\s*\{/);
+  assert.match(css, /@media \(max-width:\s*956px\)/);
+  assert.match(css, /@media \(max-width:\s*512px\)/);
+  assert.match(css, /@media \(prefers-reduced-motion:\s*reduce\)/);
+});

--- a/scripts/portal-prototype-page.test.js
+++ b/scripts/portal-prototype-page.test.js
@@ -97,6 +97,7 @@ test("prototype renders source-authored scenes in order through footer including
     'id="scene-community"',
     'id="alumni"',
     'id="sponsors"',
+    'id="navigation"',
   ];
   ids.reduce((previous, id) => {
     const current = html.indexOf(id);
@@ -108,6 +109,16 @@ test("prototype renders source-authored scenes in order through footer including
   }, -1);
 
   assert.ok(html.includes('id="portal-scenes"'));
+  assert.ok(html.includes('id="navigation"'));
+  assert.ok(html.includes('role="navigation"'));
+  assert.ok(html.includes('href="#scene-users"'));
+  assert.ok(html.includes('href="#scene-developers"'));
+  assert.ok(html.includes('href="#scene-mission"'));
+  assert.ok(html.includes('href="#scene-picker"'));
+  assert.ok(html.includes('href="#scene-community"'));
+  assert.ok(html.includes(">For Devs<"));
+  assert.ok(html.includes(">Our Mission<"));
+  assert.ok(html.includes(">Try Out<"));
   assert.match(html, /<h1[^>]*>\s*<img[^>]*alt="Bluefin"[^>]*\/>\s*<\/h1>/);
   assert.match(
     html,

--- a/src/components/portal/PortalNavigation.module.css
+++ b/src/components/portal/PortalNavigation.module.css
@@ -1,0 +1,206 @@
+.navigation,
+.appNavigation {
+  --portal-blue-rgb: 108, 122, 233;
+  position: fixed;
+  bottom: 1.5em;
+  left: 50%;
+  transform: translateX(-50%);
+  width: clamp(564px, 50%, 792px);
+  border: 1px solid var(--portal-border-light, #616161);
+  border-radius: 24px;
+  background-color: rgba(var(--portal-bg-rgb, 12, 16, 22), 0.8);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  z-index: 100;
+  box-sizing: border-box;
+  animation: popup 1s cubic-bezier(0.85, 0, 0.15, 1) 0s 1;
+}
+
+@keyframes popup {
+  from {
+    bottom: -100%;
+  }
+  to {
+    bottom: 1.5em;
+  }
+}
+
+.nav {
+  width: 100%;
+}
+
+.navList {
+  display: grid;
+  gap: 0;
+  width: 100%;
+  position: relative;
+  z-index: 5;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bg {
+  transition: all 0.5s cubic-bezier(0.76, 0, 0.24, 1);
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 24px;
+  background-color: rgba(var(--portal-blue-rgb, 108, 122, 233), 0.25);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.navItem {
+  z-index: 5;
+  width: 100%;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.navLink {
+  transition: all 0.1s cubic-bezier(0.76, 0, 0.24, 1);
+  font-weight: 700;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  text-transform: uppercase;
+  width: 100%;
+  height: 48px;
+  border-radius: 24px;
+  flex: 1;
+  font-size: 1.2rem;
+  color: var(--portal-text, #bdbdbd);
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.navLink:focus-visible {
+  outline: 2px solid var(--portal-blue-light, #8a97f7);
+  outline-offset: 2px;
+}
+
+.navLink:hover,
+.navLink.active {
+  color: var(--portal-text-light, #ffffff);
+}
+
+.icon {
+  pointer-events: none;
+  font-size: 2rem;
+  color: var(--portal-text, #bdbdbd);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.navLink:hover .icon,
+.navLink.active .icon {
+  color: var(--portal-text-light, #ffffff);
+}
+
+.btnUp {
+  transition: all 0.1s cubic-bezier(0.76, 0, 0.24, 1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  left: calc(100% + 16px);
+  height: 48px;
+  width: 48px;
+  top: 0;
+  border-radius: 50%;
+  border: 1px solid var(--portal-border-light, #616161);
+  background-color: rgba(var(--portal-bg-rgb, 12, 16, 22), 0.75);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  cursor: pointer;
+  padding: 0;
+  box-sizing: border-box;
+  animation: fadeIn 0.2s cubic-bezier(0.76, 0, 0.24, 1);
+}
+
+.btnUp:focus-visible {
+  outline: 2px solid var(--portal-blue-light, #8a97f7);
+  outline-offset: 2px;
+}
+
+.btnUp:hover {
+  background-color: rgba(var(--portal-blue-rgb, 108, 122, 233), 0.25);
+}
+
+.btnUpIcon {
+  color: var(--portal-text, #bdbdbd);
+  font-size: 2rem;
+  display: block;
+}
+
+.btnUp:hover .btnUpIcon {
+  color: var(--portal-text-light, #ffffff);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 956px) {
+  .navigation,
+  .appNavigation {
+    width: 70%;
+    max-width: 512px;
+    bottom: 1em;
+  }
+
+  .btnUp {
+    height: 40px;
+    width: 40px;
+  }
+
+  .navLink {
+    font-size: 0.9rem;
+    height: 40px;
+  }
+
+  .icon {
+    font-size: 1.4rem;
+  }
+
+  .btnUpIcon {
+    font-size: 1.4rem;
+  }
+}
+
+@media (max-width: 512px) {
+  .navigation,
+  .appNavigation {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navigation,
+  .appNavigation {
+    animation: none;
+  }
+
+  .bg,
+  .btnUp,
+  .navLink {
+    transition: none !important;
+  }
+
+  .btnUp {
+    animation: none;
+  }
+}

--- a/src/components/portal/PortalNavigation.tsx
+++ b/src/components/portal/PortalNavigation.tsx
@@ -1,0 +1,221 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import {
+  MdFaceRetouchingNatural,
+  MdCode,
+  MdDownload,
+  MdArrowUpward,
+} from "react-icons/md";
+import {
+  useScrollSpy,
+  DEFAULT_TRACKED_SECTIONS,
+  type UseScrollSpyOptions,
+} from "./useScrollSpy";
+import styles from "./PortalNavigation.module.css";
+
+export interface PortalNavLink {
+  readonly id: string;
+  readonly name: string;
+  readonly label: string;
+  readonly ariaLabel?: string;
+  readonly icon?: React.ComponentType<{
+    readonly className?: string;
+    readonly "aria-hidden"?: boolean | "true" | "false";
+  }>;
+}
+
+export const DEFAULT_PORTAL_NAV_LINKS: readonly PortalNavLink[] = [
+  {
+    id: "#scene-users",
+    name: "Navbar.ForYou",
+    label: "For You",
+    icon: MdFaceRetouchingNatural,
+  },
+  {
+    id: "#scene-developers",
+    name: "Navbar.ForDevs",
+    label: "For Devs",
+    icon: MdCode,
+  },
+  {
+    id: "#scene-mission",
+    name: "Navbar.OurMission",
+    label: "Our Mission",
+  },
+  {
+    id: "#scene-picker",
+    name: "Navbar.TryOut",
+    label: "Try Out",
+    icon: MdDownload,
+  },
+  {
+    id: "#scene-community",
+    name: "Navbar.Community",
+    label: "Community",
+  },
+];
+
+export interface PortalNavigationProps {
+  readonly links?: readonly PortalNavLink[];
+  readonly trackedSections?: readonly string[];
+  readonly activeSection?: string;
+  readonly defaultSection?: string;
+  readonly onSectionChange?: (sectionId: string) => void;
+  readonly showScrollTop?: boolean;
+}
+
+export { useScrollSpy, DEFAULT_TRACKED_SECTIONS, type UseScrollSpyOptions };
+
+export default function PortalNavigation({
+  links = DEFAULT_PORTAL_NAV_LINKS,
+  trackedSections = DEFAULT_TRACKED_SECTIONS,
+  activeSection: propActiveSection,
+  defaultSection,
+  onSectionChange,
+  showScrollTop: propShowScrollTop,
+}: PortalNavigationProps): React.JSX.Element {
+  const { activeSection: spyActiveSection, scrollTo } = useScrollSpy({
+    sectionIds: trackedSections,
+    defaultValue: defaultSection,
+  });
+
+  const effectiveActiveSection = propActiveSection ?? spyActiveSection;
+
+  useEffect(() => {
+    if (onSectionChange) {
+      onSectionChange(effectiveActiveSection);
+    }
+  }, [effectiveActiveSection, onSectionChange]);
+
+  const activeIndex = links.findIndex(
+    (link) => link.id === effectiveActiveSection,
+  );
+  const isVisible = activeIndex !== -1;
+
+  const lastIndexRef = useRef(0);
+  if (activeIndex !== -1) {
+    lastIndexRef.current = activeIndex;
+  }
+
+  const offsetIndex = activeIndex !== -1 ? activeIndex : lastIndexRef.current;
+  const linksCount = links.length;
+  const widthPercent = linksCount > 0 ? 100 / linksCount : 20;
+  const leftPercent = offsetIndex * widthPercent;
+
+  const [internalShowButtonUp, setInternalShowButtonUp] =
+    useState<boolean>(false);
+  const showButtonUp = propShowScrollTop ?? internalShowButtonUp;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const checkScrollUp = () => {
+      const scrollY = window.scrollY ?? document.documentElement.scrollTop ?? 0;
+      const scrollHeight = document.documentElement.scrollHeight;
+      const innerHeight = window.innerHeight;
+
+      if (scrollY >= scrollHeight - innerHeight - 256) {
+        setInternalShowButtonUp(true);
+      } else {
+        setInternalShowButtonUp(false);
+      }
+    };
+
+    window.addEventListener("scroll", checkScrollUp, { passive: true });
+    window.addEventListener("resize", checkScrollUp, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", checkScrollUp);
+      window.removeEventListener("resize", checkScrollUp);
+    };
+  }, []);
+
+  const handleScrollUp = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    const prefersReduced =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReduced ? "auto" : "smooth",
+    });
+  }, []);
+
+  const handleLinkClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+      event.preventDefault();
+      scrollTo(id);
+    },
+    [scrollTo],
+  );
+
+  return (
+    <header
+      id="navigation"
+      className={`${styles.navigation} ${styles.appNavigation ?? ""} app-navigation`}
+      role="navigation"
+    >
+      <nav aria-label="Navigation" className={styles.nav}>
+        <ul
+          className={`${styles.navList} nav-list`}
+          style={{ gridTemplateColumns: `repeat(${linksCount}, 1fr)` }}
+        >
+          {links.map((link) => {
+            const isActive = link.id === effectiveActiveSection;
+            const Icon = link.icon;
+            return (
+              <li
+                key={link.id}
+                data-section={link.id}
+                className={`${styles.navItem} nav-item`}
+              >
+                {/* eslint-disable-next-line @docusaurus/no-html-links */}
+                <a
+                  href={link.id}
+                  className={`${styles.navLink} nav-link${
+                    isActive ? ` ${styles.active} active` : ""
+                  }`}
+                  aria-label={
+                    link.ariaLabel ?? `Section ${link.name ?? link.label}`
+                  }
+                  onClick={(e) => handleLinkClick(e, link.id)}
+                >
+                  {Icon && (
+                    <Icon
+                      className={`${styles.icon} nav-icon`}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {link.label}
+                </a>
+              </li>
+            );
+          })}
+
+          <div
+            className={`${styles.bg} bg`}
+            style={{
+              left: `${leftPercent}%`,
+              width: `${Math.round(widthPercent)}%`,
+              opacity: isVisible ? 1 : 0,
+            }}
+          />
+        </ul>
+      </nav>
+
+      {showButtonUp && (
+        <button
+          type="button"
+          className={`${styles.btnUp} btn-up`}
+          aria-label="Scroll up button"
+          onClick={handleScrollUp}
+        >
+          <MdArrowUpward className={styles.btnUpIcon} aria-hidden="true" />
+        </button>
+      )}
+    </header>
+  );
+}

--- a/src/components/portal/PortalPrototype.tsx
+++ b/src/components/portal/PortalPrototype.tsx
@@ -5,6 +5,7 @@ import PortalBazaar from "./PortalBazaar";
 import PortalSectionPicker from "./PortalSectionPicker";
 import PortalCommunity from "./PortalCommunity";
 import PortalFooter from "./PortalFooter";
+import PortalNavigation from "./PortalNavigation";
 import styles from "./PortalPrototype.module.css";
 import { TRANSITION_SRC } from "./portalModel";
 
@@ -169,6 +170,8 @@ export default function PortalPrototype(): React.JSX.Element {
 
       {/* Downstream insertion seam: Subproject 3 (PortalFlock, PortalContributors, PortalNews) mounts here between Community and Footer */}
       <PortalFooter />
+
+      <PortalNavigation />
     </main>
   );
 }

--- a/src/components/portal/useScrollSpy.ts
+++ b/src/components/portal/useScrollSpy.ts
@@ -1,0 +1,128 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface UseScrollSpyOptions {
+  readonly sectionIds?: readonly string[];
+  readonly defaultValue?: string;
+  readonly offsetRatio?: number;
+}
+
+export const DEFAULT_TRACKED_SECTIONS: readonly string[] = [
+  "#scene-landing",
+  "#scene-users",
+  "#scene-developers",
+  "#scene-mission",
+  "#scene-picker",
+  "#scene-community",
+];
+
+export function useScrollSpy(
+  sectionIdsOrOptions?: readonly string[] | UseScrollSpyOptions,
+  maybeOptions?: UseScrollSpyOptions,
+): {
+  activeSection: string;
+  setActiveSection: React.Dispatch<React.SetStateAction<string>>;
+  scrollTo: (sectionId: string) => void;
+} {
+  const options: UseScrollSpyOptions =
+    sectionIdsOrOptions && Array.isArray(sectionIdsOrOptions)
+      ? {
+          sectionIds: sectionIdsOrOptions as readonly string[],
+          ...maybeOptions,
+        }
+      : ((sectionIdsOrOptions as UseScrollSpyOptions | undefined) ?? {});
+
+  const sectionIds = options.sectionIds ?? DEFAULT_TRACKED_SECTIONS;
+  const defaultValue = options.defaultValue ?? (sectionIds[0] || "");
+  const offsetRatio = options.offsetRatio ?? 0.5;
+
+  const [activeSection, setActiveSection] = useState<string>(defaultValue);
+
+  const calculateActiveSection = useCallback(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const triggerY = window.innerHeight * offsetRatio;
+    let current = sectionIds[0] || "";
+
+    for (const id of sectionIds) {
+      const el = document.querySelector(id);
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        if (rect.top <= triggerY) {
+          current = id;
+        }
+      }
+    }
+
+    setActiveSection((prev) => (prev !== current ? current : prev));
+  }, [sectionIds, offsetRatio]);
+
+  const scrollTo = useCallback((sectionId: string) => {
+    if (typeof document === "undefined") return;
+    const target = document.querySelector(sectionId);
+    if (!target) return;
+
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    target.scrollIntoView({
+      behavior: prefersReduced ? "auto" : "smooth",
+    });
+
+    if (target instanceof HTMLElement) {
+      if (!target.hasAttribute("tabindex")) {
+        target.setAttribute("tabindex", "-1");
+      }
+      target.focus({ preventScroll: true });
+    }
+
+    if (typeof window !== "undefined" && window.history?.pushState) {
+      window.history.pushState(null, "", sectionId);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    calculateActiveSection();
+
+    const handleScroll = () => {
+      calculateActiveSection();
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleScroll, { passive: true });
+
+    let observer: IntersectionObserver | null = null;
+    if (typeof IntersectionObserver !== "undefined") {
+      observer = new IntersectionObserver(
+        () => {
+          calculateActiveSection();
+        },
+        {
+          threshold: [0, 0.25, 0.5, 0.75, 1],
+        },
+      );
+
+      for (const id of sectionIds) {
+        const el = document.querySelector(id);
+        if (el) {
+          observer.observe(el);
+        }
+      }
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+      observer?.disconnect();
+    };
+  }, [sectionIds, calculateActiveSection]);
+
+  return { activeSection, setActiveSection, scrollTo };
+}


### PR DESCRIPTION
Closes #1132

### Summary
Implements the signature floating bottom dock navigation and scroll spy in the documentation portal prototype, achieving parity with `projectbluefin.io` (`website/src/components/Navigation.vue`).

### Key Changes
- **`src/components/portal/PortalNavigation.tsx` & `PortalNavigation.module.css`**:
  - Centered floating bottom pill dock with `backdrop-filter: blur(15px)`, `border-radius: 24px`, and load popup animation.
  - Links matching `Navigation.vue`: `#scene-users` (For You), `#scene-developers` (For Devs), `#scene-mission` (Our Mission), `#scene-picker` (Try Out), `#scene-community` (Community).
  - Material Design Icons from `react-icons/md` for users, developers, picker, and scroll-to-top.
  - Sliding pill indicator (`div.bg`) with smooth position interpolation and opacity fade out on `#scene-landing`.
  - Floating `.btn-up` scroll-to-top button appearing when approaching page bottom.
  - Responsive styles hiding dock on mobile (`<= 512px`), scaling down on tablet (`<= 956px`), and disabling animations under `prefers-reduced-motion: reduce`.
- **`src/components/portal/useScrollSpy.ts`**:
  - Reusable scroll spy hook tracking visible sections via `IntersectionObserver` and fallback scroll geometry.
  - Accessible smooth scrolling with focus management and history updates.
- **`src/components/portal/PortalPrototype.tsx`**:
  - Mounts `PortalNavigation` at the bottom of the portal prototype.
- **Tests**:
  - `scripts/portal-navigation-render.test.js`: unit tests for static SSR render, active section indicator positioning, scroll-to-top toggle, and scoped CSS rules.
  - `scripts/portal-prototype-page.test.js`: updated integration assertions to verify `#navigation` ordering.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `4f90ace6`