### PR TITLE
fix(contributors): prevent visitor-side GitHub requests when contributor data is unavailable

### DIFF
--- a/scripts/fetch-contributors.js
+++ b/scripts/fetch-contributors.js
@@ -92,24 +92,52 @@ function getAllMarkdownFiles(dir) {
     });
 }
 
+function buildPayload(
+  files = {},
+  { generatedAt, unavailable, stateReason } = {},
+) {
+  const fileEntries =
+    files instanceof Map ? Object.fromEntries(files) : files || {};
+  const fileCount = Object.keys(fileEntries).length;
+  const isUnavailable =
+    unavailable !== undefined ? Boolean(unavailable) : fileCount === 0;
+
+  return {
+    generatedAt: generatedAt ?? new Date().toISOString(),
+    files: fileEntries,
+    unavailable: isUnavailable,
+    stateReason: isUnavailable
+      ? (stateReason ?? "No contributor requests succeeded")
+      : null,
+  };
+}
+
 async function fetchAllContributors() {
+  const force = process.argv.includes("--force");
+
   // Check if existing cache is fresh enough
   if (fs.existsSync(OUTPUT_FILE)) {
-    const stats = fs.statSync(OUTPUT_FILE);
-    const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+    try {
+      const stats = fs.statSync(OUTPUT_FILE);
+      const ageHours = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
 
-    if (ageHours < CACHE_MAX_AGE_HOURS && !process.argv.includes("--force")) {
-      console.log(
-        `✓ Cache is ${ageHours.toFixed(1)}h old (max ${CACHE_MAX_AGE_HOURS}h). Skipping fetch.`,
-      );
-      console.log(`  Use --force flag to bypass cache and force fresh fetch.`);
-      return;
-    } else if (ageHours >= CACHE_MAX_AGE_HOURS) {
-      console.log(
-        `⏱️  Cache is ${ageHours.toFixed(1)}h old (max ${CACHE_MAX_AGE_HOURS}h). Fetching fresh data...`,
-      );
-    } else {
-      console.log("🔄 --force flag detected. Fetching fresh data...");
+      if (ageHours < CACHE_MAX_AGE_HOURS && !force) {
+        console.log(
+          `✓ Cache is ${ageHours.toFixed(1)}h old (max ${CACHE_MAX_AGE_HOURS}h). Skipping fetch.`,
+        );
+        console.log(
+          `  Use --force flag to bypass cache and force fresh fetch.`,
+        );
+        return;
+      } else if (ageHours >= CACHE_MAX_AGE_HOURS) {
+        console.log(
+          `⏱️  Cache is ${ageHours.toFixed(1)}h old (max ${CACHE_MAX_AGE_HOURS}h). Fetching fresh data...`,
+        );
+      } else {
+        console.log("🔄 --force flag detected. Fetching fresh data...");
+      }
+    } catch {
+      // Ignore cache read errors and proceed to fetch
     }
   }
 
@@ -134,29 +162,43 @@ async function fetchAllContributors() {
     `Found ${allFiles.length} files to process (${docFiles.length} docs, ${blogFiles.length} blog)`,
   );
 
-  const resultsMap = await sequentialFetchWithDelay(
-    allFiles,
-    async (filePath) => {
+  let resultsMap = new Map();
+  let fetchError = null;
+
+  try {
+    resultsMap = await sequentialFetchWithDelay(allFiles, async (filePath) => {
       console.log(`Fetching contributors for ${filePath}...`);
       const contributors = await fetchCommits(filePath);
       return contributors.length > 0 ? contributors : null;
-    },
-  );
+    });
+  } catch (error) {
+    console.error("Error fetching contributors:", error.message);
+    fetchError = error;
+  }
 
-  const contributorsData = Object.fromEntries(resultsMap);
   const successCount = resultsMap.size;
+  const isUnavailable = successCount === 0;
 
-  console.log(
-    `\nSuccessfully fetched contributors for ${successCount}/${allFiles.length} files`,
-  );
-
-  // Don't fail build if no contributors fetched - component will gracefully handle empty data
-  if (successCount === 0) {
+  let stateReason = null;
+  if (isUnavailable) {
     console.warn(
       "\n⚠️  No contributors fetched! Contributors will not be displayed.",
     );
-    console.warn("   Please set a GitHub token and try again.");
+    if (fetchError) {
+      stateReason = `Contributor fetch failed: ${fetchError.message}`;
+    } else if (!GITHUB_TOKEN) {
+      console.warn("   Please set a GitHub token and try again.");
+      stateReason =
+        "No GitHub token configured and contributor requests failed";
+    } else {
+      stateReason = "No contributor requests succeeded";
+    }
   }
+
+  const payload = buildPayload(resultsMap, {
+    unavailable: isUnavailable,
+    stateReason,
+  });
 
   // Ensure output directory exists
   if (!fs.existsSync(OUTPUT_DIR)) {
@@ -166,21 +208,52 @@ async function fetchAllContributors() {
   // Write to file
   fs.writeFileSync(
     OUTPUT_FILE,
-    JSON.stringify(contributorsData, null, 2),
+    JSON.stringify(payload, null, 2) + "\n",
     "utf-8",
   );
 
-  console.log(`✓ Contributors data saved to ${OUTPUT_FILE}`);
+  if (isUnavailable) {
+    console.log(`✓ Unavailable contributor payload saved to ${OUTPUT_FILE}`);
+  } else {
+    console.log(
+      `\nSuccessfully fetched contributors for ${successCount}/${allFiles.length} files`,
+    );
+    console.log(`✓ Contributors data saved to ${OUTPUT_FILE}`);
+  }
+
+  return payload;
 }
 
 if (require.main === module) {
   fetchAllContributors().catch((error) => {
-    console.error("Fatal error:", error);
-    process.exit(1);
+    console.error("Fatal error:", error.message);
+    try {
+      const fallback = buildPayload(
+        {},
+        {
+          unavailable: true,
+          stateReason: `Fatal contributor fetch error: ${error.message}`,
+        },
+      );
+      if (!fs.existsSync(OUTPUT_DIR)) {
+        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+      }
+      fs.writeFileSync(
+        OUTPUT_FILE,
+        JSON.stringify(fallback, null, 2) + "\n",
+        "utf-8",
+      );
+    } catch {
+      // ignore
+    }
+    process.exit(0);
   });
 }
 
 module.exports = {
+  OUTPUT_FILE,
   getAllMarkdownFiles,
   isBotAccount,
+  buildPayload,
+  fetchAllContributors,
 };

--- a/scripts/fetch-contributors.test.js
+++ b/scripts/fetch-contributors.test.js
@@ -1,11 +1,46 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("path");
+const fs = require("node:fs");
+const ts = require("typescript");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
 
 const {
   getAllMarkdownFiles,
   isBotAccount,
+  buildPayload,
 } = require("./fetch-contributors.js");
+
+function loadPageContributors() {
+  const tsxPath = path.join(
+    __dirname,
+    "..",
+    "src",
+    "components",
+    "PageContributors.tsx",
+  );
+  const { outputText } = ts.transpileModule(fs.readFileSync(tsxPath, "utf8"), {
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+    },
+  });
+  const mod = { exports: {} };
+  new Function("require", "module", "exports", outputText)(
+    (id) => {
+      if (id.endsWith(".css")) return {};
+      if (id === "@site/static/data/file-contributors.json") {
+        return { unavailable: true, files: {} };
+      }
+      return require(id);
+    },
+    mod,
+    mod.exports,
+  );
+  return mod.exports;
+}
 
 test("isBotAccount detects exact bot names bot suffixes and bot substrings", () => {
   assert.equal(isBotAccount("Copilot"), true);
@@ -21,4 +56,165 @@ test("getAllMarkdownFiles returns repo-relative markdown paths", () => {
   assert.ok(files.includes("docs/installation.md"));
   assert.ok(files.every((file) => file.startsWith("docs/")));
   assert.ok(files.every((file) => /\.mdx?$/.test(file)));
+});
+
+test("buildPayload constructs available payload when files map is populated", () => {
+  const mockContributors = [
+    {
+      login: "testuser",
+      html_url: "https://github.com/testuser",
+      avatar_url: "https://example.com/avatar.png",
+    },
+  ];
+  const payload = buildPayload({ "docs/index.md": mockContributors });
+
+  assert.equal(payload.unavailable, false);
+  assert.equal(payload.stateReason, null);
+  assert.ok(payload.generatedAt);
+  assert.deepEqual(payload.files["docs/index.md"], mockContributors);
+});
+
+test("buildPayload accepts a Map instance and converts to files object", () => {
+  const mockContributors = [
+    {
+      login: "testuser",
+      html_url: "https://github.com/testuser",
+      avatar_url: "https://example.com/avatar.png",
+    },
+  ];
+  const map = new Map([["docs/index.md", mockContributors]]);
+  const payload = buildPayload(map);
+
+  assert.equal(payload.unavailable, false);
+  assert.equal(payload.stateReason, null);
+  assert.deepEqual(payload.files["docs/index.md"], mockContributors);
+});
+
+test("buildPayload emits standard unavailable payload when files map is empty", () => {
+  const payload = buildPayload({});
+
+  assert.equal(payload.unavailable, true);
+  assert.ok(payload.stateReason);
+  assert.deepEqual(payload.files, {});
+  assert.ok(payload.generatedAt);
+});
+
+test("buildPayload preserves explicit unavailable flag and stateReason", () => {
+  const payload = buildPayload(
+    {},
+    {
+      unavailable: true,
+      stateReason: "Rate limited by GitHub API",
+    },
+  );
+
+  assert.equal(payload.unavailable, true);
+  assert.equal(payload.stateReason, "Rate limited by GitHub API");
+  assert.deepEqual(payload.files, {});
+});
+
+test("isDatasetUnavailable identifies unavailable datasets and empty maps", () => {
+  const { isDatasetUnavailable } = loadPageContributors();
+
+  assert.equal(
+    isDatasetUnavailable({ unavailable: true, files: {} }),
+    true,
+    "payload with unavailable: true is unavailable",
+  );
+  assert.equal(isDatasetUnavailable({}), true, "empty object is unavailable");
+  assert.equal(isDatasetUnavailable(null), true, "null is unavailable");
+  assert.equal(
+    isDatasetUnavailable(undefined),
+    true,
+    "undefined is unavailable",
+  );
+  assert.equal(
+    isDatasetUnavailable({
+      unavailable: false,
+      files: { "docs/index.md": [] },
+    }),
+    false,
+    "payload with unavailable: false is available",
+  );
+  assert.equal(
+    isDatasetUnavailable({ "docs/index.md": [] }),
+    false,
+    "legacy populated map is available",
+  );
+});
+
+test("getFileContributors retrieves contributors from payload or legacy map", () => {
+  const { getFileContributors } = loadPageContributors();
+  const sampleContributors = [
+    {
+      login: "alice",
+      html_url: "https://github.com/alice",
+      avatar_url: "https://example.com/alice.png",
+    },
+  ];
+
+  const payload = {
+    unavailable: false,
+    files: { "docs/install.md": sampleContributors },
+  };
+  assert.deepEqual(
+    getFileContributors(payload, "docs/install.md"),
+    sampleContributors,
+  );
+  assert.equal(getFileContributors(payload, "docs/missing.md"), undefined);
+
+  const legacyMap = { "docs/install.md": sampleContributors };
+  assert.deepEqual(
+    getFileContributors(legacyMap, "docs/install.md"),
+    sampleContributors,
+  );
+  assert.equal(getFileContributors(legacyMap, "docs/missing.md"), undefined);
+});
+
+test("PageContributors component renders empty (null) and suppresses fallback when dataset is unavailable", () => {
+  const { default: PageContributors } = loadPageContributors();
+
+  // Test with standard unavailable payload
+  const htmlUnavailable = renderToStaticMarkup(
+    React.createElement(PageContributors, {
+      filePath: "docs/installation.md",
+      data: { unavailable: true, files: {} },
+    }),
+  );
+  assert.equal(htmlUnavailable, "");
+
+  // Test with empty map (legacy failure output)
+  const htmlEmpty = renderToStaticMarkup(
+    React.createElement(PageContributors, {
+      filePath: "docs/installation.md",
+      data: {},
+    }),
+  );
+  assert.equal(htmlEmpty, "");
+});
+
+test("PageContributors component renders contributors when available in build data", () => {
+  const { default: PageContributors } = loadPageContributors();
+  const sampleContributors = [
+    {
+      login: "contributor1",
+      html_url: "https://github.com/contributor1",
+      avatar_url: "https://avatars.githubusercontent.com/u/12345?v=4",
+    },
+  ];
+
+  const html = renderToStaticMarkup(
+    React.createElement(PageContributors, {
+      filePath: "docs/installation.md",
+      data: {
+        unavailable: false,
+        files: { "docs/installation.md": sampleContributors },
+      },
+    }),
+  );
+
+  assert.ok(html.includes("Contributors to this page"));
+  assert.ok(html.includes("contributor1"));
+  assert.ok(html.includes("https://github.com/contributor1"));
+  assert.ok(html.includes("https://avatars.githubusercontent.com/u/12345?v=4"));
 });

--- a/src/components/PageContributors.tsx
+++ b/src/components/PageContributors.tsx
@@ -5,15 +5,40 @@
 import React, { useEffect, useState } from "react";
 import styles from "./PageContributors.module.css";
 import contributorsData from "@site/static/data/file-contributors.json";
+import type {
+  FileContributor,
+  FileContributorsData,
+} from "@site/src/types/data";
 
-interface Contributor {
-  login: string;
-  html_url: string;
-  avatar_url: string;
+export type Contributor = FileContributor;
+
+export interface PageContributorsProps {
+  filePath: string;
+  data?: FileContributorsData;
 }
 
-interface PageContributorsProps {
-  filePath: string;
+export function isDatasetUnavailable(
+  data: FileContributorsData | undefined,
+): boolean {
+  if (!data) return true;
+  if ("unavailable" in data && data.unavailable !== undefined) {
+    return Boolean(data.unavailable);
+  }
+  if ("files" in data && data.files !== undefined) {
+    return Object.keys(data.files).length === 0;
+  }
+  return Object.keys(data).length === 0;
+}
+
+export function getFileContributors(
+  data: FileContributorsData | undefined,
+  filePath: string,
+): Contributor[] | undefined {
+  if (!data) return undefined;
+  if ("files" in data && data.files && typeof data.files === "object") {
+    return (data.files as Record<string, Contributor[]>)[filePath];
+  }
+  return (data as Record<string, Contributor[]>)[filePath];
 }
 
 const CACHE_KEY_PREFIX = "file_contributors_";
@@ -129,15 +154,37 @@ const fetchFileContributors = async (
   });
 };
 
-const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
-  const [contributors, setContributors] = useState<Contributor[]>([]);
-  const [loading, setLoading] = useState(true);
+const PageContributors: React.FC<PageContributorsProps> = ({
+  filePath,
+  data = contributorsData as unknown as FileContributorsData,
+}) => {
+  const [contributors, setContributors] = useState<Contributor[]>(() => {
+    if (isDatasetUnavailable(data)) {
+      return [];
+    }
+    const buildData = getFileContributors(data, filePath);
+    return buildData ?? [];
+  });
+  const [loading, setLoading] = useState<boolean>(() => {
+    if (isDatasetUnavailable(data)) {
+      return false;
+    }
+    const buildData = getFileContributors(data, filePath);
+    return !buildData;
+  });
 
   useEffect(() => {
-    // First, try pre-fetched build-time data
-    const buildData = (contributorsData as Record<string, typeof contributorsData[keyof typeof contributorsData]>)[filePath];
+    // If the contributor dataset as a whole is unavailable, suppress visitor-side API fallback
+    if (isDatasetUnavailable(data)) {
+      setContributors([]);
+      setLoading(false);
+      return;
+    }
 
-    if (buildData) {
+    // First, try pre-fetched build-time data
+    const buildData = getFileContributors(data, filePath);
+
+    if (buildData && buildData.length > 0) {
       setContributors(buildData);
       setLoading(false);
       return;
@@ -150,11 +197,12 @@ const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
 
       if (cachedData) {
         try {
-          const { data, timestamp } = JSON.parse(cachedData);
+          const { data: cachedContributors, timestamp } =
+            JSON.parse(cachedData);
           const age = Date.now() - timestamp;
 
           if (age < CACHE_DURATION) {
-            setContributors(data);
+            setContributors(cachedContributors);
             setLoading(false);
             return;
           } else {
@@ -166,10 +214,10 @@ const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
       }
     }
 
-    // Finally, fetch from GitHub API as fallback
+    // Finally, fetch from GitHub API as fallback for cache misses on an available dataset
     fetchFileContributors(filePath)
-      .then((data) => {
-        setContributors(data);
+      .then((fetchedData) => {
+        setContributors(fetchedData);
         setLoading(false);
 
         // Cache in localStorage with 30-day expiry
@@ -179,7 +227,7 @@ const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
             localStorage.setItem(
               cacheKey,
               JSON.stringify({
-                data,
+                data: fetchedData,
                 timestamp: Date.now(),
               }),
             );
@@ -195,7 +243,7 @@ const PageContributors: React.FC<PageContributorsProps> = ({ filePath }) => {
         );
         setLoading(false);
       });
-  }, [filePath]);
+  }, [filePath, data]);
 
   if (loading) {
     return null;

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -68,7 +68,6 @@ export interface GnomeExtension {
 /**
  * File contributors from scripts/fetch-contributors.js
  * Used by: src/components/PageContributors.tsx
- * Structure: Record of file paths to contributor arrays
  */
 export interface FileContributor {
   login: string;
@@ -76,5 +75,18 @@ export interface FileContributor {
   avatar_url: string;
 }
 
-export type FileContributorsData = Record<string, FileContributor[]>;
+export interface FileContributorsPayload {
+  generatedAt?: string;
+  files?: Record<string, FileContributor[]>;
+  unavailable?: boolean;
+  stateReason?: string | null;
+}
 
+export type FileContributorsData =
+  FileContributorsPayload | Record<string, FileContributor[]>;
+
+declare module "@site/static/data/file-contributors.json" {
+  import type { FileContributorsData } from "@site/src/types/data";
+  const data: FileContributorsData;
+  export default data;
+}


### PR DESCRIPTION
### Summary

Fixes #1097.

When `scripts/fetch-contributors.js` experiences a failed fetch or fetches zero contributors (e.g. rate-limited without a token), it previously emitted an empty object `{}`. In `src/components/PageContributors.tsx`, missing file keys were treated as individual cache misses, causing every visitor's browser to make unauthenticated GitHub API requests for each page footer.

This PR:
1. Updates `scripts/fetch-contributors.js` to emit the standard unavailable payload (`{ generatedAt, files: {}, unavailable: true, stateReason }`) when no contributor requests succeed or upon fetch failure, and exports `buildPayload`.
2. Updates `src/components/PageContributors.tsx` to detect globally unavailable contributor datasets (both `{ unavailable: true }` and legacy empty map `{}`) and suppress visitor-side GitHub API requests, gracefully rendering null instead of hammering GitHub's API.
3. Updates `src/types/data.d.ts` with ambient declaration and typing for `FileContributorsPayload`.
4. Adds comprehensive unit and component tests in `scripts/fetch-contributors.test.js`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `75fc4ee2`