### PR TITLE
sec(ci): pin wrangler version in deploy-countme-worker and setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install Wrangler (Cloudflare CLI)
-        run: npm install -g wrangler@latest
+        run: npm install -g wrangler@4.129.1
 
       - name: Verify Wrangler auth
         if: env.CLOUDFLARE_API_TOKEN != ''

--- a/.github/workflows/deploy-countme-worker.yml
+++ b/.github/workflows/deploy-countme-worker.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler@latest deploy --config wrangler.countme.toml
+        run: npx wrangler@4.129.1 deploy --config wrangler.countme.toml


### PR DESCRIPTION
Pin wrangler from unpinned `latest` to `4.129.1` (matching repo devDependency in package.json) in `.github/workflows/deploy-countme-worker.yml` and `.github/workflows/copilot-setup-steps.yml` to prevent supply chain risks when executing alongside `CLOUDFLARE_API_TOKEN`.

Closes projectbluefin/documentation#1074