### PR TITLE
fix(driver-versions): generate Bluefin LTS release links with stable tags

### DIFF
--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -170,7 +170,10 @@ function rowFromSbomRelease(
     tag: releaseEntry?.tag || cacheKey,
     title: releaseEntry?.tag || cacheKey,
     releaseUrl: (() => {
-      const tag = releaseEntry?.tag || cacheKey;
+      let tag = releaseEntry?.tag || cacheKey;
+      if (streamId === "bluefin-lts" && typeof tag === "string") {
+        tag = tag.replace(/^lts-(\d{8})$/, "stable-$1");
+      }
       const repo = RELEASE_REPO_BY_STREAM[streamId];
       return repo && tag
         ? `https://github.com/${repo}/releases/tag/${tag}`

--- a/scripts/fetch-github-driver-versions.test.js
+++ b/scripts/fetch-github-driver-versions.test.js
@@ -56,6 +56,31 @@ test("rowFromSbomRelease builds kernel/mesa/gnome from SBOM only", () => {
   assert.equal(row.versions.mesa, "25.3.6-6");
   assert.equal(row.versions.gnome, "49.5-1");
   assert.equal(row.versions.nvidia, "595.58.03-1");
+  assert.equal(
+    row.releaseUrl,
+    "https://github.com/projectbluefin/bluefin/releases/tag/stable-20260331",
+  );
+});
+
+test("rowFromSbomRelease translates LTS lts-YYYYMMDD cache key to upstream stable-YYYYMMDD releaseUrl", () => {
+  const row = rowFromSbomRelease(
+    "bluefin-lts",
+    "lts-20260602",
+    {
+      tag: "lts-20260602",
+      packageVersions: {
+        kernel: "6.12.0-233.el10",
+      },
+    },
+    "595.71.05",
+  );
+
+  assert.equal(row.tag, "lts-20260602");
+  assert.equal(row.title, "lts-20260602");
+  assert.equal(
+    row.releaseUrl,
+    "https://github.com/projectbluefin/bluefin-lts/releases/tag/stable-20260602",
+  );
 });
 
 test("rowFromSbomRelease includes systemd, bootc, and pipewire when present", () => {


### PR DESCRIPTION
Translates LTS cache keys to stable-YYYYMMDD release links. Supersedes cross-fork #1175 cleanly rebased on main.