### PR TITLE
fix(gnome-extensions): render missing and unavailable extension data states

### DIFF
--- a/scripts/fetch-gnome-extensions.js
+++ b/scripts/fetch-gnome-extensions.js
@@ -96,6 +96,15 @@ function buildExtensionRecord(pk, data, localScreenshot = null) {
     donateUrl: data.donate_url || null,
   };
 }
+function buildUnavailableOutput(reason = "GNOME extensions API unavailable") {
+  return {
+    generatedAt: new Date().toISOString(),
+    unavailable: true,
+    stateReason: reason,
+    extensions: [],
+  };
+}
+
 
 async function fetchExtensionData(pk) {
   const url = `https://extensions.gnome.org/extension-info/?pk=${pk}`;
@@ -140,8 +149,11 @@ async function main() {
   }
 
   if (extensions.length === 0) {
-    console.error("All extension fetches failed — aborting.");
-    process.exit(1);
+    const unavailableReason = "GNOME extensions API unavailable";
+    console.warn(`All extension fetches failed — writing unavailable payload (${unavailableReason}).`);
+    const unavailablePayload = buildUnavailableOutput(unavailableReason);
+    fs.writeFileSync(OUTPUT_JSON, JSON.stringify(unavailablePayload, null, 2) + "\n");
+    return;
   }
   if (extensions.length < EXTENSION_IDS.length) {
     console.warn(`Warning: only ${extensions.length}/${EXTENSION_IDS.length} extensions fetched.`);
@@ -157,5 +169,6 @@ if (require.main === module) {
 
 module.exports = {
   buildExtensionRecord,
+  buildUnavailableOutput,
   isStale,
 };

--- a/scripts/fetch-gnome-extensions.test.js
+++ b/scripts/fetch-gnome-extensions.test.js
@@ -4,6 +4,7 @@ const path = require("path");
 
 const {
   buildExtensionRecord,
+  buildUnavailableOutput,
   isStale,
 } = require("./fetch-gnome-extensions.js");
 
@@ -40,4 +41,11 @@ test("isStale returns true when the cache file does not exist", () => {
     isStale(path.join(__dirname, "..", "static", "data", "missing-gnome-extensions.json")),
     true,
   );
+});
+test("buildUnavailableOutput creates unavailable payload with reason", () => {
+  const payload = buildUnavailableOutput("Service unreachable");
+  assert.equal(payload.unavailable, true);
+  assert.equal(payload.stateReason, "Service unreachable");
+  assert.deepEqual(payload.extensions, []);
+  assert.ok(payload.generatedAt);
 });

--- a/src/components/GnomeExtensions.tsx
+++ b/src/components/GnomeExtensions.tsx
@@ -23,14 +23,32 @@ const GnomeExtensions: React.FC<GnomeExtensionsProps> = ({ extensionId }) => {
   const [extension, setExtension] = useState<ExtensionData | null>(null);
   const [imageError, setImageError] = useState(false);
   const [loadError, setLoadError] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [unavailableReason, setUnavailableReason] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/data/gnome-extensions.json")
       .then((response) => response.json())
-      .then((data: ExtensionData[]) => {
-        const ext = data.find((item) => item.id === extensionId);
-        if (ext) {
-          setExtension(ext);
+      .then((data: unknown) => {
+        if (!data) {
+          setLoadError(true);
+          return;
+        }
+        if (Array.isArray(data)) {
+          const ext = data.find((item: ExtensionData) => item?.id === extensionId);
+          if (ext) {
+            setExtension(ext);
+          } else {
+            setNotFound(true);
+          }
+        } else if (typeof data === "object" && "unavailable" in data && Boolean(data.unavailable)) {
+          const reason = "stateReason" in data && typeof data.stateReason === "string"
+            ? data.stateReason
+            : "Extension data unavailable.";
+          setUnavailableReason(reason);
+          setLoadError(true);
+        } else {
+          setLoadError(true);
         }
       })
       .catch((error) => {
@@ -43,7 +61,19 @@ const GnomeExtensions: React.FC<GnomeExtensionsProps> = ({ extensionId }) => {
     return (
       <div className={styles.extensionBox}>
         <div className={styles.extensionInfo}>
-          <p className={styles.extensionDescription}>Extension data unavailable.</p>
+          <p className={styles.extensionDescription}>
+            {unavailableReason ?? "Extension data unavailable."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className={styles.extensionBox}>
+        <div className={styles.extensionInfo}>
+          <p className={styles.extensionDescription}>Extension #{extensionId} not found.</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Fixes #1095.

`GnomeExtensions.tsx` previously never transitioned out of Loading when an extension was absent from the generated array, and calling `.find()` on an unavailable-object payload would throw. In addition, `scripts/fetch-gnome-extensions.js` previously exited with code 1 when all fetches failed instead of emitting the repository-standard unavailable payload.

## Changes
- `src/components/GnomeExtensions.tsx`:
  - Guard the parsed payload to check whether it's an array or an unavailable object with `unavailable: true`.
  - Set `notFound: true` if the extension ID is absent from the array, rendering an explicit `Extension #{id} not found.` state.
  - Display `unavailableReason` from `stateReason` if the dataset is in an unavailable state.
- `scripts/fetch-gnome-extensions.js`:
  - Added `buildUnavailableOutput(reason)`.
  - When all fetches fail, write the unavailable payload to `OUTPUT_JSON` and return gracefully without non-zero exit.
- `scripts/fetch-gnome-extensions.test.js`:
  - Added unit test covering `buildUnavailableOutput`.

## Verification
- `node --test scripts/fetch-gnome-extensions.test.js` passes (3 tests).

— hive: backend=copilot model=gemini-3.8-flash