### PR TITLE
fix(catalog): generate Bluefin LTS rebases against the bluefin-lts package

### DIFF
--- a/scripts/catalog-components.test.js
+++ b/scripts/catalog-components.test.js
@@ -289,3 +289,92 @@ test("DriverVersionsCatalog showRebootStep prop controls reboot banner", () => {
   });
   assert.ok(!withoutReboot.includes("Final Step: Reboot"));
 });
+
+test("DriverVersionsCatalog generates rebase commands using the correct package for bluefin-lts and other streams", () => {
+  const catalog = {
+    generatedAt: "2026-09-06T00:00:00.000Z",
+    streams: [
+      {
+        id: "bluefin-lts",
+        latest: {
+          stream: "bluefin-lts",
+          tag: "lts-20260906",
+          versions: { kernel: "6.18.13-200.fc43" },
+        },
+        history: [],
+      },
+      {
+        id: "bluefin-stable",
+        latest: {
+          stream: "bluefin-stable",
+          tag: "stable-20260906",
+          versions: { kernel: "6.18.13-200.fc43" },
+        },
+        history: [],
+      },
+      {
+        id: "dakota-latest",
+        latest: {
+          stream: "dakota-latest",
+          tag: "latest-20260906",
+          versions: { kernel: "6.18.13-200.fc43" },
+        },
+        history: [],
+      },
+      {
+        id: "utah-testing",
+        latest: {
+          stream: "utah-testing",
+          tag: "testing-20260906",
+          versions: { kernel: "6.18.13-200.fc43" },
+        },
+        history: [],
+      },
+    ],
+  };
+
+  const ltsHtml = render(DriverVersionsCatalog, {
+    streamId: "bluefin-lts",
+    catalogOverride: catalog,
+  });
+  assert.ok(
+    ltsHtml.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin-lts:lts-20260906",
+    ),
+  );
+  assert.ok(
+    !ltsHtml.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin:lts-20260906",
+    ),
+  );
+
+  const stableHtml = render(DriverVersionsCatalog, {
+    streamId: "bluefin-stable",
+    catalogOverride: catalog,
+  });
+  assert.ok(
+    stableHtml.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin:stable-20260906",
+    ),
+  );
+
+  const dakotaHtml = render(DriverVersionsCatalog, {
+    streamId: "dakota-latest",
+    catalogOverride: catalog,
+  });
+  assert.ok(
+    dakotaHtml.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/dakota:latest-20260906",
+    ),
+  );
+
+  const utahHtml = render(DriverVersionsCatalog, {
+    streamId: "utah-testing",
+    catalogOverride: catalog,
+  });
+  assert.ok(
+    utahHtml.includes(
+      "sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/utah:testing-20260906",
+    ),
+  );
+});

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -181,9 +181,17 @@ function UserspaceMarker({
   );
 }
 
+const STREAM_PACKAGES: Record<string, string> = {
+  "bluefin-stable": "bluefin",
+  "bluefin-lts": "bluefin-lts",
+  "dakota-latest": "dakota",
+  "utah-testing": "utah",
+};
+
 function buildRebaseCommand(stream: DriverStream, tag: string): string {
   const safeTag = tag.replace(/[^a-zA-Z0-9_.-]/g, "");
-  return `sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/${stream.id.replace(/-.*/, "")}:${safeTag}`;
+  const pkg = STREAM_PACKAGES[stream.id] ?? stream.id.replace(/-.*/, "");
+  return `sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/${pkg}:${safeTag}`;
 }
 
 function ReleaseNode({


### PR DESCRIPTION
## Problem
`buildRebaseCommand` in `src/components/DriverVersionsCatalog.tsx` derives the container image package using `stream.id.replace(/-.*/, "")`. For the `bluefin-lts` stream, this stripped `-lts` and resolved to `bluefin`, generating rebase commands pointing to `ghcr.io/projectbluefin/bluefin:<tag>` instead of `ghcr.io/projectbluefin/bluefin-lts:<tag>`.

## Solution
- Added explicit `STREAM_PACKAGES` mapping in `src/components/DriverVersionsCatalog.tsx` mapping `bluefin-lts` to `bluefin-lts` (as well as explicit mappings for `bluefin-stable`, `dakota-latest`, and `utah-testing` with fallback).
- Added unit tests in `scripts/catalog-components.test.js` verifying that `DriverVersionsCatalog` emits rebase commands targeting `bluefin-lts` for `bluefin-lts` releases as well as appropriate packages for other streams.

Fixes #1079

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `66d1afb7`