### PR TITLE
fix(portal): update deprecated ublue-os links and synchronize Discord invite code

### DIFF
--- a/scripts/portal-static-data.test.js
+++ b/scripts/portal-static-data.test.js
@@ -141,11 +141,11 @@ test("portal static data exposes exact metadata contracts", () => {
   );
   assert.equal(
     data.COMMUNITY_METADATA.docsCard.discordUrl,
-    "https://discord.gg/WYCpGEM4sM",
+    "https://discord.gg/XUC8cANVHy",
   );
   assert.equal(
     data.COMMUNITY_METADATA.docsCard.discussionsUrl,
-    "https://github.com/ublue-os/bluefin/discussions",
+    "https://github.com/projectbluefin/bluefin/discussions",
   );
 
   // Alumni

--- a/scripts/portal-static-render.test.js
+++ b/scripts/portal-static-render.test.js
@@ -128,10 +128,12 @@ test("PortalCommunity statically renders documentation card, icons, and action l
   );
   assert.ok(html.includes('href="https://docs.projectbluefin.io"'));
   assert.ok(html.includes("View Documentation"));
-  assert.ok(html.includes('href="https://discord.gg/WYCpGEM4sM"'));
+  assert.ok(html.includes('href="https://discord.gg/XUC8cANVHy"'));
   assert.ok(html.includes("Join our Discord"));
   assert.ok(
-    html.includes('href="https://github.com/ublue-os/bluefin/discussions"'),
+    html.includes(
+      'href="https://github.com/projectbluefin/bluefin/discussions"',
+    ),
   );
   assert.ok(html.includes("Discussions"));
   // Verify SVG icons rendered
@@ -191,7 +193,7 @@ test("PortalFooter statically renders alumni, sponsors, powered-by, credits, and
   assert.ok(html.includes("Welcome to indie Cloud Native."));
 
   // Social
-  assert.ok(html.includes('href="https://github.com/ublue-os/bluefin"'));
+  assert.ok(html.includes('href="https://github.com/projectbluefin/bluefin"'));
   assert.ok(html.includes("GitHub"));
 
   // Credits

--- a/src/components/portal/PortalFooter.tsx
+++ b/src/components/portal/PortalFooter.tsx
@@ -150,7 +150,7 @@ export default function PortalFooter(): React.JSX.Element {
           <ul className={styles.socialLinks}>
             <li>
               <a
-                href="https://github.com/ublue-os/bluefin"
+                href="https://github.com/projectbluefin/bluefin"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/components/portal/portalStaticData.ts
+++ b/src/components/portal/portalStaticData.ts
@@ -32,8 +32,8 @@ export const COMMUNITY_METADATA = {
     iconSrc: "/icons/docs.svg",
     iconAlt: "Bluefin Documentation",
     docsUrl: "https://docs.projectbluefin.io",
-    discordUrl: "https://discord.gg/WYCpGEM4sM",
-    discussionsUrl: "https://github.com/ublue-os/bluefin/discussions",
+    discordUrl: "https://discord.gg/XUC8cANVHy",
+    discussionsUrl: "https://github.com/projectbluefin/bluefin/discussions",
   },
 } as const;
 


### PR DESCRIPTION
Resolves #1146

### Summary
Parity audit identified deprecated `ublue-os` GitHub URLs in portal metadata and footer components, as well as a desynchronized Discord invite code between `portalStaticData.ts` and `docusaurus.config.ts`.

### Changes
1. **GitHub URLs**:
   - Updated `discussionsUrl` in `src/components/portal/portalStaticData.ts` to `https://github.com/projectbluefin/bluefin/discussions`.
   - Updated GitHub repository link in `src/components/portal/PortalFooter.tsx` to `https://github.com/projectbluefin/bluefin`.
2. **Discord Invite Code**:
   - Reconciled and standardized the Discord invite URL in `src/components/portal/portalStaticData.ts` to `https://discord.gg/XUC8cANVHy` (synchronizing with `docusaurus.config.ts` and documentation files).
3. **Tests**:
   - Updated unit test assertions in `scripts/portal-static-data.test.js` and `scripts/portal-static-render.test.js` to match the canonical GitHub URLs and synchronized Discord invite.

— hive: backend=agy
