### PR TITLE
fix(factory): calculate merged-this-week from merged pull requests

### DIFF
--- a/scripts/fetch-hive-live-data.js
+++ b/scripts/fetch-hive-live-data.js
@@ -27,73 +27,49 @@
 
 import { writeFileSync, existsSync, statSync } from "fs";
 import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, "../static/data/hive-live-data.json");
 
-const CACHE_TTL_HOURS = parseFloat(process.env.HIVE_LIVE_CACHE_HOURS ?? "0.25"); // 15 min default
-const CACHE_TTL_MS = CACHE_TTL_HOURS * 60 * 60 * 1000;
-const force = process.argv.includes("--force");
-
-const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
-if (!TOKEN) {
-  console.warn("fetch-hive-live-data: no GITHUB_TOKEN — API calls will be rate-limited");
+export function buildQueries(org, weekAgo, monthAgo) {
+  return {
+    merged: `org:${org} type:pr is:merged`,
+    discussions: `org:${org} type:issue is:open -label:queue/agent-ready -label:source:agent`,
+    hivePRs: `org:${org} type:pr is:open author:kubestellar-hive[bot]`,
+    copilotPRs: `org:${org} type:pr is:open label:source:agent`,
+    openedIssues: `org:${org} type:issue created:>${weekAgo}`,
+    closedIssues: `org:${org} type:issue closed:>${weekAgo}`,
+    tapPromotions: `repo:ublue-os/homebrew-tap type:pr is:merged merged:>${monthAgo}`,
+    agentMerged: `org:${org} type:pr is:merged author:kubestellar-hive[bot] merged:>${weekAgo}`,
+    openIssues: `org:${org} state:open type:issue`,
+    openPRs: `org:${org} state:open type:pr`,
+    agentReadyIssues: `org:${org} label:queue/agent-ready state:open`,
+    mergedThisWeek: `org:${org} type:pr is:merged merged:>${weekAgo}`,
+  };
 }
 
-if (!force && existsSync(OUT)) {
-  const age = Date.now() - statSync(OUT).mtimeMs;
-  if (age < CACHE_TTL_MS) {
-    console.log(`fetch-hive-live-data: cache fresh (${Math.round(age / 60000)}m old, TTL ${Math.round(CACHE_TTL_HOURS * 60)}m), skipping`);
-    process.exit(0);
-  }
+export function mapItem(i) {
+  return {
+    number: i.number,
+    title: i.title,
+    html_url: i.html_url,
+    repository_url: i.repository_url,
+    updated_at: i.updated_at,
+    created_at: i.created_at,
+    labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
+    comments: i.comments ?? 0,
+    user: i.user
+      ? { login: i.user.login, avatar_url: i.user.avatar_url }
+      : undefined,
+    draft: i.draft ?? false,
+    pull_request: i.pull_request
+      ? { merged_at: i.pull_request.merged_at }
+      : undefined,
+  };
 }
 
-const GH_API = "https://api.github.com";
-const headers = {
-  Accept: "application/vnd.github.v3+json",
-  ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
-};
-
-async function ghSearch(q, perPage = 30) {
-  const url = `${GH_API}/search/issues?q=${encodeURIComponent(q)}&sort=updated&order=desc&per_page=${perPage}`;
-  const res = await fetch(url, { headers });
-  if (!res.ok) {
-    const err = await res.text().catch(() => res.statusText);
-    throw new Error(`${res.status} for ${url}: ${err.slice(0, 200)}`);
-  }
-  return res.json();
-}
-
-async function ghGet(path) {
-  const url = path.startsWith("http") ? path : `${GH_API}${path}`;
-  const res = await fetch(url, { headers });
-  if (!res.ok) throw new Error(`${res.status} for ${url}`);
-  return res.json();
-}
-
-async function safeSearch(q, perPage = 30) {
-  try { return await ghSearch(q, perPage); } catch (e) {
-    console.warn(`  warn: ${q.slice(0, 80)} — ${e.message}`);
-    return { total_count: 0, items: [] };
-  }
-}
-
-async function safeGet(path) {
-  try { return await ghGet(path); } catch (e) {
-    console.warn(`  warn: GET ${path} — ${e.message}`);
-    return {};
-  }
-}
-
-console.log("fetch-hive-live-data: fetching GitHub data...");
-
-const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
-const monthAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
-const org = "projectbluefin";
-
-// All queries run in parallel — authenticated token handles the rate limit
-const [
+export function buildOutput({
   mergedData,
   discussData,
   hivePRData,
@@ -107,65 +83,168 @@ const [
   openIssuesData,
   openPRsData,
   agentReadyData,
-] = await Promise.all([
-  safeSearch(`org:${org} type:pr is:merged`, 30),
-  safeSearch(`org:${org} type:issue is:open -label:queue/agent-ready -label:source:agent`, 25),
-  safeSearch(`org:${org} type:pr is:open author:kubestellar-hive[bot]`, 25),
-  safeSearch(`org:${org} type:pr is:open label:source:agent`, 25),
-  safeSearch(`org:${org} type:issue created:>${weekAgo}`, 1),
-  safeSearch(`org:${org} type:issue closed:>${weekAgo}`, 1),
-  safeGet(`/repos/${org}/testsuite/actions/runs?status=success&per_page=1`),
-  safeSearch(`repo:ublue-os/homebrew-tap type:pr is:merged merged:>${monthAgo}`, 1),
-  safeSearch(`org:${org} type:pr is:merged author:kubestellar-hive[bot] merged:>${weekAgo}`, 1),
-  safeGet(`/orgs/${org}`),
-  safeSearch(`org:${org} state:open type:issue`, 1),
-  safeSearch(`org:${org} state:open type:pr`, 1),
-  safeSearch(`org:${org} label:queue/agent-ready state:open`, 1),
-]);
-
-function mapItem(i) {
+  mergedThisWeekData,
+  fetchedAt = new Date().toISOString(),
+}) {
   return {
-    number: i.number,
-    title: i.title,
-    html_url: i.html_url,
-    repository_url: i.repository_url,
-    updated_at: i.updated_at,
-    created_at: i.created_at,
-    labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
-    comments: i.comments ?? 0,
-    user: i.user ? { login: i.user.login, avatar_url: i.user.avatar_url } : undefined,
-    draft: i.draft ?? false,
-    pull_request: i.pull_request ? { merged_at: i.pull_request.merged_at } : undefined,
+    fetchedAt,
+    mergedPRs: (mergedData?.items ?? []).map(mapItem),
+    discussions: (discussData?.items ?? []).map(mapItem),
+    hivePRs: (hivePRData?.items ?? []).map(mapItem),
+    copilotPRs: (copilotPRData?.items ?? []).map(mapItem),
+    velocity: {
+      opened: openedData?.total_count ?? 0,
+      closed: closedData?.total_count ?? 0,
+    },
+    testBuilds: testData?.total_count ?? testData?.workflow_runs?.length ?? 0,
+    tapPromotions: promosData?.total_count ?? 0,
+    agentMergedCount: agentMergedData?.total_count ?? 0,
+    orgStats: {
+      totalRepos: orgData?.public_repos ?? 0,
+      openIssues: openIssuesData?.total_count ?? 0,
+      openPRs: openPRsData?.total_count ?? 0,
+      mergedThisWeek: mergedThisWeekData?.total_count ?? 0,
+      agentReadyIssues: agentReadyData?.total_count ?? 0,
+      agentOpenPRs: hivePRData?.total_count ?? 0,
+      sourceAgentOpen: copilotPRData?.total_count ?? 0,
+    },
   };
 }
 
-const output = {
-  fetchedAt: new Date().toISOString(),
-  mergedPRs: (mergedData.items ?? []).map(mapItem),
-  discussions: (discussData.items ?? []).map(mapItem),
-  hivePRs: (hivePRData.items ?? []).map(mapItem),
-  copilotPRs: (copilotPRData.items ?? []).map(mapItem),
-  velocity: {
-    opened: openedData.total_count ?? 0,
-    closed: closedData.total_count ?? 0,
-  },
-  testBuilds: testData.total_count ?? testData.workflow_runs?.length ?? 0,
-  tapPromotions: promosData.total_count ?? 0,
-  agentMergedCount: agentMergedData.total_count ?? 0,
-  orgStats: {
-    totalRepos: orgData.public_repos ?? 0,
-    openIssues: openIssuesData.total_count ?? 0,
-    openPRs: openPRsData.total_count ?? 0,
-    mergedThisWeek: closedData.total_count ?? 0,
-    agentReadyIssues: agentReadyData.total_count ?? 0,
-    agentOpenPRs: hivePRData.total_count ?? 0,
-    sourceAgentOpen: copilotPRData.total_count ?? 0,
-  },
-};
+export async function main() {
+  const CACHE_TTL_HOURS = parseFloat(
+    process.env.HIVE_LIVE_CACHE_HOURS ?? "0.25",
+  ); // 15 min default
+  const CACHE_TTL_MS = CACHE_TTL_HOURS * 60 * 60 * 1000;
+  const force = process.argv.includes("--force");
 
-writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n");
-console.log(
-  `fetch-hive-live-data: wrote ${OUT}` +
-  ` (${output.mergedPRs.length} merged, ${output.discussions.length} discussions,` +
-  ` ${output.hivePRs.length + output.copilotPRs.length} agent PRs)`,
-);
+  const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+  if (!TOKEN) {
+    console.warn(
+      "fetch-hive-live-data: no GITHUB_TOKEN — API calls will be rate-limited",
+    );
+  }
+
+  if (!force && existsSync(OUT)) {
+    const age = Date.now() - statSync(OUT).mtimeMs;
+    if (age < CACHE_TTL_MS) {
+      console.log(
+        `fetch-hive-live-data: cache fresh (${Math.round(age / 60000)}m old, TTL ${Math.round(CACHE_TTL_HOURS * 60)}m), skipping`,
+      );
+      return;
+    }
+  }
+
+  const GH_API = "https://api.github.com";
+  const headers = {
+    Accept: "application/vnd.github.v3+json",
+    ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+  };
+
+  async function ghSearch(q, perPage = 30) {
+    const url = `${GH_API}/search/issues?q=${encodeURIComponent(q)}&sort=updated&order=desc&per_page=${perPage}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      const err = await res.text().catch(() => res.statusText);
+      throw new Error(`${res.status} for ${url}: ${err.slice(0, 200)}`);
+    }
+    return res.json();
+  }
+
+  async function ghGet(path) {
+    const url = path.startsWith("http") ? path : `${GH_API}${path}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`${res.status} for ${url}`);
+    return res.json();
+  }
+
+  async function safeSearch(q, perPage = 30) {
+    try {
+      return await ghSearch(q, perPage);
+    } catch (e) {
+      console.warn(`  warn: ${q.slice(0, 80)} — ${e.message}`);
+      return { total_count: 0, items: [] };
+    }
+  }
+
+  async function safeGet(path) {
+    try {
+      return await ghGet(path);
+    } catch (e) {
+      console.warn(`  warn: GET ${path} — ${e.message}`);
+      return {};
+    }
+  }
+
+  console.log("fetch-hive-live-data: fetching GitHub data...");
+
+  const weekAgo = new Date(Date.now() - 7 * 86400000)
+    .toISOString()
+    .slice(0, 10);
+  const monthAgo = new Date(Date.now() - 30 * 86400000)
+    .toISOString()
+    .slice(0, 10);
+  const org = "projectbluefin";
+  const queries = buildQueries(org, weekAgo, monthAgo);
+
+  // All queries run in parallel — authenticated token handles the rate limit
+  const [
+    mergedData,
+    discussData,
+    hivePRData,
+    copilotPRData,
+    openedData,
+    closedData,
+    testData,
+    promosData,
+    agentMergedData,
+    orgData,
+    openIssuesData,
+    openPRsData,
+    agentReadyData,
+    mergedThisWeekData,
+  ] = await Promise.all([
+    safeSearch(queries.merged, 30),
+    safeSearch(queries.discussions, 25),
+    safeSearch(queries.hivePRs, 25),
+    safeSearch(queries.copilotPRs, 25),
+    safeSearch(queries.openedIssues, 1),
+    safeSearch(queries.closedIssues, 1),
+    safeGet(`/repos/${org}/testsuite/actions/runs?status=success&per_page=1`),
+    safeSearch(queries.tapPromotions, 1),
+    safeSearch(queries.agentMerged, 1),
+    safeGet(`/orgs/${org}`),
+    safeSearch(queries.openIssues, 1),
+    safeSearch(queries.openPRs, 1),
+    safeSearch(queries.agentReadyIssues, 1),
+    safeSearch(queries.mergedThisWeek, 1),
+  ]);
+
+  const output = buildOutput({
+    mergedData,
+    discussData,
+    hivePRData,
+    copilotPRData,
+    openedData,
+    closedData,
+    testData,
+    promosData,
+    agentMergedData,
+    orgData,
+    openIssuesData,
+    openPRsData,
+    agentReadyData,
+    mergedThisWeekData,
+  });
+
+  writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n");
+  console.log(
+    `fetch-hive-live-data: wrote ${OUT}` +
+      ` (${output.mergedPRs.length} merged, ${output.discussions.length} discussions,` +
+      ` ${output.hivePRs.length + output.copilotPRs.length} agent PRs)`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/scripts/fetch-hive-live-data.test.js
+++ b/scripts/fetch-hive-live-data.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildQueries, buildOutput, mapItem } from "./fetch-hive-live-data.js";
+
+test("buildQueries produces correct queries including mergedThisWeek from merged PRs", () => {
+  const org = "projectbluefin";
+  const weekAgo = "2026-09-03";
+  const monthAgo = "2026-08-11";
+  const queries = buildQueries(org, weekAgo, monthAgo);
+
+  assert.equal(
+    queries.mergedThisWeek,
+    "org:projectbluefin type:pr is:merged merged:>2026-09-03",
+  );
+  assert.equal(
+    queries.closedIssues,
+    "org:projectbluefin type:issue closed:>2026-09-03",
+  );
+  assert.equal(
+    queries.openedIssues,
+    "org:projectbluefin type:issue created:>2026-09-03",
+  );
+  assert.equal(
+    queries.agentMerged,
+    "org:projectbluefin type:pr is:merged author:kubestellar-hive[bot] merged:>2026-09-03",
+  );
+
+  // Guard against regression: mergedThisWeek must query PRs, not issues
+  assert.ok(queries.mergedThisWeek.includes("type:pr"));
+  assert.ok(queries.mergedThisWeek.includes("is:merged"));
+  assert.ok(!queries.mergedThisWeek.includes("type:issue"));
+});
+
+test("buildOutput populates orgStats.mergedThisWeek from merged PR data, not closed issues", () => {
+  // Reproduce issue #1088 scenario:
+  // 113 closed issues vs 313 merged PRs
+  const output = buildOutput({
+    mergedData: { items: [] },
+    discussData: { items: [] },
+    hivePRData: { items: [], total_count: 5 },
+    copilotPRData: { items: [], total_count: 2 },
+    openedData: { total_count: 150 },
+    closedData: { total_count: 113 },
+    testData: { total_count: 42 },
+    promosData: { total_count: 7 },
+    agentMergedData: { total_count: 12 },
+    orgData: { public_repos: 50 },
+    openIssuesData: { total_count: 200 },
+    openPRsData: { total_count: 80 },
+    agentReadyData: { total_count: 15 },
+    mergedThisWeekData: { total_count: 313 },
+  });
+
+  // mergedThisWeek must reflect merged PRs (313), not closed issues (113)
+  assert.equal(output.orgStats.mergedThisWeek, 313);
+
+  // Velocity closed reflects closed issues (113)
+  assert.equal(output.velocity.closed, 113);
+  assert.equal(output.velocity.opened, 150);
+
+  // Other org stats
+  assert.equal(output.orgStats.totalRepos, 50);
+  assert.equal(output.orgStats.openIssues, 200);
+  assert.equal(output.orgStats.openPRs, 80);
+  assert.equal(output.orgStats.agentReadyIssues, 15);
+  assert.equal(output.orgStats.agentOpenPRs, 5);
+  assert.equal(output.orgStats.sourceAgentOpen, 2);
+
+  // Counts
+  assert.equal(output.testBuilds, 42);
+  assert.equal(output.tapPromotions, 7);
+  assert.equal(output.agentMergedCount, 12);
+});
+
+test("buildOutput defaults missing data safely", () => {
+  const output = buildOutput({});
+
+  assert.equal(output.orgStats.mergedThisWeek, 0);
+  assert.equal(output.velocity.closed, 0);
+  assert.equal(output.velocity.opened, 0);
+  assert.equal(output.orgStats.totalRepos, 0);
+  assert.equal(output.orgStats.openIssues, 0);
+  assert.equal(output.orgStats.openPRs, 0);
+  assert.deepEqual(output.mergedPRs, []);
+  assert.deepEqual(output.discussions, []);
+  assert.deepEqual(output.hivePRs, []);
+  assert.deepEqual(output.copilotPRs, []);
+});
+
+test("mapItem transforms GitHub issue/PR objects cleanly", () => {
+  const item = {
+    number: 1088,
+    title: "fix(factory): calculate merged-this-week from merged pull requests",
+    html_url: "https://github.com/projectbluefin/documentation/pull/1088",
+    repository_url: "https://api.github.com/repos/projectbluefin/documentation",
+    updated_at: "2026-09-10T12:00:00Z",
+    created_at: "2026-09-10T11:00:00Z",
+    labels: [{ name: "bug", color: "d73a4a" }],
+    comments: 3,
+    user: { login: "testuser", avatar_url: "https://example.com/avatar.png" },
+    draft: false,
+    pull_request: { merged_at: "2026-09-10T12:15:00Z" },
+  };
+
+  const mapped = mapItem(item);
+  assert.equal(mapped.number, 1088);
+  assert.equal(
+    mapped.title,
+    "fix(factory): calculate merged-this-week from merged pull requests",
+  );
+  assert.equal(mapped.user?.login, "testuser");
+  assert.equal(mapped.draft, false);
+  assert.equal(mapped.pull_request?.merged_at, "2026-09-10T12:15:00Z");
+  assert.deepEqual(mapped.labels, [{ name: "bug", color: "d73a4a" }]);
+});


### PR DESCRIPTION
### Problem
`scripts/fetch-hive-live-data.js` previously populated `mergedThisWeek` using `closedData.total_count` from a query for closed issues (`type:issue closed:>${weekAgo}`) instead of merged pull requests.

### Solution
- Query `org:${org} type:pr is:merged merged:>${weekAgo}` for the `mergedThisWeek` metric in `scripts/fetch-hive-live-data.js`.
- Export helper functions (`buildQueries`, `buildOutput`, `mapItem`) and guard CLI execution with `import.meta.url` check for unit testing.
- Add unit test suite in `scripts/fetch-hive-live-data.test.js` validating query structure, output payload mapping, and metric calculation.

Fixes #1088

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `adf51635`