### PR TITLE
fix(factory): replace the Hive snapshot CTA hostname with a valid TLS endpoint

### DIFF
--- a/scripts/factory-snapshot.test.js
+++ b/scripts/factory-snapshot.test.js
@@ -1,0 +1,68 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+function loadComponent(tsxPath) {
+  const { outputText } = ts.transpileModule(fs.readFileSync(tsxPath, "utf8"), {
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+    },
+  });
+  const mod = { exports: {} };
+  new Function("require", "module", "exports", outputText)(
+    (id) => {
+      if (id.endsWith(".css")) return {};
+      if (id === "@docusaurus/Link") {
+        return {
+          __esModule: true,
+          default: ({ to, children, ...rest }) =>
+            React.createElement("a", { href: to, ...rest }, children),
+        };
+      }
+      return require(id);
+    },
+    mod,
+    mod.exports,
+  );
+  return mod.exports;
+}
+
+const snapshotTsx = path.join(
+  __dirname,
+  "..",
+  "src",
+  "components",
+  "factory",
+  "panels",
+  "HiveSnapshot.tsx",
+);
+
+test("HiveSnapshot CTA points to valid hivecommons.dev TLS endpoint", () => {
+  const src = fs.readFileSync(snapshotTsx, "utf8");
+  assert.ok(
+    src.includes(
+      "https://hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot",
+    ),
+    "must point to hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot",
+  );
+  assert.ok(
+    !src.includes("kubestellar.io/snapshot"),
+    "must not point to invalid kubestellar.io snapshot URL",
+  );
+});
+
+test("HiveSnapshot renders snapshot link in markup", () => {
+  const HiveSnapshot = loadComponent(snapshotTsx).default;
+  const html = renderToStaticMarkup(React.createElement(HiveSnapshot));
+  assert.match(
+    html,
+    /href="https:\/\/hosted-projectbluefin-common-nmq5\.hive\.hivecommons\.dev\/snapshot"/,
+  );
+  assert.match(html, /Open the live snapshot/);
+});

--- a/src/components/factory/panels/HiveSnapshot.tsx
+++ b/src/components/factory/panels/HiveSnapshot.tsx
@@ -4,7 +4,7 @@ import styles from "./HiveSnapshot.module.css";
 
 /** The hive instance whose read-only snapshot this links to. */
 const SNAPSHOT_URL =
-  "https://hosted-projectbluefin-common-nmq5.hive.kubestellar.io/snapshot";
+  "https://hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot";
 
 /**
  * A link to the hive's own read-only dashboard snapshot.


### PR DESCRIPTION
## Problem
`src/components/factory/panels/HiveSnapshot.tsx` links to `hosted-projectbluefin-common-nmq5.hive.kubestellar.io/snapshot`, whose TLS certificate covers `*.hivecommons.dev` and not `*.kubestellar.io`, causing TLS certificate verification errors.

## Solution
- Point `SNAPSHOT_URL` in `HiveSnapshot.tsx` to the active HTTPS snapshot endpoint `https://hosted-projectbluefin-common-nmq5.hive.hivecommons.dev/snapshot`.
- Add unit test coverage in `scripts/factory-snapshot.test.js` verifying the snapshot endpoint URL and component render markup.

Fixes #1089

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `ffb35a04`