### PR TITLE
fix(cards): preserve prevVersion on header chips

### DIFF
--- a/scripts/lib/card-template.mjs
+++ b/scripts/lib/card-template.mjs
@@ -169,7 +169,7 @@ export function renderCard(
     const pkg = (release.majorPackages ?? []).find(
       (p) => p.name.toLowerCase() === name.toLowerCase()
     );
-    if (pkg) return [{ name: pkg.name, version: pkg.version }];
+    if (pkg) return [{ name: pkg.name, version: pkg.version, prevVersion: pkg.prevVersion }];
     return [];
   });
 


### PR DESCRIPTION
## Summary

Fixes #1171.

In `scripts/lib/card-template.mjs`, `headerChips` projected `{ name: pkg.name, version: pkg.version }`, discarding `prevVersion` even when present in `release.majorPackages`. Inside `versionChip()`, `changed = Boolean(prevVersion)` was always `false`, preventing header chips (Kernel, Mesa, Podman, systemd, etc.) from ever rendering the amber change highlight or the `↑` arrow.

## Changes
- `scripts/lib/card-template.mjs`: Include `prevVersion: pkg.prevVersion` in the `headerChips` projection.

## Verification
- Tested with `node --test scripts/card-template.test.js`.

— hive: backend=copilot model=gemini-3.8-flash