### PR TITLE
fix(images): hide unpublished Utah testing image commands and attestations

### DIFF
--- a/docs/utah.mdx
+++ b/docs/utah.mdx
@@ -31,10 +31,9 @@ Utah defines four flavors matching Bluefin's standard targets: `utah`, `utah-nvi
 | `:testing` |    Dev | Daily development build from the `testing` branch.       |
 |  `:stable` | Stable | Promoted from `:testing` following automated validation. |
 
-```bash
-# Switch to the Utah testing stream
-sudo bootc switch ghcr.io/projectbluefin/utah:testing --enforce-container-sigpolicy
-```
+:::note[Awaiting initial release]
+Public container images and `bootc switch` commands are not yet available. Utah is currently awaiting its initial testing image release on GHCR. Track progress at [projectbluefin/utah](https://github.com/projectbluefin/utah).
+:::
 
 ## Features and Stack
 

--- a/scripts/catalog-components.test.js
+++ b/scripts/catalog-components.test.js
@@ -117,6 +117,56 @@ test("ImagesCatalog renders the unavailable reason", () => {
   assert.ok(html.includes("SBOM cache contains no release data"));
 });
 
+test("ImagesCatalog renders awaiting initial release for unpublished streams and hides commands", () => {
+  const html = render(imagesModule.default, {
+    initialCatalog: {
+      products: [
+        {
+          id: "projectbluefin-utah",
+          name: "Project Bluefin Utah",
+          org: "projectbluefin",
+          package: "utah",
+          artwork: "bluefin",
+          streams: [
+            {
+              label: "TESTING",
+              tag: "testing",
+              command: null,
+            },
+          ],
+          testingStreams: [],
+          security: {
+            cosignKeyUrl: null,
+            verifyCommand: null,
+            attestCommand: null,
+            hasAttestation: false,
+            sbomCommand: null,
+          },
+        },
+      ],
+      unavailable: false,
+    },
+  });
+
+  assert.ok(
+    html.includes(
+      "Awaiting initial release: <code>testing</code> image is not yet published.",
+    ),
+  );
+  assert.ok(
+    html.includes(
+      "Awaiting initial release: verification commands will be available once the image is published.",
+    ),
+  );
+  assert.ok(
+    html.includes(
+      "Awaiting initial release: attestation verification will be available once the image is published.",
+    ),
+  );
+  assert.ok(!html.includes("sudo bootc switch ghcr.io/projectbluefin/utah"));
+  assert.ok(!html.includes("cosign verify"));
+});
+
 test("DriverVersionsCatalog renders the unavailable reason", () => {
   const html = render(DriverVersionsCatalog, {
     streamId: "bluefin-lts",

--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -365,7 +365,9 @@ function buildTopStreams(spec, tagSet) {
     top.push({
       label: fallbackTag.toUpperCase(),
       tag: fallbackTag,
-      command: `sudo bootc switch ghcr.io/${spec.org}/${spec.package}:${fallbackTag} --enforce-container-sigpolicy`,
+      command: tagSet.has(fallbackTag)
+        ? `sudo bootc switch ghcr.io/${spec.org}/${spec.package}:${fallbackTag} --enforce-container-sigpolicy`
+        : null,
       versions: null,
     });
   }
@@ -381,6 +383,9 @@ function attachNvidiaCommands(
   if (!spec.nvidiaPackage) return streams;
 
   return streams.map((entry) => {
+    if (!entry.command) {
+      return { ...entry, nvidiaCommand: null };
+    }
     if (!nvidiaTagSet && Array.isArray(existingStreams)) {
       const existingEntry = existingStreams.find((s) => s.tag === entry.tag);
       if (existingEntry && "nvidiaCommand" in existingEntry) {
@@ -533,7 +538,7 @@ function attachNvidiaTestingCommands(
   });
 }
 
-function buildSecurityInfo(spec, inspectTag) {
+function buildSecurityInfo(spec, inspectTag, isAvailable = true) {
   const imageRef = `ghcr.io/${spec.org}/${spec.package}:${inspectTag}`;
 
   // Signing policy per repo lives in scripts/lib/signing-trust.js — the single
@@ -556,13 +561,13 @@ function buildSecurityInfo(spec, inspectTag) {
   const OIDC_IDENTITY_PREFIX = `^https://github.com/${spec.keyRepo}/.github/workflows/`;
   const SLSA_TYPE = "https://slsa.dev/provenance/v1";
 
-  if (hasNoPipeline) {
+  if (hasNoPipeline || !isAvailable) {
     return {
       cosignKeyUrl: null,
       verifyCommand: null,
       attestCommand: null,
       hasAttestation: false,
-      sbomCommand: `oras discover ${imageRef}`,
+      sbomCommand: null,
     };
   }
 
@@ -632,8 +637,8 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
     tags =
       existing?.allTags ||
       [
-        ...(existing?.streams || []).map((s) => s.tag),
-        ...(existing?.testingStreams || []).map((s) => s.tag),
+        ...(existing?.streams || []).filter((s) => s.command).map((s) => s.tag),
+        ...(existing?.testingStreams || []).filter((s) => s.command).map((s) => s.tag),
       ].filter(Boolean);
   }
   const tagSet = new Set(tags);
@@ -759,7 +764,7 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
     metadata,
     metadataSource,
     versions,
-    security: buildSecurityInfo(spec, inspectTag),
+    security: buildSecurityInfo(spec, inspectTag, tagSet.has(inspectTag)),
     inspectTag,
     lastPublishedAt: lastPublishedAt,
     stale,
@@ -903,6 +908,7 @@ module.exports = {
   buildSecurityInfo,
   buildStreamVersionInfo,
   buildTestingStreams,
+  buildTopStreams,
   buildUnavailableOutput,
   cacheAgeHours,
   handleUnavailableCache,

--- a/scripts/fetch-github-images.test.js
+++ b/scripts/fetch-github-images.test.js
@@ -9,6 +9,7 @@ const {
   buildSecurityInfo,
   buildStreamVersionInfo,
   buildTestingStreams,
+  buildTopStreams,
   buildUnavailableOutput,
   cacheAgeHours,
   handleUnavailableCache,
@@ -411,7 +412,7 @@ test("buildSecurityInfo returns keyless verification commands for keyless repos"
   assert.match(info.attestCommand, /https:\/\/slsa\.dev\/provenance\/v1/);
 });
 
-test("buildSecurityInfo returns keyless verification commands for Utah", () => {
+test("buildSecurityInfo returns keyless verification commands for Utah with attestationLive false", () => {
   const info = buildSecurityInfo(
     {
       keyRepo: "projectbluefin/utah",
@@ -422,9 +423,41 @@ test("buildSecurityInfo returns keyless verification commands for Utah", () => {
   );
 
   assert.equal(info.cosignKeyUrl, null);
-  assert.equal(info.hasAttestation, true);
+  assert.equal(info.hasAttestation, false);
   assert.match(info.verifyCommand, /certificate-oidc-issuer/);
   assert.match(info.attestCommand, /certificate-identity-regexp/);
+});
+
+test("buildSecurityInfo hides verification commands when tag is not available", () => {
+  const info = buildSecurityInfo(
+    {
+      keyRepo: "projectbluefin/utah",
+      org: "projectbluefin",
+      package: "utah",
+    },
+    "testing",
+    false,
+  );
+
+  assert.equal(info.cosignKeyUrl, null);
+  assert.equal(info.hasAttestation, false);
+  assert.equal(info.verifyCommand, null);
+  assert.equal(info.attestCommand, null);
+  assert.equal(info.sbomCommand, null);
+});
+
+test("buildTopStreams leaves command null when tag is not in tagSet", () => {
+  const spec = {
+    org: "projectbluefin",
+    package: "utah",
+    streamOrder: ["testing"],
+  };
+  const emptyTagSet = new Set();
+  const streams = buildTopStreams(spec, emptyTagSet);
+
+  assert.equal(streams.length, 1);
+  assert.equal(streams[0].tag, "testing");
+  assert.equal(streams[0].command, null);
 });
 
 test("handleUnavailableCache preserves a valid SBOM-derived image catalog", () => {

--- a/scripts/lib/signing-trust.js
+++ b/scripts/lib/signing-trust.js
@@ -40,11 +40,11 @@ const SIGNING_TRUST = {
     cosignKeyUrl: COSIGN_KEY_LTS,
     attestationLive: false,
   },
-  // Utah: keyless + OCI attestation live.
+  // Utah: keyless, awaiting initial testing image release and OCI attestation.
   "projectbluefin/utah": {
     keyless: true,
     cosignKeyUrl: null,
-    attestationLive: true,
+    attestationLive: false,
   },
   // Dakota: keyless, but SLSA attestations reach the OCI registry only once
   // projectbluefin/dakota#391 lands (push-to-registry: true).

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -38,7 +38,7 @@ function ArchBadges({ arches }: { arches: string[] }) {
 interface StreamInfo {
   label: string;
   tag: string;
-  command: string;
+  command?: string | null;
   nvidiaCommand?: string | null;
   versions?: {
     gnome?: string | null;
@@ -494,42 +494,52 @@ export default function ImagesCatalogComponent({
                 >
                   {product.streams.map((entry) => (
                     <TabItem key={entry.tag} value={tabValue(entry.tag)}>
-                      <p className={styles.tabCopy}>
-                        Use this command to switch to the{" "}
-                        <strong>{entry.label.toLowerCase()}</strong> channel for
-                        this image. It is the quickest way to stay on that
-                        release stream.
-                      </p>
-                      {nvidiaEnabled ? (
-                        entry.nvidiaCommand ? (
-                          <>
-                            <StreamVersionPills
-                              versions={entry.versions}
-                              showNvidia
-                            />
-                            <CodeBlock language="bash">
-                              {entry.nvidiaCommand}
-                            </CodeBlock>
-                          </>
-                        ) : (
-                          <p className={styles.emptyText}>
-                            No Nvidia variant published for this stream tag.
-                          </p>
-                        )
-                      ) : (
+                      {entry.command ? (
                         <>
-                          <StreamVersionPills
-                            versions={entry.versions}
-                            showNvidia={false}
-                          />
-                          <CodeBlock language="bash">{entry.command}</CodeBlock>
+                          <p className={styles.tabCopy}>
+                            Use this command to switch to the{" "}
+                            <strong>{entry.label.toLowerCase()}</strong> channel for
+                            this image. It is the quickest way to stay on that
+                            release stream.
+                          </p>
+                          {nvidiaEnabled ? (
+                            entry.nvidiaCommand ? (
+                              <>
+                                <StreamVersionPills
+                                  versions={entry.versions}
+                                  showNvidia
+                                />
+                                <CodeBlock language="bash">
+                                  {entry.nvidiaCommand}
+                                </CodeBlock>
+                              </>
+                            ) : (
+                              <p className={styles.emptyText}>
+                                No Nvidia variant published for this stream tag.
+                              </p>
+                            )
+                          ) : (
+                            <>
+                              <StreamVersionPills
+                                versions={entry.versions}
+                                showNvidia={false}
+                              />
+                              <CodeBlock language="bash">{entry.command}</CodeBlock>
+                            </>
+                          )}
                         </>
+                      ) : (
+                        <p className={styles.emptyText}>
+                          Awaiting initial release: <code>{entry.tag}</code> image is not yet published. Switch commands will appear once available.
+                        </p>
                       )}
                     </TabItem>
                   ))}
                 </Tabs>
               ) : (
-                <p className={styles.emptyText}>No active tags.</p>
+                <p className={styles.emptyText}>
+                  Awaiting initial release: no active image tags published yet.
+                </p>
               )}
 
               <details className={styles.testingDetails}>
@@ -581,10 +591,14 @@ export default function ImagesCatalogComponent({
                     </Link>
                     .
                   </p>
-                  {product.security?.verifyCommand && (
+                  {product.security?.verifyCommand ? (
                     <CodeBlock language="bash">
                       {product.security.verifyCommand}
                     </CodeBlock>
+                  ) : (
+                    <p className={styles.emptyText}>
+                      Awaiting initial release: verification commands will be available once the image is published.
+                    </p>
                   )}
                 </TabItem>
                 <TabItem value="verify-provenance">
@@ -600,10 +614,14 @@ export default function ImagesCatalogComponent({
                     </Link>
                     .
                   </p>
-                  {product.security?.attestCommand && (
+                  {product.security?.attestCommand ? (
                     <CodeBlock language="bash">
                       {product.security.attestCommand}
                     </CodeBlock>
+                  ) : (
+                    <p className={styles.emptyText}>
+                      Awaiting initial release: attestation verification will be available once the image is published.
+                    </p>
                   )}
                   {product.security?.attestCommand &&
                     product.security.hasAttestation === false && (
@@ -627,10 +645,14 @@ export default function ImagesCatalogComponent({
                     </Link>
                     .
                   </p>
-                  {product.security?.sbomCommand && (
+                  {product.security?.sbomCommand ? (
                     <CodeBlock language="bash">
                       {product.security.sbomCommand}
                     </CodeBlock>
+                  ) : (
+                    <p className={styles.emptyText}>
+                      Awaiting initial release: SBOM inspection will be available once the image is published.
+                    </p>
                   )}
                 </TabItem>
               </Tabs>

--- a/static/data/images.json
+++ b/static/data/images.json
@@ -296,7 +296,7 @@
         {
           "label": "TESTING",
           "tag": "testing",
-          "command": "sudo bootc switch ghcr.io/projectbluefin/utah:testing --enforce-container-sigpolicy",
+          "command": null,
           "versions": {
             "gnome": null,
             "kernel": null,
@@ -328,10 +328,10 @@
       },
       "security": {
         "cosignKeyUrl": null,
-        "verifyCommand": "cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/projectbluefin/utah/.github/workflows/' ghcr.io/projectbluefin/utah:testing",
-        "attestCommand": "cosign verify-attestation --type https://slsa.dev/provenance/v1 --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/projectbluefin/utah/.github/workflows/' ghcr.io/projectbluefin/utah:testing",
-        "hasAttestation": true,
-        "sbomCommand": "oras discover ghcr.io/projectbluefin/utah:testing"
+        "verifyCommand": null,
+        "attestCommand": null,
+        "hasAttestation": false,
+        "sbomCommand": null
       },
       "inspectTag": "testing",
       "lastPublishedAt": null,


### PR DESCRIPTION
## Problem
`docs/utah.mdx` and generated image data published `bootc switch` and Cosign verification commands for `ghcr.io/projectbluefin/utah:testing`, although that tag has not yet been published to GHCR. Furthermore, Utah was marked as having live OCI attestations.

## Solution
- Check image tag availability before rendering `bootc switch` and Cosign commands in `scripts/fetch-github-images.js`.
- Mark `attestationLive: false` for `projectbluefin/utah` in `scripts/lib/signing-trust.js` since public testing images and SLSA provenance are not yet published.
- Render an awaiting-initial-release note in `docs/utah.mdx` rather than the `bootc switch` command.
- In `src/components/ImagesCatalog.tsx`, render an awaiting-initial-release state for streams and security verification when commands are not available.
- Update `static/data/images.json` to reflect that Utah testing commands and attestations are not published.
- Add unit tests in `scripts/fetch-github-images.test.js` and `scripts/catalog-components.test.js`.

Fixes #1081

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e50d72f8`