### PR TITLE
fix(portal): align Utah ecosystem card link destination to devconf.us

### DIFF
--- a/scripts/portal-product-card-render.test.js
+++ b/scripts/portal-product-card-render.test.js
@@ -127,6 +127,22 @@ test("product card renders external wolves link safely with explicit noopener no
   assert.ok(html.includes("Seven Days to the Wolves"));
 });
 
+test("product card renders external destination link safely with explicit noopener noreferrer", () => {
+  const PortalProductCard = loadModule(componentPath).default;
+  const html = renderToStaticMarkup(
+    React.createElement(PortalProductCard, {
+      title: "Utah",
+      image: "/img/portal/characters/utah.webp",
+      href: "https://devconf.us",
+    }),
+  );
+
+  assert.match(html, /<a[^>]*href="https:\/\/devconf\.us"/);
+  assert.match(html, /target="_blank"/);
+  assert.match(html, /rel="noopener noreferrer"/);
+  assert.ok(html.includes("Utah"));
+});
+
 test("product card renders badge title and subtitle when provided", () => {
   const PortalProductCard = loadModule(componentPath).default;
   const html = renderToStaticMarkup(

--- a/scripts/portal-section-picker-render.test.js
+++ b/scripts/portal-section-picker-render.test.js
@@ -119,7 +119,7 @@ test("section picker renders id=scene-picker with header, intro, chooser, ecosys
 
   const dakotaIdx = html.indexOf('href="/dakota"');
   const serverIdx = html.indexOf('href="/server"');
-  const utahIdx = html.indexOf('href="/utah"');
+  const utahIdx = html.indexOf('href="https://devconf.us"');
   const wolvesIdx = html.indexOf('href="https://projectbluefin.io/wolves/"');
 
   assert.ok(dakotaIdx > 0, "Dakota card must link /dakota");
@@ -128,6 +128,11 @@ test("section picker renders id=scene-picker with header, intro, chooser, ecosys
   assert.ok(
     wolvesIdx > utahIdx,
     "Wolves card must follow Utah in campaign grid",
+  );
+  assert.match(
+    html,
+    /<a[^>]*href="https:\/\/devconf\.us"[^>]*target="_blank"[^>]*rel="noopener noreferrer"/,
+    "Utah card link must use target=_blank and rel=noopener noreferrer",
   );
 
   assert.match(html, /<div[^>]*aria-hidden="true"[^>]*>/);

--- a/scripts/portal-stream-adapter.test.js
+++ b/scripts/portal-stream-adapter.test.js
@@ -173,7 +173,7 @@ test("stream adapter sets available false and shows reason when stream is absent
   assert.equal(catalog.streams.lts.versions, undefined);
 });
 
-test("ecosystem cards link local routes and wolves links absolute url", () => {
+test("ecosystem cards link expected destinations and wolves links absolute url", () => {
   const { adaptStreams } = loadTsModule(adapterPath);
   const catalog = adaptStreams(deterministicImages, deterministicDrivers);
 
@@ -199,7 +199,7 @@ test("ecosystem cards link local routes and wolves links absolute url", () => {
   assert.deepEqual(server.versionRows, []);
 
   assert.equal(utah.title, "Utah");
-  assert.equal(utah.href, "/utah");
+  assert.equal(utah.href, "https://devconf.us");
   assert.equal(utah.image, "/img/portal/characters/utah.webp");
   assert.deepEqual(utah.versionRows, []);
 

--- a/src/components/portal/PortalProductCard.tsx
+++ b/src/components/portal/PortalProductCard.tsx
@@ -67,7 +67,7 @@ export default function PortalProductCard({
   );
 
   if (href) {
-    const isExternal = /^https?:\/\//.test(href);
+    const isExternal = /^https?:\/\//i.test(href);
     return (
       <a
         className={cardClassName}

--- a/src/components/portal/portalStreamAdapter.ts
+++ b/src/components/portal/portalStreamAdapter.ts
@@ -269,7 +269,7 @@ export function adaptStreams(
         id: "utah",
         title: "Utah",
         description: "",
-        href: "/utah",
+        href: "https://devconf.us",
         image: "/img/portal/characters/utah.webp",
         versionRows: [],
       },


### PR DESCRIPTION
### Summary
Aligns the Utah ecosystem card destination link in the portal to `https://devconf.us` to achieve parity with `projectbluefin.io` (`website/src/components/sections/SectionPicker.vue`).

### Changes
1. Updated `portalStreamAdapter.ts` to set Utah card `href: "https://devconf.us"`.
2. Verified `PortalProductCard.tsx` applies external link attributes (`target="_blank" rel="noopener noreferrer"`) for external destinations.
3. Updated unit tests in `scripts/portal-stream-adapter.test.js`, `scripts/portal-section-picker-render.test.js`, and `scripts/portal-product-card-render.test.js`.

Closes #1141

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6ab0b6f8`