### PR TITLE
feat(portal): implement PortalPageLoading overlay and character asset preloader

### DIFF
--- a/scripts/portal-page-loading.test.js
+++ b/scripts/portal-page-loading.test.js
@@ -1,0 +1,178 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+const root = path.join(__dirname, "..");
+const portalDir = path.join(root, "src", "components", "portal");
+
+function loadModule(file) {
+  const { outputText } = ts.transpileModule(fs.readFileSync(file, "utf8"), {
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+    },
+  });
+  const mod = { exports: {} };
+  new Function("require", "module", "exports", outputText)(
+    (id) => {
+      if (id.endsWith(".css")) return {};
+      if (id.startsWith("@site/")) {
+        const rel = id.slice("@site/".length);
+        const target = path.resolve(root, rel);
+        if (target.endsWith(".json"))
+          return JSON.parse(fs.readFileSync(target, "utf8"));
+        for (const suffix of [
+          ".ts",
+          ".tsx",
+          "/index.ts",
+          "/index.tsx",
+          ".json",
+        ]) {
+          if (fs.existsSync(target + suffix)) {
+            if (suffix === ".json")
+              return JSON.parse(fs.readFileSync(target + suffix, "utf8"));
+            return loadModule(target + suffix);
+          }
+        }
+      }
+      if (id.startsWith(".")) {
+        const base = path.resolve(path.dirname(file), id);
+        if (base.endsWith(".json"))
+          return JSON.parse(fs.readFileSync(base, "utf8"));
+        for (const suffix of [
+          ".ts",
+          ".tsx",
+          "/index.ts",
+          "/index.tsx",
+          ".json",
+        ]) {
+          if (fs.existsSync(base + suffix)) {
+            if (suffix === ".json")
+              return JSON.parse(fs.readFileSync(base + suffix, "utf8"));
+            return loadModule(base + suffix);
+          }
+        }
+      }
+      return require(id);
+    },
+    mod,
+    mod.exports,
+  );
+  return mod.exports;
+}
+
+test("PortalPageLoading statically renders overlay, spinner loader, and initial dot", () => {
+  const componentPath = path.join(portalDir, "PortalPageLoading.tsx");
+  assert.ok(fs.existsSync(componentPath), "PortalPageLoading.tsx must exist");
+
+  const PortalPageLoading = loadModule(componentPath).default;
+  const html = renderToStaticMarkup(React.createElement(PortalPageLoading));
+
+  assert.ok(html.includes('role="status"'));
+  assert.ok(html.includes('aria-live="polite"'));
+  assert.match(html, /<span[^>]*aria-hidden="true"[^>]*><\/span>/);
+  assert.match(html, /<span[^>]*aria-hidden="true"[^>]*>\.<\/span>/);
+});
+
+test("PortalPageLoading CSS defines 56px spinner, rotation keyframes, and full-screen overlay", () => {
+  const cssPath = path.join(portalDir, "PortalPageLoading.module.css");
+  assert.ok(fs.existsSync(cssPath), "PortalPageLoading.module.css must exist");
+
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  // Fixed full-screen overlay
+  assert.match(css, /\.pageLoading\s*\{[^}]*position:\s*fixed/s);
+  assert.match(css, /\.pageLoading\s*\{[^}]*inset:\s*0/s);
+  assert.match(css, /\.pageLoading\s*\{[^}]*display:\s*flex/s);
+
+  // 56px blue rotating spinner
+  assert.match(css, /\.loader\s*\{[^}]*width:\s*56px/s);
+  assert.match(css, /\.loader\s*\{[^}]*height:\s*56px/s);
+  assert.match(css, /\.loader\s*\{[^}]*border-radius:\s*50%/s);
+  assert.match(
+    css,
+    /\.loader\s*\{[^}]*animation:\s*rotation\s+1s\s+linear\s+infinite/s,
+  );
+  assert.match(
+    css,
+    /@keyframes\s+rotation\s*\{[^}]*0%\s*\{[^}]*transform:\s*rotate\(0deg\)/s,
+  );
+  assert.match(css, /100%\s*\{[^}]*transform:\s*rotate\(360deg\)/s);
+
+  // Animated dots styling
+  assert.match(css, /\.dots\s*\{[^}]*font-size:\s*1\.8rem/s);
+
+  // Reduced motion support
+  assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+});
+
+test("above-the-fold character asset constants match parity expectations", () => {
+  const modelPath = path.join(portalDir, "portalModel.ts");
+  const model = loadModule(modelPath);
+
+  const expectedImages = [
+    "/img/characters/bluefin-small.webp",
+    "/img/portal/characters/bluefin.webp",
+    "/img/portal/characters/karl.webp",
+    "/img/portal/characters/nest.webp",
+  ];
+
+  assert.deepEqual(Array.from(model.CHARACTER_IMAGES), expectedImages);
+  assert.deepEqual(Array.from(model.PORTAL_CHARACTER_IMAGES), expectedImages);
+
+  for (const imgPath of expectedImages) {
+    const diskPath = path.join(root, "static", imgPath);
+    assert.ok(fs.existsSync(diskPath), `Asset must exist on disk: ${imgPath}`);
+  }
+});
+
+test("PortalPrototype integrates PortalPageLoading overlay barrier with image preloader", () => {
+  const componentPath = path.join(portalDir, "PortalPrototype.tsx");
+  const prototypeModule = loadModule(componentPath);
+
+  assert.equal(typeof prototypeModule.useImagePreloader, "function");
+  assert.deepEqual(Array.from(prototypeModule.CHARACTER_IMAGES), [
+    "/img/characters/bluefin-small.webp",
+    "/img/portal/characters/bluefin.webp",
+    "/img/portal/characters/karl.webp",
+    "/img/portal/characters/nest.webp",
+  ]);
+
+  const html = renderToStaticMarkup(
+    React.createElement(prototypeModule.default),
+  );
+
+  // Loading overlay is rendered as an initial barrier
+  assert.ok(html.includes('role="status"'));
+  assert.ok(html.includes('aria-busy="true"'));
+  assert.ok(html.includes('aria-label="Loading page"'));
+  assert.ok(html.includes('id="portal-scenes"'));
+});
+
+test("image preloader hook utilizes Promise.all for character assets", () => {
+  const componentPath = path.join(portalDir, "PortalPrototype.tsx");
+  const source = fs.readFileSync(componentPath, "utf8");
+
+  assert.ok(
+    source.includes("Promise.all("),
+    "useImagePreloader must utilize Promise.all",
+  );
+  assert.ok(
+    source.includes("img.onload ="),
+    "preloader must hook into img.onload",
+  );
+  assert.ok(
+    source.includes("img.onerror ="),
+    "preloader must hook into img.onerror to prevent blocking",
+  );
+  assert.ok(
+    source.includes("PortalPageLoading"),
+    "PortalPrototype must mount PortalPageLoading",
+  );
+});

--- a/src/components/portal/PortalPageLoading.module.css
+++ b/src/components/portal/PortalPageLoading.module.css
@@ -1,0 +1,43 @@
+.pageLoading {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  background: var(--portal-bg, #0c1016);
+  color: var(--portal-text-light, #ffffff);
+}
+
+.loader {
+  width: 56px;
+  height: 56px;
+  border: 2px solid var(--portal-blue, var(--color-blue, #4285f4));
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.dots {
+  font-size: 1.8rem;
+  text-align: left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loader {
+    animation-duration: 2s;
+  }
+}

--- a/src/components/portal/PortalPageLoading.tsx
+++ b/src/components/portal/PortalPageLoading.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+import styles from "./PortalPageLoading.module.css";
+
+export default function PortalPageLoading(): React.JSX.Element {
+  const [dots, setDots] = useState(".");
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDots((prev) => (prev === "....." ? "." : prev + "."));
+    }, 500);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div
+      className={styles.pageLoading}
+      role="status"
+      aria-live="polite"
+      aria-label="Loading page"
+    >
+      <span className={styles.loader} aria-hidden="true" />
+      <span className={styles.dots} aria-hidden="true">
+        {dots}
+      </span>
+    </div>
+  );
+}

--- a/src/components/portal/PortalPrototype.tsx
+++ b/src/components/portal/PortalPrototype.tsx
@@ -5,8 +5,55 @@ import PortalBazaar from "./PortalBazaar";
 import PortalSectionPicker from "./PortalSectionPicker";
 import PortalCommunity from "./PortalCommunity";
 import PortalFooter from "./PortalFooter";
+import PortalPageLoading from "./PortalPageLoading";
 import styles from "./PortalPrototype.module.css";
-import { TRANSITION_SRC } from "./portalModel";
+import {
+  CHARACTER_IMAGES,
+  PORTAL_CHARACTER_IMAGES,
+  TRANSITION_SRC,
+} from "./portalModel";
+
+export { CHARACTER_IMAGES, PORTAL_CHARACTER_IMAGES };
+
+export function useImagePreloader(images: readonly string[]): boolean {
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    if (typeof Image === "undefined" || images.length === 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    Promise.all(
+      images.map((src) => {
+        return new Promise<void>((resolve) => {
+          const img = new Image();
+          img.src = src;
+          if (img.complete) {
+            resolve();
+          } else {
+            img.onload = () => resolve();
+            img.onerror = () => resolve();
+          }
+        });
+      }),
+    ).finally(() => {
+      setTimeout(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }, 100);
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [images]);
+
+  return isLoading;
+}
 
 const userBenefits = [
   "Applications by Flathub",
@@ -24,6 +71,8 @@ const developerBenefits = [
 ];
 
 export default function PortalPrototype(): React.JSX.Element {
+  const isLoading = useImagePreloader(CHARACTER_IMAGES);
+
   const handleDiscoverClick = (
     event: React.MouseEvent<HTMLAnchorElement>,
   ): void => {
@@ -44,7 +93,8 @@ export default function PortalPrototype(): React.JSX.Element {
   };
 
   return (
-    <main className={styles.portal}>
+    <main className={styles.portal} aria-busy={isLoading}>
+      {isLoading && <PortalPageLoading />}
       <div id="portal-scenes" className={styles.sceneStack}>
         <section id="scene-landing" className={styles.landingScene}>
           <div className={styles.landingGrid}>

--- a/src/components/portal/portalModel.ts
+++ b/src/components/portal/portalModel.ts
@@ -2,6 +2,15 @@ export const PORTAL_BREAKPOINT_PX = 956;
 export const MOBILE_LAYER_SRC = "/img/portal/mobile-parallax.webp";
 export const TRANSITION_SRC = "/img/portal/layer-transition.webp";
 
+export const PORTAL_CHARACTER_IMAGES = [
+  "/img/characters/bluefin-small.webp",
+  "/img/portal/characters/bluefin.webp",
+  "/img/portal/characters/karl.webp",
+  "/img/portal/characters/nest.webp",
+] as const;
+
+export const CHARACTER_IMAGES = PORTAL_CHARACTER_IMAGES;
+
 export type PortalDrift = "left" | "right";
 
 export type PortalLayer = {


### PR DESCRIPTION
Resolves #1133

### Summary of Changes
- Created `PortalPageLoading.tsx` and `PortalPageLoading.module.css` matching `projectbluefin.io` parity (`PageLoading.vue` & `_loading.scss`):
  - Fixed full-screen loading overlay barrier with `z-index: 1000` and dark background (`var(--portal-bg, #0c1016)`).
  - Rotating 56px blue spinner (`border: 2px solid var(--portal-blue, var(--color-blue, #4285f4))`).
  - Animated dot ellipsis starting at `.` and cycling through `.....` every 500ms before looping back.
- Defined `CHARACTER_IMAGES` / `PORTAL_CHARACTER_IMAGES` in `portalModel.ts` capturing above-the-fold character assets:
  - `/img/characters/bluefin-small.webp`
  - `/img/portal/characters/bluefin.webp`
  - `/img/portal/characters/karl.webp`
  - `/img/portal/characters/nest.webp`
- Implemented `useImagePreloader` hook in `PortalPrototype.tsx` utilizing `Promise.all(images.map(...))` to preload character assets and gracefully resolve on completion or error without blocking layout.
- Integrated `PortalPageLoading` overlay barrier in `PortalPrototype.tsx` to prevent layout shifts while preserving SSR scenes in order.
- Added comprehensive unit tests in `scripts/portal-page-loading.test.js`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e7c6f554`