### PR TITLE
fix(countme): recognize Dakota and Utah without misclassifying Bluefin variants

### DIFF
--- a/scripts/fetch-countme.js
+++ b/scripts/fetch-countme.js
@@ -2,7 +2,7 @@
 /**
  * Fetches weekly countme data from the Fedora countme totals CSV and writes
  * static/data/countme-history.json, consumed by the site to show active-device
- * trends for Bluefin, Bluefin LTS, Aurora, Bazzite, and Fedora.
+ * trends for Bluefin, Bluefin LTS, Aurora, Bazzite, Fedora, Dakota, and Utah.
  *
  * COUNTING RULE — keep in step with ublue-os/countme.
  *
@@ -23,8 +23,10 @@
  *      to the base ^fedora-[0-9]+$ repo picks the one repo every Fedora-based
  *      system has exactly one of; summing across those tags therefore sums
  *      across releases (F41 + F42 + …), not across repos of one machine.
- *   3. Bluefin LTS is exempt from rule 2. It is CentOS Stream based and has no
- *      fedora-N repo at all, so it is counted across its own (EPEL) repos.
+ *   3. Bluefin LTS and Dakota are exempt from rule 2. Bluefin LTS is CentOS
+ *      Stream based and has no fedora-N repo at all, so it is counted across
+ *      its own (EPEL) repos. Dakota is GNOME OS based and also has no
+ *      fedora-N base repo.
  *   4. Two upstream weeks are known bad and are skipped outright.
  *
  * The source CSV is ~600 MB. This script uses HTTP Range requests to fetch only
@@ -52,7 +54,15 @@ const OUT = resolve(__dirname, "../static/data/countme-history.json");
 const CSV_URL =
   "https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv";
 
-const VARIANTS = ["bluefin", "bluefin-lts", "aurora", "bazzite", "fedora"];
+export const VARIANTS = [
+  "bluefin",
+  "bluefin-lts",
+  "aurora",
+  "bazzite",
+  "fedora",
+  "dakota",
+  "utah",
+];
 
 /**
  * How a weekly number is derived from the CSV. Stamped into the payload so a
@@ -71,9 +81,9 @@ const BASE_REPO = /^fedora-\d+$/;
 /**
  * Variants with no fedora-N repo, counted across their own repos instead.
  * Bluefin LTS is CentOS Stream based and reaches Fedora's counter only through
- * EPEL. ublue-os/countme has this same carve-out.
+ * EPEL. Dakota is GNOME OS based and has no Fedora base repo.
  */
-const NON_FEDORA_VARIANTS = new Set(["bluefin-lts"]);
+export const NON_FEDORA_VARIANTS = new Set(["bluefin-lts", "dakota"]);
 
 /**
  * Weeks upstream got wrong, skipped exactly as ublue-os/countme skips them.
@@ -169,7 +179,7 @@ export function parseCsvLine(line) {
  * Returns null for unrecognised names — bucketing an unknown OS into a variant
  * would inflate the headline number.
  *
- * ORDER MATTERS: LTS checks before generic bluefin.
+ * ORDER MATTERS: LTS, Dakota, and Utah check before generic bluefin.
  */
 export function normalizeVariant(osName) {
   if (osName == null) return null;
@@ -183,6 +193,23 @@ export function normalizeVariant(osName) {
     s.startsWith("bluefin-lts")
   )
     return "bluefin-lts";
+
+  // Specific Bluefin variants before generic flagship fallback
+  if (
+    s.startsWith("bluefin-dakota") ||
+    s.includes("bluefin dakota") ||
+    s.startsWith("dakota") ||
+    s.includes("dakota")
+  )
+    return "dakota";
+
+  if (
+    s.startsWith("bluefin-utah") ||
+    s.includes("bluefin utah") ||
+    s.startsWith("utah") ||
+    s.includes("utah")
+  )
+    return "utah";
 
   if (s.startsWith("bluefin")) return "bluefin";
   if (s.startsWith("aurora")) return "aurora";

--- a/scripts/fetch-countme.test.js
+++ b/scripts/fetch-countme.test.js
@@ -11,6 +11,8 @@ import {
   tailRange,
   buildPayload,
   METHOD,
+  VARIANTS,
+  NON_FEDORA_VARIANTS,
 } from "./fetch-countme.js";
 
 /**
@@ -104,6 +106,8 @@ test("normalizeVariant folds known OS names", () => {
   assert.equal(normalizeVariant("Aurora"), "aurora");
   assert.equal(normalizeVariant("Bazzite"), "bazzite");
   assert.equal(normalizeVariant("Fedora Linux"), "fedora");
+  assert.equal(normalizeVariant("Dakota"), "dakota");
+  assert.equal(normalizeVariant("Utah"), "utah");
 });
 
 test("normalizeVariant folds downstream spins", () => {
@@ -121,6 +125,29 @@ test("normalizeVariant returns bluefin-lts for Bluefin LTS, not bluefin", () => 
   // Branch order: LTS must be checked before generic bluefin
   assert.equal(normalizeVariant("Bluefin LTS"), "bluefin-lts");
   assert.notEqual(normalizeVariant("Bluefin LTS"), "bluefin");
+});
+
+test("normalizeVariant recognizes Dakota and Utah before generic bluefin fallback", () => {
+  // Branch order: specific variants must be checked before generic bluefin
+  const names = ["Dakota", "bluefin-dakota", "Utah", "bluefin-utah"];
+  assert.deepEqual(names.map(normalizeVariant), [
+    "dakota",
+    "dakota",
+    "utah",
+    "utah",
+  ]);
+
+  assert.equal(normalizeVariant("Dakota"), "dakota");
+  assert.equal(normalizeVariant("bluefin-dakota"), "dakota");
+  assert.equal(normalizeVariant("Bluefin Dakota"), "dakota");
+  assert.equal(normalizeVariant("Project Bluefin Dakota"), "dakota");
+  assert.notEqual(normalizeVariant("bluefin-dakota"), "bluefin");
+
+  assert.equal(normalizeVariant("Utah"), "utah");
+  assert.equal(normalizeVariant("bluefin-utah"), "utah");
+  assert.equal(normalizeVariant("Bluefin Utah"), "utah");
+  assert.equal(normalizeVariant("Project Bluefin Utah"), "utah");
+  assert.notEqual(normalizeVariant("bluefin-utah"), "bluefin");
 });
 
 // ── aggregateWeeks ───────────────────────────────────────────────────────
@@ -178,6 +205,30 @@ test("aggregateWeeks counts Bluefin LTS across its own repos, having no fedora-N
   const weeks = aggregateWeeks(rows);
   assert.equal(weeks[0]["bluefin-lts"], 159);
   assert.equal(weeks[0].bluefin, undefined);
+});
+
+test("aggregateWeeks counts Dakota across non-Fedora repos, having no fedora-N repo", () => {
+  // Dakota is GNOME OS based and has no fedora-N repo; it must not be dropped
+  // by the base repo restriction or misclassified as flagship bluefin.
+  const rows = parseAll([
+    row({ os_name: "bluefin-dakota", repo_tag: "gnome-os", hits: 12 }),
+    row({ os_name: "Dakota", repo_tag: "gnome-os-master", hits: 8 }),
+  ]);
+  const weeks = aggregateWeeks(rows);
+  assert.equal(weeks.length, 1);
+  assert.equal(weeks[0].dakota, 20);
+  assert.equal(weeks[0].bluefin, undefined);
+});
+
+test("aggregateWeeks counts Utah systems with base fedora repo, separated from Bluefin", () => {
+  const rows = parseAll([
+    row({ os_name: "bluefin-utah", repo_tag: "fedora-44", hits: 15 }),
+    row({ os_name: "bluefin", repo_tag: "fedora-44", hits: 30 }),
+  ]);
+  const weeks = aggregateWeeks(rows);
+  assert.equal(weeks.length, 1);
+  assert.equal(weeks[0].utah, 15);
+  assert.equal(weeks[0].bluefin, 30);
 });
 
 test("aggregateWeeks skips the two weeks upstream got wrong", () => {
@@ -303,6 +354,9 @@ test("buildPayload produces the documented shape", () => {
   assert.equal(payload.unavailable, false);
   assert.equal(payload.stateReason, null);
   assert.equal(payload.weeks.length, 1);
+  assert.deepEqual(payload.variants, VARIANTS);
+  assert.ok(payload.variants.includes("dakota"));
+  assert.ok(payload.variants.includes("utah"));
 });
 
 test("buildPayload can retain history while marking a failed refresh unavailable", () => {

--- a/static/data/countme-history.json
+++ b/static/data/countme-history.json
@@ -3,7 +3,15 @@
   "source": "https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv",
   "method": "ublue-countme-v1",
   "unit": "estimated weekly active systems",
-  "variants": ["bluefin", "bluefin-lts", "aurora", "bazzite", "fedora"],
+  "variants": [
+    "bluefin",
+    "bluefin-lts",
+    "aurora",
+    "bazzite",
+    "fedora",
+    "dakota",
+    "utah"
+  ],
   "weeks": [
     {
       "week": "2025-12-01",


### PR DESCRIPTION
Resolves #1083

### Summary of changes
- Add `dakota` and `utah` to tracked `VARIANTS` in `scripts/fetch-countme.js` and `static/data/countme-history.json`
- Include `dakota` in `NON_FEDORA_VARIANTS` so that GNOME OS-based Dakota systems without `fedora-N` base repos are properly counted across their repositories
- Evaluate specific Dakota and Utah matching before the generic `startsWith("bluefin")` fallback in `normalizeVariant` to avoid misclassifying `bluefin-dakota` and `bluefin-utah` as flagship Bluefin
- Add test coverage in `scripts/fetch-countme.test.js` validating normalization and aggregation for Dakota and Utah

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `30856817`