### PR TITLE
fix(pin-state): replace removed Bluefin LTS HWE workflow paths

### DIFF
--- a/scripts/fetch-pin-state.js
+++ b/scripts/fetch-pin-state.js
@@ -1,8 +1,8 @@
 /**
  * fetch-pin-state.js
  *
- * Reads bluefin-lts HWE workflow YAML files from the GitHub Contents API
- * and extracts any `kernel-pin` (or future `*-pin`) workflow inputs.
+ * Reads bluefin-lts build workflows and image-version files from the GitHub Contents API
+ * and extracts any `kernel-pin` (or future `*-pin`) workflow inputs or version pins.
  * Writes static/data/stream-pins.json consumed by the docs UI to render
  * 📌 "Pinned" badges next to intentionally-held component versions.
  *
@@ -12,34 +12,49 @@
 const fs = require("fs");
 const path = require("path");
 
-const OUTPUT_FILE = path.join(__dirname, "..", "static", "data", "stream-pins.json");
+const OUTPUT_FILE = path.join(
+  __dirname,
+  "..",
+  "static",
+  "data",
+  "stream-pins.json",
+);
 
 const WORKFLOWS_TO_CHECK = [
   {
     repo: "projectbluefin/bluefin-lts",
-    path: ".github/workflows/build-regular-hwe.yml",
+    path: ".github/workflows/build-regular.yml",
     stream: "bluefin-lts",
   },
   {
     repo: "projectbluefin/bluefin-lts",
-    path: ".github/workflows/build-dx-hwe.yml",
+    path: ".github/workflows/build-nvidia.yml",
+    stream: "bluefin-lts",
+  },
+  {
+    repo: "projectbluefin/bluefin-lts",
+    path: "image-versions.yaml",
     stream: "bluefin-lts",
   },
 ];
 
 async function fetchWorkflowContent(repo, filePath) {
   const url = `https://api.github.com/repos/${repo}/contents/${filePath}`;
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   const headers = {
     "User-Agent": "bluefin-docs/fetch-pin-state",
     Accept: "application/vnd.github.v3+json",
-    ...(process.env.GITHUB_TOKEN
-      ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
-      : {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
 
-  const response = await fetch(url, { headers, signal: AbortSignal.timeout(15000) });
+  const response = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(15000),
+  });
   if (!response.ok) {
-    throw new Error(`GitHub API error for ${repo}/${filePath}: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `GitHub API error for ${repo}/${filePath}: ${response.status} ${response.statusText}`,
+    );
   }
 
   const data = await response.json();
@@ -47,12 +62,51 @@ async function fetchWorkflowContent(repo, filePath) {
 }
 
 /**
- * Extract `kernel-pin` value from a workflow YAML string.
- * Matches the pattern:   kernel-pin: <version>
+ * Extract `kernel-pin` value from a workflow YAML or version file string.
+ * Matches patterns:
+ *   kernel-pin: <version>
+ *   kernel_pin: <version>
+ *   pins:
+ *     kernel: <version>
  */
 function extractKernelPin(yamlContent) {
-  const match = yamlContent.match(/kernel-pin:\s*([^\s\n#]+)/);
-  return match ? match[1].trim() : null;
+  if (!yamlContent || typeof yamlContent !== "string") {
+    return null;
+  }
+
+  const directMatch = yamlContent.match(
+    /kernel[-_]pin:\s*["']?([^\s\n#"']+)["']?/,
+  );
+  if (directMatch) {
+    return directMatch[1].trim();
+  }
+
+  const lines = yamlContent.split(/\r?\n/);
+  let inPinsBlock = false;
+  let pinsIndent = 0;
+
+  for (const line of lines) {
+    const pinsMatch = line.match(/^(\s*)pins:\s*(?:#.*)?$/);
+    if (pinsMatch) {
+      inPinsBlock = true;
+      pinsIndent = pinsMatch[1].length;
+      continue;
+    }
+
+    if (inPinsBlock) {
+      const indentMatch = line.match(/^(\s*)\S/);
+      if (indentMatch && indentMatch[1].length <= pinsIndent) {
+        inPinsBlock = false;
+        continue;
+      }
+      const kernelMatch = line.match(/^\s*kernel:\s*["']?([^\s\n#"']+)["']?/);
+      if (kernelMatch) {
+        return kernelMatch[1].trim();
+      }
+    }
+  }
+
+  return null;
 }
 
 function applyKernelPin(streamPins, stream, kernelPin, filePath) {
@@ -92,13 +146,15 @@ async function main() {
         console.log(`  ${stream}: no kernel-pin found (floating)`);
       }
     } catch (err) {
-      console.warn(`  Warning: could not fetch ${repo}/${filePath}: ${err.message}`);
+      console.warn(
+        `  Warning: could not fetch ${repo}/${filePath}: ${err.message}`,
+      );
       // Non-fatal: keep any previously discovered pin for this stream.
     }
   }
 
   // Ensure all known streams appear in the output, even if empty (= all floating).
-  for (const stream of ["bluefin-stable"]) {
+  for (const stream of ["bluefin-stable", "bluefin-lts"]) {
     if (!streamPins[stream]) {
       streamPins[stream] = {};
     }
@@ -123,4 +179,6 @@ if (require.main === module) {
 module.exports = {
   applyKernelPin,
   extractKernelPin,
+  fetchWorkflowContent,
+  WORKFLOWS_TO_CHECK,
 };

--- a/scripts/fetch-pin-state.test.js
+++ b/scripts/fetch-pin-state.test.js
@@ -4,23 +4,90 @@ const assert = require("node:assert/strict");
 const {
   applyKernelPin,
   extractKernelPin,
+  WORKFLOWS_TO_CHECK,
 } = require("./fetch-pin-state.js");
 
+test("WORKFLOWS_TO_CHECK targets active Bluefin LTS workflows and image version sources", () => {
+  const paths = WORKFLOWS_TO_CHECK.map((w) => w.path);
+
+  assert.ok(paths.includes(".github/workflows/build-regular.yml"));
+  assert.ok(paths.includes(".github/workflows/build-nvidia.yml"));
+  assert.ok(paths.includes("image-versions.yaml"));
+
+  // Verify removed paths are no longer configured
+  assert.ok(!paths.includes(".github/workflows/build-regular-hwe.yml"));
+  assert.ok(!paths.includes(".github/workflows/build-dx-hwe.yml"));
+
+  for (const entry of WORKFLOWS_TO_CHECK) {
+    assert.equal(entry.repo, "projectbluefin/bluefin-lts");
+    assert.equal(entry.stream, "bluefin-lts");
+  }
+});
+
 test("extractKernelPin reads kernel-pin values and ignores missing pins", () => {
-  assert.equal(extractKernelPin("kernel-pin: 6.12.30-204 # comment"), "6.12.30-204");
+  assert.equal(
+    extractKernelPin("kernel-pin: 6.12.30-204 # comment"),
+    "6.12.30-204",
+  );
+  assert.equal(extractKernelPin("kernel_pin: 6.12.30-204"), "6.12.30-204");
+  assert.equal(extractKernelPin('kernel-pin: "6.12.30-204"'), "6.12.30-204");
+  assert.equal(extractKernelPin("kernel_pin: '6.12.30-204'"), "6.12.30-204");
+  assert.equal(
+    extractKernelPin("pins:\n  kernel: 6.12.30-204\n"),
+    "6.12.30-204",
+  );
+  assert.equal(
+    extractKernelPin("pins:\n  gnome: 50\n  kernel: '6.12.30-204'\n"),
+    "6.12.30-204",
+  );
+  assert.equal(extractKernelPin("name: build-regular"), null);
   assert.equal(extractKernelPin("name: build-regular-hwe"), null);
+  assert.equal(extractKernelPin(""), null);
+  assert.equal(extractKernelPin(null), null);
 });
 
 test("applyKernelPin stores a stream pin and rejects conflicting values", () => {
   const streamPins = {};
 
-  applyKernelPin(streamPins, "bluefin-lts", "6.12.30-204", "build-regular-hwe.yml");
+  applyKernelPin(
+    streamPins,
+    "bluefin-lts",
+    "6.12.30-204",
+    ".github/workflows/build-regular.yml",
+  );
   assert.deepEqual(streamPins, {
     "bluefin-lts": { hweKernel: "6.12.30-204" },
   });
 
+  // Matching pin from another file should not throw
+  applyKernelPin(
+    streamPins,
+    "bluefin-lts",
+    "6.12.30-204",
+    ".github/workflows/build-nvidia.yml",
+  );
+  assert.deepEqual(streamPins, {
+    "bluefin-lts": { hweKernel: "6.12.30-204" },
+  });
+
+  // Conflicting pin should throw
   assert.throws(
-    () => applyKernelPin(streamPins, "bluefin-lts", "6.12.31-204", "build-dx-hwe.yml"),
+    () =>
+      applyKernelPin(
+        streamPins,
+        "bluefin-lts",
+        "6.12.31-204",
+        "image-versions.yaml",
+      ),
     /Conflicting hweKernel pins/,
   );
+
+  // Null pin should not overwrite existing pin
+  applyKernelPin(
+    streamPins,
+    "bluefin-lts",
+    null,
+    ".github/workflows/build-regular.yml",
+  );
+  assert.equal(streamPins["bluefin-lts"].hweKernel, "6.12.30-204");
 });

--- a/static/data/stream-pins.json
+++ b/static/data/stream-pins.json
@@ -1,6 +1,7 @@
 {
-  "generatedAt": "2026-07-21T05:48:34.788Z",
+  "generatedAt": "2026-09-10T11:49:08.642Z",
   "streams": {
+    "bluefin-lts": {},
     "bluefin-stable": {}
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1092 by updating `scripts/fetch-pin-state.js` to target active Bluefin LTS workflows and authoritative version sources in `projectbluefin/bluefin-lts`, replacing the removed `build-regular-hwe.yml` and `build-dx-hwe.yml` workflow paths.

## Changes
- **Replace obsolete workflow paths**: Configure `WORKFLOWS_TO_CHECK` with `.github/workflows/build-regular.yml`, `.github/workflows/build-nvidia.yml`, and `image-versions.yaml` from `projectbluefin/bluefin-lts`.
- **Align authentication**: Support `GH_TOKEN` along with `GITHUB_TOKEN` in `fetchWorkflowContent` to align with the rest of the documentation fetch scripts and prevent unauthenticated rate limiting.
- **Support varied pin declarations**: Enhance `extractKernelPin` to support `kernel-pin:` and `kernel_pin:`, optional quotes, and nested `pins:` blocks.
- **Ensure stream presence**: Ensure `bluefin-lts` is consistently populated in `static/data/stream-pins.json` alongside `bluefin-stable` even when floating without pins.
- **Unit test coverage**: Update `scripts/fetch-pin-state.test.js` to assert the active workflow paths and test new pin syntax formats.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `0abbc32f`