### PR TITLE
fix(portal): resolve nested <main> landmark, focus suppression, and WCAG AA contrast

### DIFF
--- a/scripts/portal-prototype-page.test.js
+++ b/scripts/portal-prototype-page.test.js
@@ -169,3 +169,42 @@ test("portal prototype preserves downstream live-section insertion seam comment"
     "insertion seam comment between Community and Footer must be preserved",
   );
 });
+
+test("portal prototype avoids nested landmark and suppresses no outlines", () => {
+  const componentSource = fs.readFileSync(componentPath, "utf8");
+  assert.match(
+    componentSource,
+    /<div className=\{styles\.portal\}>/,
+    "PortalPrototype must use div with styles.portal as root",
+  );
+  assert.ok(
+    !componentSource.includes("<main"),
+    "PortalPrototype must not contain <main> tag",
+  );
+  assert.ok(
+    !componentSource.includes("</main>"),
+    "PortalPrototype must not contain </main> tag",
+  );
+
+  const PortalPrototype = loadModule(componentPath).default;
+  const html = renderToStaticMarkup(React.createElement(PortalPrototype));
+  assert.ok(
+    !html.includes("<main"),
+    "Rendered HTML must not include <main> landmark",
+  );
+  assert.ok(
+    !html.includes("</main>"),
+    "Rendered HTML must not include </main> closing tag",
+  );
+
+  const css = fs.readFileSync(cssPath, "utf8");
+  assert.ok(
+    !css.includes("outline: none"),
+    "PortalPrototype.module.css must not use outline: none",
+  );
+  assert.match(
+    css,
+    /\.contentScene:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--portal-blue-light\)/,
+    "contentScene must have explicit 2px solid var(--portal-blue-light) focus-visible ring",
+  );
+});

--- a/scripts/portal-section-picker-render.test.js
+++ b/scripts/portal-section-picker-render.test.js
@@ -260,3 +260,61 @@ test("section picker CSS enforces pointer-events none on connector, single glow,
   );
   assert.match(css, /@media \(max-width:\s*956px\)/);
 });
+
+test("section picker CSS resolves focus suppression, touch targets, and accessible contrast", () => {
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  // Focus suppression removed and explicit focus-visible rings added
+  assert.ok(
+    !css.includes("outline: none"),
+    "outline: none must be removed from PortalSectionPicker.module.css",
+  );
+  assert.match(
+    css,
+    /:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--portal-blue-light\)/,
+    "interactive and focusable elements must have explicit focus-visible rings",
+  );
+
+  // Touch target minimum height 44px
+  assert.ok(
+    !css.includes("height: 36px"),
+    "height: 36px must be removed to meet WCAG 44px touch target recommendation",
+  );
+  assert.match(
+    css,
+    /\.backButton\s*\{[^}]*min-height:\s*44px/s,
+    "backButton must have min-height: 44px",
+  );
+  assert.match(
+    css,
+    /\.startOverButton\s*\{[^}]*min-height:\s*44px/s,
+    "startOverButton must have min-height: 44px",
+  );
+  assert.match(
+    css,
+    /\.btnSecondary\s*\{[^}]*min-height:\s*44px/s,
+    "btnSecondary must have min-height: 44px",
+  );
+  assert.match(
+    css,
+    /\.downloadButton\s*\{[^}]*min-height:\s*44px/s,
+    "downloadButton must have min-height: 44px",
+  );
+
+  // Button background high-contrast compliant shade (#3b82f6 replaced with #2563eb)
+  assert.match(
+    css,
+    /\.downloadButton\s*\{[^}]*background-color:\s*#2563eb/s,
+    "downloadButton must use WCAG AA compliant shade #2563eb",
+  );
+  assert.match(
+    css,
+    /\.backButton\s*\{[^}]*background-color:\s*#2563eb/s,
+    "backButton must use WCAG AA compliant shade #2563eb",
+  );
+  assert.match(
+    css,
+    /\.startOverButton\s*\{[^}]*background-color:\s*#2563eb/s,
+    "startOverButton must use WCAG AA compliant shade #2563eb",
+  );
+});

--- a/src/components/portal/PortalPrototype.module.css
+++ b/src/components/portal/PortalPrototype.module.css
@@ -106,8 +106,8 @@
   scroll-margin-top: var(--ifm-navbar-height, 60px);
 }
 
-.contentScene:focus {
-  outline: none;
+.contentScene:focus-visible {
+  outline: 2px solid var(--portal-blue-light);
 }
 
 .sceneContent strong {

--- a/src/components/portal/PortalPrototype.tsx
+++ b/src/components/portal/PortalPrototype.tsx
@@ -44,7 +44,7 @@ export default function PortalPrototype(): React.JSX.Element {
   };
 
   return (
-    <main className={styles.portal}>
+    <div className={styles.portal}>
       <div id="portal-scenes" className={styles.sceneStack}>
         <section id="scene-landing" className={styles.landingScene}>
           <div className={styles.landingGrid}>
@@ -169,6 +169,6 @@ export default function PortalPrototype(): React.JSX.Element {
 
       {/* Downstream insertion seam: Subproject 3 (PortalFlock, PortalContributors, PortalNews) mounts here between Community and Footer */}
       <PortalFooter />
-    </main>
+    </div>
   );
 }

--- a/src/components/portal/PortalSectionPicker.module.css
+++ b/src/components/portal/PortalSectionPicker.module.css
@@ -352,12 +352,12 @@
 
 .backButton {
   font-weight: 700;
-  height: 36px;
-  line-height: 36px;
-  border: 2px solid #3b82f6;
-  background-color: #3b82f6;
-  color: #f3f4f6;
-  border-radius: 18px;
+  min-height: 44px;
+  line-height: 44px;
+  border: 2px solid #2563eb;
+  background-color: #2563eb;
+  color: #ffffff;
+  border-radius: 22px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -372,7 +372,8 @@
 }
 
 .backButton:hover {
-  background-color: #2563eb;
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
 }
 
 .optionsGrid {
@@ -382,6 +383,7 @@
 
 .optionButton {
   position: relative;
+  min-height: 44px;
   padding: 15px;
   border: 2px solid #374151;
   border-radius: 8px;
@@ -534,6 +536,8 @@
 }
 
 .copyButton {
+  min-height: 44px;
+  min-width: 44px;
   background: rgba(74, 144, 226, 0.2);
   border: 1px solid rgba(74, 144, 226, 0.4);
   border-radius: 6px;
@@ -570,11 +574,12 @@
   display: inline-flex;
   align-items: center;
   gap: 9px;
+  min-height: 44px;
   height: 44px;
   line-height: 44px;
-  border: 2px solid #3b82f6;
-  background-color: #3b82f6;
-  color: #f3f4f6;
+  border: 2px solid #2563eb;
+  background-color: #2563eb;
+  color: #ffffff;
   border-radius: 22px;
   padding: 0 25px;
   font-size: 17.5px;
@@ -588,8 +593,9 @@
 }
 
 .downloadButton:hover {
-  background-color: #2563eb;
-  color: #f3f4f6;
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #ffffff;
   text-decoration: none;
 }
 
@@ -609,12 +615,12 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  height: 36px;
-  line-height: 36px;
+  min-height: 44px;
+  line-height: 44px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: rgba(255, 255, 255, 0.05);
   color: #f3f4f6;
-  border-radius: 18px;
+  border-radius: 22px;
   padding: 0 16px;
   font-size: 14px;
   font-weight: 600;
@@ -646,12 +652,12 @@
 
 .startOverButton {
   font-weight: 700;
-  height: 36px;
-  line-height: 36px;
-  border: 2px solid #3b82f6;
-  background-color: #3b82f6;
-  color: #f3f4f6;
-  border-radius: 18px;
+  min-height: 44px;
+  line-height: 44px;
+  border: 2px solid #2563eb;
+  background-color: #2563eb;
+  color: #ffffff;
+  border-radius: 22px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -666,7 +672,8 @@
 }
 
 .startOverButton:hover {
-  background-color: #2563eb;
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
 }
 
 .srOnly {
@@ -681,9 +688,18 @@
   border: 0;
 }
 
-.stepHeader h3:focus,
-.releaseTitle:focus {
-  outline: none;
+.cardBox:focus-visible,
+.releaseBox:focus-visible,
+.backButton:focus-visible,
+.optionButton:focus-visible,
+.downloadButton:focus-visible,
+.btnSecondary:focus-visible,
+.startOverButton:focus-visible,
+.copyButton:focus-visible,
+.stepHeader h3:focus-visible,
+.releaseTitle:focus-visible {
+  outline: 2px solid var(--portal-blue-light);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -703,6 +719,7 @@
 }
 
 .sectionWrap {
+  --portal-blue-light: #8a97f7;
   padding: 60px 0;
   width: 100%;
 }


### PR DESCRIPTION
### Summary
Resolves accessibility and DOM audit findings identified in #1145:
1. **Landmark Nesting**: Replaced outer `<main>` in `PortalPrototype.tsx` with `<div className={styles.portal}>` to eliminate nested `<main>` landmarks inside Docusaurus `@theme/Layout` (WCAG 1.3.1).
2. **Focus Suppression**: Removed all `outline: none` rules in `PortalPrototype.module.css` and `PortalSectionPicker.module.css`. Added explicit `:focus-visible` rings (`2px solid var(--portal-blue-light)`) with offset for interactive and focusable elements.
3. **Touch Targets**: Increased target heights on interactive buttons (`.btnSecondary`, `.backButton`, `.startOverButton`, `.downloadButton`, `.optionButton`, `.copyButton`) to `min-height: 44px` (WCAG 2.5.5 / 2.5.8).
4. **WCAG AA Contrast**: Adjusted button background to high-contrast compliant shade `#2563eb` (Tailwind Blue-600, yielding > 4.5:1 contrast ratio with white text) and hover to `#1d4ed8`.
5. **Tests**: Added regression and accessibility assertions to `scripts/portal-prototype-page.test.js` and `scripts/portal-section-picker-render.test.js`.

Closes #1145

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `unknown`