### PR TITLE
ci(pdf): pin node version for docusaurus-prince-pdf compatibility

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24'
+          node-version: '20'
 
       - name: Prepare Prince cache dirs
         run: |


### PR DESCRIPTION
Pin Node.js to version 20 in the Generate Docs PDF workflow.

docusaurus-prince-pdf 1.2.1 uses import assertion syntax (assert { type: 'json' }) in index.js, which causes 'SyntaxError: Unexpected identifier assert' under Node 24. Pinning setup-node to Node 20 restores compatibility.

Closes projectbluefin/documentation#1041