### PR TITLE
fix(feed-items): supply NVIDIA versions at the data shape the release feed consumes

### DIFF
--- a/scripts/fetch-firehose.js
+++ b/scripts/fetch-firehose.js
@@ -1,5 +1,10 @@
 const fs = require("fs");
 const path = require("path");
+const {
+  buildNvidiaMapFromSbomStream,
+  buildLtsNvidiaByTagFromSbom,
+  resolveCompanionNvidia,
+} = require("./fetch-github-driver-versions.js");
 
 const OUTPUT_DIR = path.join(__dirname, "..", "static", "data");
 const OUTPUT_FILE = path.join(OUTPUT_DIR, "firehose-apps.json");
@@ -83,6 +88,7 @@ function buildOsInfo(streamId, packageVersions) {
   if (packageVersions.podman) majorPackages["Podman"] = packageVersions.podman;
   if (packageVersions.systemd) majorPackages["systemd"] = packageVersions.systemd;
   if (packageVersions.bootc) majorPackages["bootc"] = packageVersions.bootc;
+  if (packageVersions.nvidia) majorPackages["NVIDIA"] = packageVersions.nvidia;
 
   if (Object.keys(majorPackages).length > 0) {
     info.majorPackages = majorPackages;
@@ -140,6 +146,16 @@ function buildOsApp(spec, sbomCache) {
   const stream = sbomCache?.streams?.[spec.streamId];
   const releases = sortedReleases(stream);
 
+  let nvidiaByTag = null;
+  if (spec.streamId === "bluefin-stable") {
+    nvidiaByTag = buildNvidiaMapFromSbomStream(
+      sbomCache,
+      "bluefin-nvidia-open-stable",
+    );
+  } else if (spec.streamId === "bluefin-lts") {
+    nvidiaByTag = buildLtsNvidiaByTagFromSbom(sbomCache);
+  }
+
   // Find the most recent entry that has packageVersions populated
   const latestWithVersions = releases.find((r) => r.packageVersions != null);
 
@@ -157,7 +173,16 @@ function buildOsApp(spec, sbomCache) {
       currentReleaseDate = `${currentReleaseVersion}T00:00:00Z`;
       updatedAt = currentReleaseDate;
     }
-    osInfo = buildOsInfo(spec.streamId, latestWithVersions.packageVersions);
+    const companionNvidia = resolveCompanionNvidia(
+      nvidiaByTag,
+      latestWithVersions,
+      latestWithVersions.cacheKey,
+    );
+    const resolvedPackageVersions = {
+      ...latestWithVersions.packageVersions,
+      nvidia: latestWithVersions.packageVersions.nvidia || companionNvidia || null,
+    };
+    osInfo = buildOsInfo(spec.streamId, resolvedPackageVersions);
   } else if (releases.length > 0) {
     // Have releases but none with packageVersions yet (SBOM not populated for this entry)
     const first = releases[0];
@@ -192,6 +217,13 @@ function buildOsApp(spec, sbomCache) {
       packageDiff = computePackageDiff(currentAllPkgs, prevAllPkgs);
     }
 
+    const companionNvidia = r.packageVersions
+      ? resolveCompanionNvidia(nvidiaByTag, r, r.cacheKey)
+      : null;
+    const nvidiaVersion = r.packageVersions
+      ? r.packageVersions.nvidia || companionNvidia || null
+      : null;
+
     return {
       version: dateStr || r.cacheKey,
       date: (dateStr ? `${dateStr}T00:00:00Z` : null) || r.checkedAt,
@@ -210,6 +242,7 @@ function buildOsApp(spec, sbomCache) {
             systemd: r.packageVersions.systemd,
             bootc: r.packageVersions.bootc,
             fedora: r.packageVersions.fedora,
+            nvidia: nvidiaVersion,
           }
         : null,
       packageDiff,

--- a/scripts/fetch-firehose.test.js
+++ b/scripts/fetch-firehose.test.js
@@ -27,6 +27,7 @@ test("buildOsInfo keeps core OS versions and major packages", () => {
     mesa: "25.0",
     podman: "5.4",
     systemd: "257",
+    nvidia: "595.71.05",
   });
 
   assert.deepEqual(info, {
@@ -38,8 +39,77 @@ test("buildOsInfo keeps core OS versions and major packages", () => {
     majorPackages: {
       Podman: "5.4",
       systemd: "257",
+      NVIDIA: "595.71.05",
     },
   });
+});
+
+test("buildOsApp resolves companion NVIDIA versions for stable and LTS streams", () => {
+  const sbomCache = {
+    streams: {
+      "bluefin-stable": {
+        releases: {
+          "stable-20260402": {
+            packageVersions: {
+              kernel: "6.14.1",
+              gnome: "48.1",
+              nvidia: null,
+            },
+          },
+        },
+      },
+      "bluefin-nvidia-open-stable": {
+        releases: {
+          "nvidia-open-stable-20260402": {
+            packageVersions: {
+              nvidia: "595.71.05",
+            },
+          },
+        },
+      },
+      "bluefin-lts": {
+        releases: {
+          "lts-20260402": {
+            packageVersions: {
+              kernel: "6.12.0",
+              gnome: "47.2",
+            },
+          },
+        },
+      },
+      "bluefin-lts-nvidia": {
+        releases: {
+          "lts-nvidia-20260402": {
+            packageVersions: {
+              nvidia: "580.40.01",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const stableSpec = {
+    streamId: "bluefin-stable",
+    appId: "bluefin-os-stable",
+    name: "Bluefin OS (Stable)",
+    summary: "Stable track",
+    ghReleasesUrl: "https://github.com/projectbluefin/bluefin/releases",
+  };
+  const stableApp = buildOsApp(stableSpec, sbomCache);
+  assert.equal(stableApp.osInfo.majorPackages.NVIDIA, "595.71.05");
+  assert.equal(stableApp.releases[0].packageVersions.nvidia, "595.71.05");
+
+  const ltsSpec = {
+    streamId: "bluefin-lts",
+    appId: "bluefin-os-lts",
+    name: "Bluefin OS (LTS)",
+    summary: "LTS track",
+    ghReleasesUrl: "https://github.com/projectbluefin/bluefin-lts/releases",
+  };
+  const ltsApp = buildOsApp(ltsSpec, sbomCache);
+  assert.equal(ltsApp.osInfo.majorPackages.NVIDIA, "580.40.01");
+  assert.equal(ltsApp.releases[0].packageVersions.nvidia, "580.40.01");
 });
 
 test("buildOsApp picks the newest populated release and computes package diffs", () => {

--- a/src/types/firehose.ts
+++ b/src/types/firehose.ts
@@ -15,6 +15,7 @@ export interface FirehosePackageVersions {
   systemd?: string | null;
   bootc?: string | null;
   fedora?: string | null;
+  nvidia?: string | null;
   /** Full RPM name→version map — used for diff computation */
   allPackages?: Record<string, string> | null;
 }

--- a/static/data/firehose-apps.json
+++ b/static/data/firehose-apps.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-07-21T01:48:56.994Z",
+  "generatedAt": "2026-09-10T02:41:58.502Z",
   "generatedBy": "bluefin-releases v1.0.0",
   "buildDuration": "9.357971736s",
   "stats": {
@@ -37,7 +37,8 @@
         "majorPackages": {
           "Podman": "5.8.2",
           "systemd": "259.5",
-          "bootc": "1.15.2"
+          "bootc": "1.15.2",
+          "NVIDIA": "595.71.05"
         }
       },
       "releases": [
@@ -65,12 +66,13 @@
             "podman": "5.8.2",
             "systemd": "259.5",
             "bootc": "1.15.2",
-            "fedora": "F44"
+            "fedora": "F44",
+            "nvidia": "595.71.05"
           },
           "packageDiff": null
         }
       ],
-      "fetchedAt": "2026-07-21T01:48:56.990Z",
+      "fetchedAt": "2026-09-10T02:41:58.499Z",
       "isVerified": false,
       "appSet": "core",
       "packageType": "os"
@@ -92,7 +94,8 @@
         "majorPackages": {
           "Podman": "5.8.2",
           "systemd": "257",
-          "bootc": "1.15.2"
+          "bootc": "1.15.2",
+          "NVIDIA": "595.71.05"
         }
       },
       "releases": [
@@ -110,7 +113,8 @@
             "podman": "5.8.2",
             "systemd": "257",
             "bootc": "1.15.2",
-            "fedora": null
+            "fedora": null,
+            "nvidia": "595.71.05"
           },
           "packageDiff": {
             "added": [],
@@ -153,7 +157,8 @@
             "podman": "5.8.2",
             "systemd": "257",
             "bootc": "1.15.2",
-            "fedora": null
+            "fedora": null,
+            "nvidia": "595.71.05"
           },
           "packageDiff": {
             "added": [],
@@ -175,12 +180,13 @@
             "podman": "5.8.2",
             "systemd": "257",
             "bootc": "1.15.2",
-            "fedora": null
+            "fedora": null,
+            "nvidia": "595.71.05"
           },
           "packageDiff": null
         }
       ],
-      "fetchedAt": "2026-07-21T01:48:56.994Z",
+      "fetchedAt": "2026-09-10T02:41:58.502Z",
       "isVerified": false,
       "appSet": "core",
       "packageType": "os"


### PR DESCRIPTION
Resolves projectbluefin/documentation#1096

### Description
The release feed in `src/components/FeedItems.tsx` queries NVIDIA driver versions via `getNvidiaVersionFromFirehose`, which looks at `FIREHOSE_OS_APP_LOOKUP[appId]?.osInfo?.majorPackages?.NVIDIA` (or `Nvidia` / `nvidia`). Previously, `fetch-firehose.js` did not resolve or populate NVIDIA versions in `osInfo.majorPackages` or in the per-release `packageVersions`.

This PR:
- Imports NVIDIA companion stream helper functions from `scripts/fetch-github-driver-versions.js` (`buildNvidiaMapFromSbomStream`, `buildLtsNvidiaByTagFromSbom`, and `resolveCompanionNvidia`).
- Resolves companion NVIDIA versions for `bluefin-stable` (from `bluefin-nvidia-open-stable`) and `bluefin-lts` (from LTS NVIDIA streams).
- Adds `majorPackages["NVIDIA"]` in `buildOsInfo` when `packageVersions.nvidia` is present.
- Preserves resolved `nvidia` versions on `releases[].packageVersions` in synthesized OS app entries.
- Updates `FirehosePackageVersions` in `src/types/firehose.ts` to declare optional `nvidia` version field.
- Adds test cases in `scripts/fetch-firehose.test.js` covering companion NVIDIA resolution.
- Regenerates `static/data/firehose-apps.json` with `NVIDIA` populated.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f56ae762`