### PR TITLE
fix(driver-versions): generate Bluefin LTS release links with stable tags

### DIFF
--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -170,7 +170,10 @@ function rowFromSbomRelease(
     tag: releaseEntry?.tag || cacheKey,
     title: releaseEntry?.tag || cacheKey,
     releaseUrl: (() => {
-      const tag = releaseEntry?.tag || cacheKey;
+      let tag = releaseEntry?.tag || cacheKey;
+      if (streamId === "bluefin-lts" && typeof tag === "string") {
+        tag = tag.replace(/^lts-(\d{8})$/, "stable-$1");
+      }
       const repo = RELEASE_REPO_BY_STREAM[streamId];
       return repo && tag
         ? `https://github.com/${repo}/releases/tag/${tag}`

--- a/scripts/fetch-github-driver-versions.test.js
+++ b/scripts/fetch-github-driver-versions.test.js
@@ -56,6 +56,31 @@ test("rowFromSbomRelease builds kernel/mesa/gnome from SBOM only", () => {
   assert.equal(row.versions.mesa, "25.3.6-6");
   assert.equal(row.versions.gnome, "49.5-1");
   assert.equal(row.versions.nvidia, "595.58.03-1");
+  assert.equal(
+    row.releaseUrl,
+    "https://github.com/projectbluefin/bluefin/releases/tag/stable-20260331",
+  );
+});
+
+test("rowFromSbomRelease translates LTS lts-YYYYMMDD cache key to upstream stable-YYYYMMDD releaseUrl", () => {
+  const row = rowFromSbomRelease(
+    "bluefin-lts",
+    "lts-20260602",
+    {
+      tag: "lts-20260602",
+      packageVersions: {
+        kernel: "6.12.0-233.el10",
+      },
+    },
+    "595.71.05",
+  );
+
+  assert.equal(row.tag, "lts-20260602");
+  assert.equal(row.title, "lts-20260602");
+  assert.equal(
+    row.releaseUrl,
+    "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260602",
+  );
 });
 
 test("buildStreamFromSbom sorts newest-first and marks source sbom", () => {

--- a/static/data/driver-versions.json
+++ b/static/data/driver-versions.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-06T23:03:51.211Z",
+  "generatedAt": "2026-09-10T01:42:07.293Z",
   "cacheHours": 168,
   "historyDays": 90,
   "streams": [
@@ -52,7 +52,7 @@
         "stream": "bluefin-lts",
         "tag": "lts-20260602",
         "title": "lts-20260602",
-        "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/lts-20260602",
+        "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260602",
         "publishedAt": "2026-06-02T00:00:00.000Z",
         "versions": {
           "kernel": "6.12.0-233.el10",
@@ -67,7 +67,7 @@
           "stream": "bluefin-lts",
           "tag": "lts-20260602",
           "title": "lts-20260602",
-          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/lts-20260602",
+          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260602",
           "publishedAt": "2026-06-02T00:00:00.000Z",
           "versions": {
             "kernel": "6.12.0-233.el10",
@@ -81,7 +81,7 @@
           "stream": "bluefin-lts",
           "tag": "lts-20260531",
           "title": "lts-20260531",
-          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/lts-20260531",
+          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260531",
           "publishedAt": "2026-05-31T00:00:00.000Z",
           "versions": {
             "kernel": "6.12.0-231.el10",
@@ -95,7 +95,7 @@
           "stream": "bluefin-lts",
           "tag": "lts-20260530",
           "title": "lts-20260530",
-          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/lts-20260530",
+          "releaseUrl": "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260530",
           "publishedAt": "2026-05-30T00:00:00.000Z",
           "versions": {
             "kernel": "6.12.0-231.el10",


### PR DESCRIPTION
Fixes #1080

### Problem
`scripts/fetch-github-driver-versions.js` built Bluefin LTS release URLs with internal `lts-YYYYMMDD` cache keys, but upstream `projectbluefin/bluefin-lts` releases are tagged `stable-YYYYMMDD`. This resulted in broken 404 links on the LTS driver timeline.

### Solution
- In `rowFromSbomRelease`, translate `bluefin-lts` release tags matching `^lts-(\d{8})$` to `stable-$1` when constructing the `releaseUrl`.
- Keep `row.tag` and `row.title` intact as `lts-YYYYMMDD` so rebase commands and frontend keying remain consistent.
- Update `static/data/driver-versions.json` with the corrected release URLs.
- Add unit test coverage verifying the translation for `bluefin-lts`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `96dfec92`