### PR TITLE
fix(sbom): support version-qualified live tags in recent-release discovery

### DIFF
--- a/scripts/fetch-github-sbom.test.js
+++ b/scripts/fetch-github-sbom.test.js
@@ -339,11 +339,46 @@ test("findRecentTagsForStream: picks stable-YYYYMMDD tags from GHCR list", () =>
   assert.equal(result[0].cacheKey, `stable-${FIXED_RECENT_DATE}`);
 });
 
-test("findRecentTagsForStream: excludes tags older than LOOKBACK_DAYS", () => {
+test("findRecentTagsForStream: excludes tags older than LOOKBACK_DAYS when recent releases exist", () => {
   const oldDate = "20200101"; // way in the past
-  const ghcrTags = [`stable-${oldDate}`];
+  const ghcrTags = [`stable-${FIXED_RECENT_DATE}`, `stable-${oldDate}`];
   const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
-  assert.equal(result.length, 0, "old tags must be excluded");
+  assert.equal(
+    result.length,
+    1,
+    "old tags must be excluded when recent releases exist",
+  );
+  assert.equal(result[0].tag, `stable-${FIXED_RECENT_DATE}`);
+});
+
+test("findRecentTagsForStream: retains latest-release fallback when lookback finds no releases", () => {
+  const oldDate = "20200101";
+  const olderDate = "20190101";
+  const ghcrTags = [`stable-${olderDate}`, `stable-${oldDate}`];
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(
+    result.length,
+    1,
+    "must retain single latest release as fallback",
+  );
+  assert.equal(result[0].dateStr, oldDate);
+});
+
+test("findRecentTagsForStream: recognizes version-qualified live tags", () => {
+  const ghcrTags = [
+    `stable-44.${FIXED_RECENT_DATE}`,
+    `testing-44.${FIXED_RECENT_DATE}`,
+    `stable-daily-44.${FIXED_RECENT_DATE}`,
+  ];
+  const stableResult = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(stableResult.length, 1);
+  assert.equal(stableResult[0].tag, `stable-44.${FIXED_RECENT_DATE}`);
+  assert.equal(stableResult[0].cacheKey, `stable-${FIXED_RECENT_DATE}`);
+
+  const dailyResult = findRecentTagsForStream(ghcrTags, MOCK_STABLE_DAILY_SPEC);
+  assert.equal(dailyResult.length, 1);
+  assert.equal(dailyResult[0].tag, `stable-daily-44.${FIXED_RECENT_DATE}`);
+  assert.equal(dailyResult[0].cacheKey, `stable-daily-${FIXED_RECENT_DATE}`);
 });
 
 test("findRecentTagsForStream: deduplicates same date", () => {

--- a/scripts/lib/sbom/parser.js
+++ b/scripts/lib/sbom/parser.js
@@ -101,6 +101,23 @@ function buildCacheKey(streamPrefix, dateStr) {
   return `${streamPrefix}-${dateStr}`;
 }
 
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Match a tag against a stream prefix and date string.
+ * Supports:
+ *   - Canonical unversioned: `<streamPrefix>-YYYYMMDD` or `<streamPrefix>.YYYYMMDD`
+ *   - Version-qualified live tags: `<streamPrefix>-<version>.YYYYMMDD` or `<streamPrefix>-<version>-YYYYMMDD`
+ */
+function matchesStreamTag(tag, streamPrefix, dateStr) {
+  const pattern = new RegExp(
+    `^${escapeRegExp(streamPrefix)}(?:-(\\d+))?[.-]${dateStr}$`,
+  );
+  return pattern.test(tag);
+}
+
 /**
  * Filter a list of GHCR tag strings to find recent dated tags for a given stream.
  *
@@ -116,13 +133,11 @@ function findRecentTagsForStream(ghcrTags, spec) {
 
   for (const tagName of ghcrTags) {
     const normalised = normaliseLtsTag(tagName.toLowerCase());
-    if (!normalised.startsWith(`${spec.streamPrefix}-`)) continue;
+    if (!normalised.startsWith(spec.streamPrefix)) continue;
     const dateStr = extractDateFromTag(normalised);
     if (!dateStr) continue;
 
-    // Enforce canonical tag: only exact `<streamPrefix>-YYYYMMDD` is accepted.
-    const expectedCanonical = `${spec.streamPrefix}-${dateStr}`;
-    if (normalised !== expectedCanonical) continue;
+    if (!matchesStreamTag(normalised, spec.streamPrefix, dateStr)) continue;
 
     // Tags from GHCR have no publishedAt — derive from the date string.
     const year = dateStr.slice(0, 4);
@@ -130,7 +145,7 @@ function findRecentTagsForStream(ghcrTags, spec) {
     const day = dateStr.slice(6, 8);
     const publishedAt = `${year}-${month}-${day}T00:00:00Z`;
     const publishedMs = Date.parse(publishedAt);
-    if (isNaN(publishedMs) || publishedMs < cutoff) continue;
+    if (isNaN(publishedMs)) continue;
 
     found.push({
       tag: normalised,
@@ -138,23 +153,46 @@ function findRecentTagsForStream(ghcrTags, spec) {
       dateStr,
       imageRef: `ghcr.io/${spec.org}/${spec.package}:${tagName}`,
       publishedAt,
+      publishedMs,
     });
   }
 
-  // Deduplicate by cacheKey (keep first/most-recent encounter)
-  const seen = new Set();
-  const unique = [];
+  // Deduplicate by cacheKey, preferring the exact canonical tag (<prefix>-YYYYMMDD)
+  // over version-qualified alternatives if both are present for the same date.
+  const byCacheKey = new Map();
   for (const entry of found) {
-    if (!seen.has(entry.cacheKey)) {
-      seen.add(entry.cacheKey);
-      unique.push(entry);
+    const existing = byCacheKey.get(entry.cacheKey);
+    if (!existing) {
+      byCacheKey.set(entry.cacheKey, entry);
+    } else {
+      const canonicalTag = `${spec.streamPrefix}-${entry.dateStr}`;
+      if (entry.tag === canonicalTag && existing.tag !== canonicalTag) {
+        byCacheKey.set(entry.cacheKey, entry);
+      }
     }
   }
+
+  const unique = Array.from(byCacheKey.values());
 
   // Sort descending by dateStr (YYYYMMDD sorts lexicographically)
   unique.sort((a, b) => b.dateStr.localeCompare(a.dateStr));
 
-  return unique.slice(0, maxReleases);
+  // Lookback filter with latest-release fallback:
+  // Return releases within the lookback window up to maxReleases.
+  // When the fixed lookback finds no releases, retain the single latest release.
+  const withinLookback = unique.filter((entry) => entry.publishedMs >= cutoff);
+  const results =
+    withinLookback.length > 0
+      ? withinLookback.slice(0, maxReleases)
+      : unique.slice(0, 1);
+
+  return results.map(({ tag, cacheKey, dateStr, imageRef, publishedAt }) => ({
+    tag,
+    cacheKey,
+    dateStr,
+    imageRef,
+    publishedAt,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +244,8 @@ function extractPackageVersions(sbomPath) {
   //   Packages represent BST elements, not RPM packages. Extraction uses
   //   (name, BST element path suffix) pairs to disambiguate between components
   //   that share a name (e.g. the `linux` kernel element vs. Rust `linux` crates).
-  const isSpdx = Array.isArray(sbom?.packages) && typeof sbom?.spdxVersion === "string";
+  const isSpdx =
+    Array.isArray(sbom?.packages) && typeof sbom?.spdxVersion === "string";
   const isBstSpdx =
     isSpdx &&
     (sbom.packages || []).some((pkg) =>
@@ -348,6 +387,7 @@ module.exports = {
   stripRpmRelease,
   extractDateFromTag,
   normaliseLtsTag,
+  matchesStreamTag,
   buildCacheKey,
   findRecentTagsForStream,
   extractPackageVersions,

--- a/scripts/lib/sbom/parser.test.js
+++ b/scripts/lib/sbom/parser.test.js
@@ -10,6 +10,7 @@ const {
   stripRpmRelease,
   extractDateFromTag,
   normaliseLtsTag,
+  matchesStreamTag,
   buildCacheKey,
   findRecentTagsForStream,
   extractPackageVersions,
@@ -226,16 +227,113 @@ test("findRecentTagsForStream honours SBOM_MAX_RELEASES", () => {
   }
 });
 
-test("findRecentTagsForStream honours SBOM_LOOKBACK_DAYS", () => {
-  const tags = [`stable-${daysAgoTag(30)}`];
+test("findRecentTagsForStream honours SBOM_LOOKBACK_DAYS when recent releases exist", () => {
+  const tags = [`stable-${daysAgoTag(3)}`, `stable-${daysAgoTag(30)}`];
   const previous = process.env.SBOM_LOOKBACK_DAYS;
   process.env.SBOM_LOOKBACK_DAYS = "7";
   try {
-    assert.equal(findRecentTagsForStream(tags, STABLE_SPEC).length, 0);
+    const found = findRecentTagsForStream(tags, STABLE_SPEC);
+    assert.equal(found.length, 1);
+    assert.equal(found[0].dateStr, daysAgoTag(3));
   } finally {
     if (previous === undefined) delete process.env.SBOM_LOOKBACK_DAYS;
     else process.env.SBOM_LOOKBACK_DAYS = previous;
   }
+});
+
+test("findRecentTagsForStream retains latest-release fallback when lookback finds no releases", () => {
+  const tags = [`stable-${daysAgoTag(30)}`, `stable-${daysAgoTag(60)}`];
+  const previous = process.env.SBOM_LOOKBACK_DAYS;
+  process.env.SBOM_LOOKBACK_DAYS = "7";
+  try {
+    const found = findRecentTagsForStream(tags, STABLE_SPEC);
+    assert.equal(found.length, 1);
+    assert.equal(found[0].dateStr, daysAgoTag(30));
+  } finally {
+    if (previous === undefined) delete process.env.SBOM_LOOKBACK_DAYS;
+    else process.env.SBOM_LOOKBACK_DAYS = previous;
+  }
+});
+
+test("findRecentTagsForStream supports version-qualified live tags", () => {
+  const recent = daysAgoTag(3);
+  const tags = [
+    `stable-44.${recent}`,
+    `testing-44.${recent}`,
+    "stable-44.notadate",
+  ];
+  const found = findRecentTagsForStream(tags, STABLE_SPEC);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].tag, `stable-44.${recent}`);
+  assert.equal(found[0].cacheKey, `stable-${recent}`);
+  assert.equal(found[0].dateStr, recent);
+  assert.equal(
+    found[0].imageRef,
+    `ghcr.io/ublue-os/bluefin:stable-44.${recent}`,
+  );
+});
+
+test("findRecentTagsForStream handles issue #1082 probe tags and fallback", () => {
+  const probeTags = [
+    "stable-20260606",
+    "stable-44.20260606",
+    "testing-44.20260720",
+  ];
+
+  // For stable: both tags are older than 90-day lookback from now, so fallback retains 20260606
+  const stableFound = findRecentTagsForStream(probeTags, STABLE_SPEC);
+  assert.equal(stableFound.length, 1);
+  assert.equal(stableFound[0].dateStr, "20260606");
+  assert.equal(stableFound[0].cacheKey, "stable-20260606");
+  // Exact canonical tag is preferred over version-qualified when both exist
+  assert.equal(stableFound[0].tag, "stable-20260606");
+
+  // For testing: testing-44.20260720 is recognized
+  const testingSpec = {
+    streamPrefix: "testing",
+    org: "projectbluefin",
+    package: "utah",
+  };
+  const testingFound = findRecentTagsForStream(probeTags, testingSpec);
+  assert.equal(testingFound.length, 1);
+  assert.equal(testingFound[0].dateStr, "20260720");
+  assert.equal(testingFound[0].cacheKey, "testing-20260720");
+  assert.equal(testingFound[0].tag, "testing-44.20260720");
+});
+
+test("matchesStreamTag matches canonical and version-qualified tags", () => {
+  assert.equal(matchesStreamTag("stable-20260606", "stable", "20260606"), true);
+  assert.equal(matchesStreamTag("stable.20260606", "stable", "20260606"), true);
+  assert.equal(
+    matchesStreamTag("stable-44.20260606", "stable", "20260606"),
+    true,
+  );
+  assert.equal(
+    matchesStreamTag("stable-44-20260606", "stable", "20260606"),
+    true,
+  );
+  assert.equal(
+    matchesStreamTag("testing-44.20260720", "testing", "20260720"),
+    true,
+  );
+  assert.equal(
+    matchesStreamTag("stable-daily-44.20260530", "stable-daily", "20260530"),
+    true,
+  );
+  // Rejections
+  assert.equal(
+    matchesStreamTag("stable-daily-20260606", "stable", "20260606"),
+    false,
+  );
+  assert.equal(
+    matchesStreamTag("stable-daily-44.20260606", "stable", "20260606"),
+    false,
+  );
+  assert.equal(
+    matchesStreamTag("stable-20260606-hwe", "stable", "20260606"),
+    false,
+  );
+  assert.equal(matchesStreamTag("gts-20260606", "stable", "20260606"), false);
 });
 
 test("findRecentTagsForStream returns an empty list for no tags", () => {

--- a/scripts/sbom-parser.test.js
+++ b/scripts/sbom-parser.test.js
@@ -180,6 +180,51 @@ test("findRecentTagsForStream deduplicates, sorts newest first, and caps the cou
   );
 });
 
+test("findRecentTagsForStream recognizes version-qualified dated tags", () => {
+  const recent = daysAgoTag(2);
+  const found = findRecentTagsForStream([`stable-44.${recent}`], SPEC);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].tag, `stable-44.${recent}`);
+  assert.equal(found[0].cacheKey, `stable-${recent}`);
+  assert.equal(found[0].dateStr, recent);
+});
+
+test("findRecentTagsForStream retains latest-release fallback when lookback finds no releases", (t) => {
+  t.after(() => {
+    delete process.env.SBOM_LOOKBACK_DAYS;
+  });
+  process.env.SBOM_LOOKBACK_DAYS = "7";
+  const old1 = daysAgoTag(30);
+  const old2 = daysAgoTag(60);
+  const found = findRecentTagsForStream(
+    [`stable-${old2}`, `stable-${old1}`],
+    SPEC,
+  );
+  assert.equal(found.length, 1);
+  assert.equal(found[0].dateStr, old1);
+});
+
+test("findRecentTagsForStream resolves issue #1082 probe tags", () => {
+  const probeTags = [
+    "stable-20260606",
+    "stable-44.20260606",
+    "testing-44.20260720",
+  ];
+  const stableFound = findRecentTagsForStream(probeTags, SPEC);
+  assert.equal(stableFound.length, 1);
+  assert.equal(stableFound[0].dateStr, "20260606");
+  assert.equal(stableFound[0].cacheKey, "stable-20260606");
+
+  const testingFound = findRecentTagsForStream(probeTags, {
+    streamPrefix: "testing",
+    org: "projectbluefin",
+    package: "utah",
+  });
+  assert.equal(testingFound.length, 1);
+  assert.equal(testingFound[0].dateStr, "20260720");
+  assert.equal(testingFound[0].cacheKey, "testing-20260720");
+});
+
 // ---------------------------------------------------------------------------
 // extractPackageVersions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #1082

### Problem
`findRecentTagsForStream` previously only accepted exact canonical `<prefix>-YYYYMMDD` tags inside the lookback window. Live container images in GHCR also use version-qualified tags such as `stable-44.YYYYMMDD` and `testing-44.YYYYMMDD`. In addition, when a stream had no releases within the fixed 90-day lookback window (e.g. `bluefin-stable` with latest release on 2026-06-06), `findRecentTagsForStream` returned 0 releases, triggering the empty-cache / partial-releases guard and leaving the SBOM attestation cache stale (>1800h old).

### Changes
- **Version-qualified live tags:** Updated `findRecentTagsForStream` and introduced `matchesStreamTag` in `scripts/lib/sbom/parser.js` to accept both canonical (`<streamPrefix>-YYYYMMDD`, `<streamPrefix>.YYYYMMDD`) and version-qualified (`<streamPrefix>-<version>.YYYYMMDD`, `<streamPrefix>-<version>-YYYYMMDD`) tags.
- **Deduplication priority:** When both an exact canonical tag and a version-qualified tag exist for the same stream and date (e.g. `stable-20260606` and `stable-44.20260606`), canonical unversioned tags are preferred.
- **Latest-release fallback:** When the fixed lookback window finds zero releases for a stream, `findRecentTagsForStream` falls back to retaining the single latest release.
- **Unit test coverage:** Added tests in `scripts/lib/sbom/parser.test.js`, `scripts/fetch-github-sbom.test.js`, and `scripts/sbom-parser.test.js` validating version-qualified tags, latest-release fallback, and the probe cases from issue #1082.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `fbe5ea1f`