### PR TITLE
sec(ci): pin bun and wrangler versions in copilot environments

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install Wrangler (Cloudflare CLI)
-        run: npm install -g wrangler@latest
+        run: npm install -g wrangler@4.129.1
 
       - name: Verify Wrangler auth
         if: env.CLOUDFLARE_API_TOKEN != ''


### PR DESCRIPTION
Pin wrangler to `4.129.1` in `.github/workflows/copilot-setup-steps.yml` (matching the tested repository version in `package.json`), and verify that `.github/copilot-codespace.yml` pins Bun to an exact version with SHA-256 integrity verification, preventing unpinned execution risks in Copilot environments.

Closes projectbluefin/documentation#1048