### PR TITLE
fix(factory): render an unavailable change-failure rate instead of 0.0 percent

### DIFF
--- a/scripts/metrics-panels.test.js
+++ b/scripts/metrics-panels.test.js
@@ -436,6 +436,35 @@ function render(fixtures) {
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
+test("null change failure rate renders unavailable marker, never 0.0%", () => {
+  const doraNullRate = {
+    ...DORA,
+    current: { ...DORA.current, changeFailureRate: null },
+  };
+  const html = render({
+    countme: COUNTME_FULL,
+    brew: BREW,
+    dora: doraNullRate,
+    scorecard: SCORECARD,
+  });
+  assert.ok(!html.includes("0.0%"));
+  assert.ok(html.includes("—"));
+});
+
+test("zero change failure rate renders 0.0%", () => {
+  const doraZeroRate = {
+    ...DORA,
+    current: { ...DORA.current, changeFailureRate: 0 },
+  };
+  const html = render({
+    countme: COUNTME_FULL,
+    brew: BREW,
+    dora: doraZeroRate,
+    scorecard: SCORECARD,
+  });
+  assert.ok(html.includes("0.0%"));
+});
+
 test("lead time renders as not-measured, never as 0", () => {
   const html = render({
     countme: COUNTME_FULL,

--- a/src/components/factory/panels/MetricsPanels.tsx
+++ b/src/components/factory/panels/MetricsPanels.tsx
@@ -56,12 +56,12 @@ interface DoraMonthly {
   passed: number;
   failed: number;
   running?: number;
-  failureRate: number;
+  failureRate: number | null;
   medianDurationMin: number;
 }
 interface DoraCurrent {
   deploymentsPerWeek: number;
-  changeFailureRate: number;
+  changeFailureRate: number | null;
   medianLeadTimeHours: number | null;
   leadTimeReason?: string;
 }
@@ -113,7 +113,8 @@ function fmt(n: number | null | undefined): string {
   return n.toLocaleString("en-US");
 }
 
-function pct(n: number): string {
+function pct(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "—";
   return `${(n * 100).toFixed(1)}%`;
 }
 


### PR DESCRIPTION
Resolves #1091

### Problem
`pct(n)` in `MetricsPanels.tsx` multiplied `null` by 100, so missing `changeFailureRate` data from `fetch-dora.js` (which deliberately emits `null` when no terminal runs exist) was formatted as `0.0%`.

### Fix
- Updated `pct(n)` to check for `null`, `undefined`, or non-finite values and render an unavailable marker (`—`), reserving `0.0%` exclusively for real measured zero values.
- Updated `DoraCurrent.changeFailureRate` and `DoraMonthly.failureRate` type definitions to `number | null`.
- Added unit tests in `scripts/metrics-panels.test.js` verifying that `null` change failure rates render `—` rather than `0.0%`, and that actual zero values render `0.0%`.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `8c0d23a8`