### PR TITLE
fix(factory): ensure live snapshot button text is visible in light mode

### DIFF
--- a/scripts/factory-snapshot.test.js
+++ b/scripts/factory-snapshot.test.js
@@ -66,3 +66,25 @@ test("HiveSnapshot renders snapshot link in markup", () => {
   );
   assert.match(html, /Open the live snapshot/);
 });
+
+test("HiveSnapshot CTA button uses readable high-contrast text color token", () => {
+  const css = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "src",
+      "components",
+      "factory",
+      "panels",
+      "HiveSnapshot.module.css",
+    ),
+    "utf8",
+  );
+  // Must not use var(--fx-bg) for text color (transparent in light mode)
+  assert.ok(!css.includes("color: var(--fx-bg)"), "CTA must not use --fx-bg for text color");
+  assert.match(
+    css,
+    /\.cta\s*\{[^}]*color:\s*var\(--fx-text-on-accent\)/s,
+    "CTA button must use --fx-text-on-accent for high-contrast text in light mode",
+  );
+});

--- a/src/components/factory/panels/HiveSnapshot.module.css
+++ b/src/components/factory/panels/HiveSnapshot.module.css
@@ -31,7 +31,7 @@
   padding: 0 var(--fx-space-4);
   border-radius: var(--fx-radius-md);
   background: var(--fx-accent);
-  color: var(--fx-bg);
+  color: var(--fx-text-on-accent);
   font-size: var(--fx-text-sm);
   font-weight: var(--fx-weight-bold);
   transition: var(--fx-transition);
@@ -40,7 +40,7 @@
 .cta:hover,
 .cta:focus-visible {
   background: var(--fx-accent-dim);
-  color: var(--fx-bg);
+  color: var(--fx-text-on-accent);
   text-decoration: none;
 }
 

--- a/src/components/factory/tokens.css
+++ b/src/components/factory/tokens.css
@@ -28,6 +28,7 @@
   --fx-text-strong: var(--ifm-heading-color);
   --fx-text-muted: var(--ifm-color-emphasis-700);
   --fx-text-faint: var(--ifm-color-emphasis-600);
+  --fx-text-on-accent: var(--ifm-font-color-base-inverse, #fff);
 
   --fx-accent: var(--ifm-color-primary);
   --fx-accent-dim: var(--ifm-color-primary-dark);


### PR DESCRIPTION
## Description

On the factory page, the "Open the live snapshot" CTA button in `HiveSnapshot` was styled with `color: var(--fx-bg);`. In light mode, Infima's `--ifm-background-color` (and therefore `--fx-bg`) evaluates to `transparent`, causing the button text to become invisible against the accent background.

This change:
1. Adds `--fx-text-on-accent: var(--ifm-font-color-base-inverse, #fff);` to `src/components/factory/tokens.css`.
2. Updates `src/components/factory/panels/HiveSnapshot.module.css` (`.cta` and `.cta:hover, .cta:focus-visible`) to use `color: var(--fx-text-on-accent);`.
3. Adds a unit test in `scripts/factory-snapshot.test.js` verifying the button text color token is high-contrast and does not use `--fx-bg`.

Closes projectbluefin/documentation#1053