### PR TITLE
fix(factory): use a public queue-data fallback for anonymous visitors

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
           "style-src 'self' 'unsafe-inline'",
           "img-src 'self' data: https:",
           "font-src 'self' data:",
-          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://queue.projectbluefin.io https://hosted-projectbluefin-knuckle-gjvq.hive.hivecommons.dev https://hive.kubestellar.io",
+          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://projectbluefin.github.io https://hosted-projectbluefin-knuckle-gjvq.hive.hivecommons.dev https://hive.kubestellar.io",
           "frame-src https://giscus.app https://www.youtube.com https://youtube.com https://insights.linuxfoundation.org",
         ].join("; "),
       },

--- a/scripts/factory-queue-fallback.test.js
+++ b/scripts/factory-queue-fallback.test.js
@@ -1,0 +1,166 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+const React = require("react");
+
+const dashboardPath = path.join(
+  __dirname,
+  "..",
+  "src",
+  "components",
+  "HiveFactoryDashboard.tsx",
+);
+const configPath = path.join(__dirname, "..", "docusaurus.config.ts");
+
+function loadDashboardModule() {
+  const { outputText } = ts.transpileModule(
+    fs.readFileSync(dashboardPath, "utf8"),
+    {
+      compilerOptions: {
+        jsx: ts.JsxEmit.React,
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.CommonJS,
+      },
+    },
+  );
+  const mod = { exports: {} };
+  new Function("require", "module", "exports", outputText)(
+    (id) => {
+      if (id.endsWith(".css")) return {};
+      if (id.includes("FactoryDataContext")) {
+        return {
+          useDataset: () => ({
+            data: null,
+            loading: false,
+            reason: null,
+          }),
+        };
+      }
+      if (id === "@docusaurus/Link") {
+        return { __esModule: true, default: ({ children }) => children };
+      }
+      if (id === "@theme/Heading") {
+        return { __esModule: true, default: ({ children }) => children };
+      }
+      if (id === "@theme/Layout") {
+        return { __esModule: true, default: ({ children }) => children };
+      }
+      if (id.includes("Sparkline") || id.includes("ActivityCalendar")) {
+        return { __esModule: true, default: () => React.createElement("svg") };
+      }
+      if (id.includes("chartTheme")) return { FX_SEVERITY: {} };
+      if (id.startsWith("@docusaurus/")) {
+        return { __esModule: true, default: () => null };
+      }
+      return require(id);
+    },
+    mod,
+    mod.exports,
+  );
+  return mod.exports;
+}
+
+test("QUEUE_URL_FALLBACK points to projectbluefin.github.io/review/queue.json", () => {
+  const source = fs.readFileSync(dashboardPath, "utf8");
+  assert.match(
+    source,
+    /const QUEUE_URL_FALLBACK = "https:\/\/projectbluefin\.github\.io\/review\/queue\.json";/,
+  );
+  assert.doesNotMatch(
+    source,
+    /const QUEUE_URL_FALLBACK = "https:\/\/queue\.projectbluefin\.io\/data\.json";/,
+  );
+});
+
+test("docusaurus CSP connect-src allows projectbluefin.github.io and not queue.projectbluefin.io", () => {
+  const config = fs.readFileSync(configPath, "utf8");
+  assert.ok(
+    config.includes("https://projectbluefin.github.io"),
+    "CSP should allow projectbluefin.github.io",
+  );
+  assert.ok(
+    !config.includes("https://queue.projectbluefin.io"),
+    "CSP should not contain queue.projectbluefin.io",
+  );
+});
+
+test("normalizePublicQueueFeed maps flat feed items to QueueData shape", () => {
+  const { normalizePublicQueueFeed } = loadDashboardModule();
+  assert.equal(typeof normalizePublicQueueFeed, "function");
+
+  const sampleFeed = {
+    generated_at: "2026-09-10T12:00:00Z",
+    items: [
+      {
+        id: "projectbluefin/common#807",
+        repository: "projectbluefin/common",
+        number: 807,
+        url: "https://github.com/projectbluefin/common/pull/807",
+        title: "feat(telemetry): countme client",
+        author: "castrojo",
+        updated_at: "2026-08-07T01:55:17Z",
+        labels: ["4-review", "agent/scanner"],
+      },
+      {
+        id: "projectbluefin/documentation#1090",
+        repository: "projectbluefin/documentation",
+        number: 1090,
+        url: "https://github.com/projectbluefin/documentation/pull/1090",
+        title: "fix(factory): queue fallback",
+        author: "Danathar",
+        updated_at: "2026-09-10T12:05:00Z",
+      },
+    ],
+  };
+
+  const queueData = normalizePublicQueueFeed(sampleFeed);
+
+  assert.equal(queueData.generated, "2026-09-10T12:00:00Z");
+  assert.deepEqual(queueData.repos, [
+    "projectbluefin/common",
+    "projectbluefin/documentation",
+  ]);
+  assert.deepEqual(queueData.issues, { p0: [], p1: [] });
+  assert.equal(queueData.prs.required.length, 2);
+  assert.deepEqual(queueData.prs.approved, []);
+  assert.deepEqual(queueData.prs.none, []);
+
+  const firstPr = queueData.prs.required[0];
+  assert.equal(firstPr.title, "feat(telemetry): countme client");
+  assert.equal(
+    firstPr.html_url,
+    "https://github.com/projectbluefin/common/pull/807",
+  );
+  assert.equal(
+    firstPr.repository_url,
+    "https://api.github.com/repos/projectbluefin/common",
+  );
+  assert.equal(firstPr.updated_at, "2026-08-07T01:55:17Z");
+  assert.deepEqual(firstPr.labels, [
+    { name: "4-review", color: "" },
+    { name: "agent/scanner", color: "" },
+  ]);
+
+  const secondPr = queueData.prs.required[1];
+  assert.deepEqual(secondPr.labels, []);
+
+  assert.equal(queueData.victories.startDate, "2026-09-10T12:00:00Z");
+  assert.equal(queueData.victories.dreams.count, 0);
+  assert.deepEqual(queueData.victories.dreams.recent, []);
+});
+
+test("normalizePublicQueueFeed handles empty items safely", () => {
+  const { normalizePublicQueueFeed } = loadDashboardModule();
+
+  const emptyFeed = {
+    generated_at: "2026-09-10T12:00:00Z",
+    items: [],
+  };
+
+  const queueData = normalizePublicQueueFeed(emptyFeed);
+  assert.equal(queueData.generated, "2026-09-10T12:00:00Z");
+  assert.deepEqual(queueData.repos, []);
+  assert.deepEqual(queueData.prs.required, []);
+});

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -548,9 +548,12 @@ function contributorDossierUrl(login: string): string {
 // The old raw.githubusercontent.com HTML snapshot is no longer published.
 const SNAPSHOT_API_URL = `${HOSTED_INSTANCE_URL}/api/status`;
 
-// Queue data: try the hosted instance first (credentials:include), fall back to public mirror
+// Queue data: try the hosted instance first (credentials:include), fall back to public mirror.
+// The public mirror is the queue-feed skill's canonical endpoint (see
+// projectbluefin/common docs/skills/queue-feed.md) — queue.projectbluefin.io/data.json
+// 404s, so anonymous visitors need this URL instead.
 const QUEUE_URL_HOSTED = `${HOSTED_INSTANCE_URL}/data.json`;
-const QUEUE_URL_FALLBACK = "https://queue.projectbluefin.io/data.json";
+const QUEUE_URL_FALLBACK = "https://projectbluefin.github.io/review/queue.json";
 const GH_API = "https://api.github.com";
 const DAKOTA = "projectbluefin/dakota";
 const BUILD_WORKFLOW = "246164114";
@@ -924,6 +927,44 @@ async function fetchTimeout(
   }
 }
 
+// Shape of the public queue-feed mirror (projectbluefin/common docs/skills/queue-feed.md):
+// a flat list of PR review-queue items. It carries no P0/P1 issue triage or victory-log
+// data, so those QueueData sections stay empty when only this fallback is available.
+export interface PublicQueueItem {
+  repository: string;
+  url: string;
+  title: string;
+  updated_at: string;
+  labels?: string[];
+}
+
+export interface PublicQueueFeed {
+  generated_at: string;
+  items: PublicQueueItem[];
+}
+
+export function normalizePublicQueueFeed(feed: PublicQueueFeed): QueueData {
+  const prs: QueuePR[] = (feed.items ?? []).map((item) => ({
+    title: item.title,
+    html_url: item.url,
+    repository_url: `https://api.github.com/repos/${item.repository}`,
+    updated_at: item.updated_at,
+    labels: (item.labels ?? []).map((name) => ({ name, color: "" })),
+  }));
+  return {
+    generated: feed.generated_at,
+    repos: Array.from(new Set((feed.items ?? []).map((i) => i.repository))),
+    issues: { p0: [], p1: [] },
+    prs: { approved: [], required: prs, none: [] },
+    victories: {
+      startDate: feed.generated_at,
+      dreams: { count: 0, recent: [] },
+      relief: { count: 0, recent: [] },
+      toil: { count: 0, recent: [] },
+    },
+  };
+}
+
 // Fetch queue data from the hosted instance first (works when the user has an active
 // hive.kubestellar.io session), falling back to the public mirror.
 async function fetchQueueData(): Promise<QueueData | null> {
@@ -937,7 +978,8 @@ async function fetchQueueData(): Promise<QueueData | null> {
   }
   try {
     const r = await fetchTimeout(QUEUE_URL_FALLBACK, 10000);
-    if (r.ok) return (await r.json()) as QueueData;
+    if (r.ok)
+      return normalizePublicQueueFeed((await r.json()) as PublicQueueFeed);
   } catch {
     // both sources unavailable
   }


### PR DESCRIPTION
## Problem

`HiveFactoryDashboard.tsx` falls back to `https://queue.projectbluefin.io/data.json` when the hosted Hive instance requires login, but that fallback returns 404 — leaving anonymous visitors with no queue data.

## Fix

- Point `QUEUE_URL_FALLBACK` to the canonical public queue mirror `https://projectbluefin.github.io/review/queue.json` (documented in `projectbluefin/common` `docs/skills/queue-feed.md`), which returns 200 with CORS enabled.
- Add `normalizePublicQueueFeed()` to transform the public queue feed's flat item list into the `QueueData` structure expected by the factory dashboard.
- Update the CSP `connect-src` allowlist in `docusaurus.config.ts` to allow `https://projectbluefin.github.io` instead of the 404ing `https://queue.projectbluefin.io`.
- Add unit tests in `scripts/factory-queue-fallback.test.js` verifying the fallback URL, CSP allowlist, and feed normalization.

## Verification

- `npm test` passes (794 tests pass).
- `npx prettier --check` passes on touched files.
- `npx eslint` passes with 0 errors on modified files.
- `npm run typecheck` passes with no new errors.

Fixes #1090

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `c83b91b6`