### PR TITLE
fix(blog): remove expired Discourse CDN images from ublue-2024 wrap-up

### DIFF
--- a/blog/2024-12-30-ublue-2024-wrapup.md
+++ b/blog/2024-12-30-ublue-2024-wrapup.md
@@ -13,11 +13,9 @@ First up, [Happy Birthday to Bazzite](https://universal-blue.discourse.group/t/h
 
 :::info[The Verge]
 
-![](https://global.discourse-cdn.com/free1/uploads/univeral_blue/original/2X/0/0fb70f954d33be086a81ed8a1d4ddd2bd5287e13.png) [The Steam Deck has finally been surpassed — by a fork of Valve’s own experience](https://www.theverge.com/2024/12/30/24329005/bazzite-asus-rog-ally-x-steam-os-editorial "01:00PM - 30 December 2024")
+[The Steam Deck has finally been surpassed — by a fork of Valve’s own experience](https://www.theverge.com/2024/12/30/24329005/bazzite-asus-rog-ally-x-steam-os-editorial "01:00PM - 30 December 2024")
 
 :::
-
-![](https://global.discourse-cdn.com/free1/uploads/univeral_blue/optimized/2X/8/856e9185c25db4f62c6c50d6e69b852a2dfa9d1f_2_690x361.jpeg)
 
 ### [The Steam Deck has finally been surpassed — by a fork of Valve’s own experience](https://www.theverge.com/2024/12/30/24329005/bazzite-asus-rog-ally-x-steam-os-editorial)
 


### PR DESCRIPTION
Closes #1100

## Problem
`blog/2024-12-30-ublue-2024-wrapup.md` references two `global.discourse-cdn.com` images that now return HTTP 403 (S3 `AccessDenied`), producing broken images on `/blog/ublue-2024/`.

## Fix
No approved local replacement assets exist for these external screenshots (a Verge article thumbnail and a Steam Deck photo), so the broken embeds are removed per the issue's fallback guidance, while keeping the surrounding links and text intact. The other two images in the post (growth chart, closing image) still return HTTP 200 and were left unchanged.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bae4e19e`