### PR TITLE
fix(analytics): calculate and format hero deltas for the selected range

### DIFF
--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -135,20 +135,26 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
   }, [weeks, heroRange]);
 
   // Delta calculation for Bluefin fleet
-  const firstWeek = weeks[0] || ({} as CountmeWeek);
+  const firstWeek = heroFilteredWeeks[0] || ({} as CountmeWeek);
   const initialTotalBluefin =
     (Number(firstWeek.bluefin) || 0) +
       (Number(firstWeek["bluefin-lts"]) || 0) +
       (Number(firstWeek.dakota) || 0) +
       (Number(firstWeek.utah) || 0) || currentTotalBluefin;
 
-  const bluefinDeltaPct =
+  const rawDeltaPct =
     initialTotalBluefin > 0
-      ? (
-          ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
-          100
-        ).toFixed(1)
-      : "0.0";
+      ? ((currentTotalBluefin - initialTotalBluefin) / initialTotalBluefin) *
+        100
+      : 0;
+
+  const bluefinDeltaPct =
+    Math.abs(rawDeltaPct) < 0.05 ? "0.0" : rawDeltaPct.toFixed(1);
+
+  const heroDeltaFormatted =
+    Number(bluefinDeltaPct) > 0
+      ? `+${bluefinDeltaPct}%`
+      : `${bluefinDeltaPct}%`;
 
   // Filtered weeks for comparative time-series charts
   const filteredWeeks = useMemo(() => {
@@ -440,7 +446,7 @@ export default function CountmeAnalyticsCharts(): React.JSX.Element {
             </div>
             <div className={styles.heroMeta}>
               <span style={{ fontWeight: 700, color: "#39d2c0" }}>
-                +{bluefinDeltaPct}% overall
+                {heroDeltaFormatted} overall
               </span>
               <span>latest week ({latestWeek.week})</span>
             </div>


### PR DESCRIPTION
## Summary
Fixes #1087 by calculating the hero starting total from `heroFilteredWeeks[0]` (the first week in the selected range) rather than all-time history (`weeks[0]`), and conditionally formatting the delta sign so negative deltas do not render as `+-X%`.

- Base starting total calculation on `heroFilteredWeeks[0]`
- Conditionally prefix `+` only for positive deltas
- Avoid `-0.0%` by rounding deltas near zero to `0.0%`

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `31f7ecb2`