### PR TITLE
fix(blog): replace Printful CDN hotlinks blocked on five-years-of-bluefin

### DIFF
--- a/blog/2026-07-22-seven-days-to-the-wolves.mdx
+++ b/blog/2026-07-22-seven-days-to-the-wolves.mdx
@@ -252,7 +252,7 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/dakotaraptor-forever" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/13377675699888df1bfc2__825"
+        src="/img/store/dakotaraptor-forever-0.jpg"
         alt="Dakotaraptor Forever shirt"
         loading="lazy"
       />
@@ -267,7 +267,7 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/bluefin-official-shirt-68b3b18f23f1a" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/890372068c75e06281d0__825"
+        src="/img/store/bluefin-shirt-1.jpg"
         alt="Bluefin Official Shirt"
         loading="lazy"
       />
@@ -280,24 +280,9 @@ The [Bluefin store](https://projectbluefin.printful.me/) has a couple of especia
   </article>
 
   <article className="merch-card">
-    <a href="https://projectbluefin.printful.me/product/flock-of-raptors" target="_blank" rel="noopener noreferrer">
-      <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/876146868ae61b19790a__825"
-        alt="Flock of Raptors pin set"
-        loading="lazy"
-      />
-    </a>
-    <div className="merch-card__body">
-      <h3>Flock of Raptors</h3>
-      <p>A set of five glossy, scratch-resistant raptor pins for your jacket, bag, or battle vest.</p>
-      <a className="merch-card__link" href="https://projectbluefin.printful.me/product/flock-of-raptors" target="_blank" rel="noopener noreferrer">Shop the pin set - $9.50</a>
-    </div>
-  </article>
-
-  <article className="merch-card">
     <a href="https://projectbluefin.printful.me/product/bluefin-womens-rawr" target="_blank" rel="noopener noreferrer">
       <img
-        src="https://cdn.printful.me/t/quick-stores/variants/w339/876121968c75cec0c967__825"
+        src="/img/store/bluefin-womens-rawr-0.jpg"
         alt="Bluefin Women's Rawr shirt"
         loading="lazy"
       />

--- a/scripts/blog-store-assets.test.js
+++ b/scripts/blog-store-assets.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.join(__dirname, "..");
+
+test("blog/2026-07-22-seven-days-to-the-wolves.mdx does not hotlink Printful CDN", () => {
+  const blogPath = path.join(
+    repoRoot,
+    "blog/2026-07-22-seven-days-to-the-wolves.mdx",
+  );
+  assert.ok(fs.existsSync(blogPath), "seven-days-to-the-wolves.mdx must exist");
+
+  const content = fs.readFileSync(blogPath, "utf8");
+  assert.ok(
+    !content.includes("cdn.printful.me"),
+    "seven-days-to-the-wolves.mdx must not contain hotlinks to cdn.printful.me",
+  );
+});
+
+test("blog/2026-07-22-seven-days-to-the-wolves.mdx merch images exist in static/img/store/", () => {
+  const blogPath = path.join(
+    repoRoot,
+    "blog/2026-07-22-seven-days-to-the-wolves.mdx",
+  );
+  const content = fs.readFileSync(blogPath, "utf8");
+
+  const storeImgMatches = [...content.matchAll(/src="(\/img\/store\/[^"]+)"/g)];
+  assert.ok(
+    storeImgMatches.length >= 3,
+    "seven-days-to-the-wolves.mdx should have at least 3 local store images",
+  );
+
+  for (const match of storeImgMatches) {
+    const relativeWebPath = match[1];
+    const localFsPath = path.join(
+      repoRoot,
+      "static",
+      relativeWebPath.replace(/^\//, ""),
+    );
+    assert.ok(
+      fs.existsSync(localFsPath),
+      `Referenced store image ${relativeWebPath} must exist at ${localFsPath}`,
+    );
+  }
+});


### PR DESCRIPTION
## Problem

`blog/2026-07-22-seven-days-to-the-wolves.mdx` hotlinked four merchandise images from the Printful CDN (`cdn.printful.me`). Each CDN URL returns HTTP 403 with a Cloudflare mitigation challenge, producing broken merchandise images on the deployed Five Years of Bluefin page.

## Solution

- Replaced hotlinked `cdn.printful.me` image URLs for **Dakotaraptor Forever**, **Bluefin Official Shirt**, and **Bluefin Women's Rawr** with the corresponding local store assets under `/img/store/` (`/img/store/dakotaraptor-forever-0.jpg`, `/img/store/bluefin-shirt-1.jpg`, `/img/store/bluefin-womens-rawr-0.jpg`), consistent with references in other blog posts.
- Removed the **Flock of Raptors** pin set merch card because there is no approved local asset committed in the repository, avoiding broken images on the page.
- Added unit tests in `scripts/blog-store-assets.test.js` to ensure no `cdn.printful.me` hotlinks exist in the blog post and all referenced `/img/store/` assets exist locally.

Fixes #1098

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f2cb1f99`