### PR TITLE
fix(theme): prevent header logo flash when switching themes

### DIFF
--- a/scripts/brand-assets.test.js
+++ b/scripts/brand-assets.test.js
@@ -123,3 +123,22 @@ test("navbar i18n translation and css suppress duplicate title", () => {
     );
   }
 });
+
+test("custom.css hides inactive theme logo to prevent stacking flash", () => {
+  const cssPath = path.join(repoRoot, "src/css/custom.css");
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  assert.ok(
+    css.includes(".navbar__logo img"),
+    "custom.css must style .navbar__logo img",
+  );
+  // Verify inactive logos are hidden to prevent stacking flash
+  assert.ok(
+    css.includes("themedComponent--dark") && css.includes("display: none"),
+    "custom.css must hide dark logo in light mode to prevent flash",
+  );
+  assert.ok(
+    css.includes("themedComponent--light") && css.includes("display: none"),
+    "custom.css must hide light logo in dark mode to prevent flash",
+  );
+});

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -255,7 +255,18 @@ aside.col--3 nav.thin-scrollbar {
   height: 100%;
   width: auto;
   max-width: none;
+}
+
+html[data-theme="light"] .navbar__logo img[class*="themedComponent--light"],
+html:not([data-theme]) .navbar__logo img[class*="themedComponent--light"],
+html[data-theme="dark"] .navbar__logo img[class*="themedComponent--dark"] {
   display: block;
+}
+
+html[data-theme="light"] .navbar__logo img[class*="themedComponent--dark"],
+html:not([data-theme]) .navbar__logo img[class*="themedComponent--dark"],
+html[data-theme="dark"] .navbar__logo img[class*="themedComponent--light"] {
+  display: none !important;
 }
 
 .navbar__title {


### PR DESCRIPTION
Explicitly hide the inactive theme logo in `.navbar__logo img` using `data-theme` attribute selectors to ensure both light and dark SVGs do not appear stacked vertically before hydration or when overriding display rules.

Closes projectbluefin/documentation#1052