### PR TITLE
test(scripts): add unit test coverage for scripts/lib modules

### DIFF
--- a/scripts/build-metrics.test.js
+++ b/scripts/build-metrics.test.js
@@ -1,0 +1,220 @@
+/**
+ * Tests for scripts/lib/build-metrics.mjs
+ *
+ * Covers:
+ * - calculateWorkflowMetrics:
+ *   - empty runs fallback
+ *   - success rate calculation and rounding
+ *   - failure count
+ *   - average duration calculation from run_started_at and updated_at
+ * - calculateStatistics:
+ *   - totalBuilds across images
+ *   - mostActive image identification
+ *   - perfectImages (100% success rate with builds > 0)
+ *   - weighted average duration across all builds
+ *   - empty images array fallback
+ * - calculateMoMChange:
+ *   - positive and negative percentage changes
+ *   - zero baseline returns 0
+ * - fetchBuildMetrics:
+ *   - end-to-end with injected requestClient seam
+ *   - error handling and graceful degradation to null
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+async function load() {
+  return import("./lib/build-metrics.mjs");
+}
+
+describe("calculateWorkflowMetrics", () => {
+  it("returns zeroed metrics when runs list is empty", async () => {
+    const { calculateWorkflowMetrics } = await load();
+    const result = calculateWorkflowMetrics("test:wf", "org/repo", 1234, []);
+
+    assert.deepEqual(result, {
+      name: "test:wf",
+      repo: "org/repo",
+      workflowId: 1234,
+      successRate: 0,
+      totalBuilds: 0,
+      failures: 0,
+      avgDuration: 0,
+    });
+  });
+
+  it("calculates success rate, failures, and avgDuration correctly", async () => {
+    const { calculateWorkflowMetrics } = await load();
+    const runs = [
+      {
+        conclusion: "success",
+        run_started_at: "2026-03-01T10:00:00Z",
+        updated_at: "2026-03-01T10:02:00Z", // 120s
+      },
+      {
+        conclusion: "success",
+        run_started_at: "2026-03-02T10:00:00Z",
+        updated_at: "2026-03-02T10:04:00Z", // 240s
+      },
+      {
+        conclusion: "failure",
+        run_started_at: "2026-03-03T10:00:00Z",
+        updated_at: "2026-03-03T10:01:00Z", // 60s
+      },
+    ];
+
+    const result = calculateWorkflowMetrics("bluefin:stable", "projectbluefin/bluefin", 125772764, runs);
+
+    assert.equal(result.totalBuilds, 3);
+    assert.equal(result.failures, 1);
+    // (2 / 3) * 100 = 66.666... -> 66.7
+    assert.equal(result.successRate, 66.7);
+    // (120 + 240 + 60) / 3 = 140s
+    assert.equal(result.avgDuration, 140);
+  });
+
+  it("handles runs with missing timestamps gracefully", async () => {
+    const { calculateWorkflowMetrics } = await load();
+    const runs = [
+      {
+        conclusion: "success",
+        run_started_at: null,
+        updated_at: null,
+      },
+      {
+        conclusion: "success",
+        run_started_at: "2026-03-01T10:00:00Z",
+        updated_at: "2026-03-01T10:01:00Z", // 60s
+      },
+    ];
+
+    const result = calculateWorkflowMetrics("bluefin:stable", "projectbluefin/bluefin", 125772764, runs);
+
+    assert.equal(result.totalBuilds, 2);
+    assert.equal(result.successRate, 100);
+    assert.equal(result.avgDuration, 60);
+  });
+});
+
+describe("calculateStatistics", () => {
+  it("returns zeroed statistics when images array is empty", async () => {
+    const { calculateStatistics } = await load();
+    const stats = calculateStatistics([]);
+
+    assert.deepEqual(stats, {
+      totalBuilds: 0,
+      mostActive: null,
+      perfectStreak: 0,
+      perfectImages: [],
+      avgDuration: 0,
+    });
+  });
+
+  it("identifies mostActive, perfectImages, and computes weighted avgDuration", async () => {
+    const { calculateStatistics } = await load();
+    const images = [
+      {
+        name: "bluefin:stable",
+        totalBuilds: 50,
+        successRate: 100,
+        avgDuration: 100,
+      },
+      {
+        name: "bluefin:latest",
+        totalBuilds: 100,
+        successRate: 98.0,
+        avgDuration: 200,
+      },
+      {
+        name: "bluefin:lts",
+        totalBuilds: 20,
+        successRate: 100,
+        avgDuration: 150,
+      },
+    ];
+
+    const stats = calculateStatistics(images);
+
+    assert.equal(stats.totalBuilds, 170);
+    assert.equal(stats.mostActive, "bluefin:latest");
+    assert.deepEqual(stats.perfectImages, ["bluefin:stable", "bluefin:lts"]);
+    assert.equal(stats.perfectStreak, 30);
+    // (50*100 + 100*200 + 20*150) / 170 = (5000 + 20000 + 3000) / 170 = 28000 / 170 = 164.705... -> 165
+    assert.equal(stats.avgDuration, 165);
+  });
+
+  it("handles images with totalBuilds === 0", async () => {
+    const { calculateStatistics } = await load();
+    const images = [
+      {
+        name: "unused:workflow",
+        totalBuilds: 0,
+        successRate: 0,
+        avgDuration: 0,
+      },
+    ];
+
+    const stats = calculateStatistics(images);
+    assert.equal(stats.totalBuilds, 0);
+    assert.deepEqual(stats.perfectImages, []);
+    assert.equal(stats.perfectStreak, 0);
+  });
+});
+
+describe("calculateMoMChange", () => {
+  it("returns percentage delta rounded to 1 decimal", async () => {
+    const { calculateMoMChange } = await load();
+    assert.equal(calculateMoMChange(95.0, 90.0), 5.6);
+    assert.equal(calculateMoMChange(80.0, 100.0), -20);
+    assert.equal(calculateMoMChange(100.0, 100.0), 0);
+  });
+
+  it("returns 0 when previous is 0 (no division by zero)", async () => {
+    const { calculateMoMChange } = await load();
+    assert.equal(calculateMoMChange(50.0, 0), 0);
+  });
+});
+
+describe("fetchBuildMetrics with injected requestClient seam", () => {
+  it("fetches metrics for tracked workflows and computes monthly stats", async () => {
+    const { fetchBuildMetrics } = await load();
+
+    const start = new Date("2026-03-01T00:00:00Z");
+    const end = new Date("2026-03-31T23:59:59Z");
+
+    const mockRequest = async (route, params) => {
+      assert.equal(route, "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs");
+      // Return a run based on the workflow id
+      return {
+        data: {
+          workflow_runs: [
+            {
+              conclusion: "success",
+              run_started_at: "2026-03-05T00:00:00Z",
+              updated_at: "2026-03-05T00:02:00Z", // 120s
+            },
+          ],
+        },
+      };
+    };
+
+    const metrics = await fetchBuildMetrics(start, end, {
+      requestClient: mockRequest,
+    });
+
+    assert.ok(metrics);
+    assert.ok(Array.isArray(metrics.images));
+    assert.equal(metrics.images.length, 7); // 7 TRACKED_WORKFLOWS
+    assert.equal(metrics.stats.totalBuilds, 7);
+    assert.equal(metrics.stats.perfectImages.length, 7);
+    assert.equal(metrics.previousMonth.images.length, 7);
+  });
+
+  it("returns null gracefully if an unhandled top-level error occurs", async () => {
+    const { fetchBuildMetrics } = await load();
+    // Passing invalid Date that throws in getFullYear or similar
+    const result = await fetchBuildMetrics(null, null);
+    assert.equal(result, null);
+  });
+});

--- a/scripts/graphql-queries.test.js
+++ b/scripts/graphql-queries.test.js
@@ -414,6 +414,34 @@ describe("fetchClosedItemsFromRepo", () => {
 
     assert.deepEqual(result, { items: [], partial: false });
   });
+
+  it("accepts an injected client option to bypass the default graphqlWithAuth", async () => {
+    const { fetchClosedItemsFromRepo, REPO_CLOSED_ISSUES_QUERY, REPO_MERGED_PRS_QUERY } = await load();
+    const mockCalls = [];
+    const customClient = async (query, vars) => {
+      mockCalls.push({ query, vars });
+      if (query === REPO_CLOSED_ISSUES_QUERY) {
+        return repoPages({ issues: page([issueNode({ number: 99 })]) });
+      }
+      if (query === REPO_MERGED_PRS_QUERY) {
+        return repoPages({ pullRequests: page([prNode({ number: 100 })]) });
+      }
+      return repoPages();
+    };
+
+    const result = await fetchClosedItemsFromRepo("custom-owner", "custom-repo", START, END, {
+      client: customClient,
+    });
+
+    assert.equal(result.partial, false);
+    assert.deepEqual(
+      result.items.map((i) => i.number),
+      [99, 100],
+    );
+    assert.equal(mockCalls.length, 2);
+    assert.equal(mockCalls[0].vars.owner, "custom-owner");
+    assert.equal(mockCalls[0].vars.name, "custom-repo");
+  });
 });
 
 describe("graphql-queries module surface", () => {

--- a/scripts/lib/build-metrics.mjs
+++ b/scripts/lib/build-metrics.mjs
@@ -68,9 +68,19 @@ const requestWithAuth = request.defaults({
  * @param {number} workflowId - Workflow ID
  * @param {Date} startDate - Start of date range
  * @param {Date} endDate - End of date range
+ * @param {object} [options] - Options
+ * @param {Function} [options.requestClient=requestWithAuth] - Octokit request client
  * @returns {Promise<Array>} Array of workflow run objects
  */
-async function fetchWorkflowRuns(owner, repo, workflowId, startDate, endDate) {
+async function fetchWorkflowRuns(
+  owner,
+  repo,
+  workflowId,
+  startDate,
+  endDate,
+  options = {},
+) {
+  const { requestClient = requestWithAuth } = options;
   const runs = [];
   let page = 1;
   const perPage = 100;
@@ -83,7 +93,7 @@ async function fetchWorkflowRuns(owner, repo, workflowId, startDate, endDate) {
     while (true) {
       const response = await retryWithBackoff(
         async () => {
-          return await requestWithAuth(
+          return await requestClient(
             "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
             {
               owner,
@@ -127,7 +137,7 @@ async function fetchWorkflowRuns(owner, repo, workflowId, startDate, endDate) {
  * @param {Array} runs - Workflow runs
  * @returns {Object} Workflow metrics
  */
-function calculateWorkflowMetrics(name, repo, workflowId, runs) {
+export function calculateWorkflowMetrics(name, repo, workflowId, runs) {
   const totalBuilds = runs.length;
 
   if (totalBuilds === 0) {
@@ -178,7 +188,7 @@ function calculateWorkflowMetrics(name, repo, workflowId, runs) {
  * @param {Array} images - Array of workflow metrics
  * @returns {Object} Aggregate statistics
  */
-function calculateStatistics(images) {
+export function calculateStatistics(images) {
   const totalBuilds = images.reduce((sum, img) => sum + img.totalBuilds, 0);
 
   if (totalBuilds === 0) {
@@ -230,7 +240,7 @@ function calculateStatistics(images) {
  * @param {number} previous - Previous month value
  * @returns {number} Percentage change (e.g., +2.3, -1.5)
  */
-function calculateMoMChange(current, previous) {
+export function calculateMoMChange(current, previous) {
   if (previous === 0) {
     return 0; // No previous data
   }
@@ -244,9 +254,12 @@ function calculateMoMChange(current, previous) {
  *
  * @param {Date} startDate - Start of current month
  * @param {Date} endDate - End of current month
+ * @param {object} [options] - Options
+ * @param {Function} [options.requestClient=requestWithAuth] - Octokit request client
  * @returns {Promise<Object|null>} Build metrics or null if unavailable
  */
-export async function fetchBuildMetrics(startDate, endDate) {
+export async function fetchBuildMetrics(startDate, endDate, options = {}) {
+  const { requestClient = requestWithAuth } = options;
   console.log("[build-metrics] Fetching build health metrics...");
 
   try {
@@ -281,6 +294,7 @@ export async function fetchBuildMetrics(startDate, endDate) {
           workflow.workflowId,
           startDate,
           endDate,
+          { requestClient },
         );
         const metrics = calculateWorkflowMetrics(
           workflow.name,
@@ -312,6 +326,7 @@ export async function fetchBuildMetrics(startDate, endDate) {
           workflow.workflowId,
           prevMonthStart,
           prevMonthEnd,
+          { requestClient },
         );
         const metrics = calculateWorkflowMetrics(
           workflow.name,
@@ -370,3 +385,5 @@ export async function fetchBuildMetrics(startDate, endDate) {
     return null; // Graceful degradation
   }
 }
+
+export { TRACKED_WORKFLOWS, requestWithAuth };

--- a/scripts/lib/graphql-queries.mjs
+++ b/scripts/lib/graphql-queries.mjs
@@ -92,6 +92,8 @@ const REPO_MERGED_PRS_QUERY = `
  * @param {string} name - Repository name (e.g., "bluefin")
  * @param {Date} startDate - Start of date range
  * @param {Date} endDate - End of date range
+ * @param {object} [options] - Optional dependencies/overrides
+ * @param {Function} [options.client=graphqlWithAuth] - GraphQL client
  * @returns {Promise<{items: Array, partial: boolean, error?: string}>} Fetch result
  */
 export async function fetchClosedItemsFromRepo(
@@ -99,7 +101,9 @@ export async function fetchClosedItemsFromRepo(
   name,
   startDate,
   endDate,
+  options = {},
 ) {
+  const { client = graphqlWithAuth } = options;
   // Declared outside try so partial results are preserved on mid-pagination error.
   const allItems = [];
   try {
@@ -108,7 +112,7 @@ export async function fetchClosedItemsFromRepo(
     let issuesHasNextPage = true;
     while (issuesHasNextPage) {
       const result = await retryWithBackoff(async () => {
-        return await graphqlWithAuth(REPO_CLOSED_ISSUES_QUERY, {
+        return await client(REPO_CLOSED_ISSUES_QUERY, {
           owner,
           name,
           since: startDate.toISOString(),
@@ -143,7 +147,7 @@ export async function fetchClosedItemsFromRepo(
     let prsHasNextPage = true;
     while (prsHasNextPage) {
       const result = await retryWithBackoff(async () => {
-        return await graphqlWithAuth(REPO_MERGED_PRS_QUERY, {
+        return await client(REPO_MERGED_PRS_QUERY, {
           owner,
           name,
           cursor: prsCursor,

--- a/scripts/lib/tap-promotions.mjs
+++ b/scripts/lib/tap-promotions.mjs
@@ -17,13 +17,16 @@ const TAP_REPOS = {
  *
  * @param {Date} startDate - Start of reporting period
  * @param {Date} endDate - End of reporting period
+ * @param {object} [options] - Optional dependencies/overrides
+ * @param {Function} [options.client=graphqlWithAuth] - GraphQL client
+ * @param {Function} [options.fetchImpl=fetch] - fetch implementation
  * @returns {Promise<Array>} Array of {name, description, mergedAt, prNumber, prUrl}
  */
-export async function fetchTapPromotions(startDate, endDate) {
+export async function fetchTapPromotions(startDate, endDate, options = {}) {
   console.log(
     `\n🍺 Fetching tap promotions from ${startDate.toISOString().split("T")[0]} to ${endDate.toISOString().split("T")[0]}...\n`,
   );
-  return fetchRepoAdditions(TAP_REPOS.production, startDate, endDate);
+  return fetchRepoAdditions(TAP_REPOS.production, startDate, endDate, options);
 }
 
 /**
@@ -31,13 +34,16 @@ export async function fetchTapPromotions(startDate, endDate) {
  *
  * @param {Date} startDate - Start of reporting period
  * @param {Date} endDate - End of reporting period
+ * @param {object} [options] - Optional dependencies/overrides
+ * @param {Function} [options.client=graphqlWithAuth] - GraphQL client
+ * @param {Function} [options.fetchImpl=fetch] - fetch implementation
  * @returns {Promise<Array>} Array of {name, description, mergedAt, prNumber, prUrl}
  */
-export async function fetchExperimentalAdditions(startDate, endDate) {
+export async function fetchExperimentalAdditions(startDate, endDate, options = {}) {
   console.log(
     `\n🧪 Fetching experimental tap additions from ${startDate.toISOString().split("T")[0]} to ${endDate.toISOString().split("T")[0]}...\n`,
   );
-  return fetchRepoAdditions(TAP_REPOS.experimental, startDate, endDate);
+  return fetchRepoAdditions(TAP_REPOS.experimental, startDate, endDate, options);
 }
 
 /**
@@ -46,18 +52,19 @@ export async function fetchExperimentalAdditions(startDate, endDate) {
  * @param {string} repo - Repository in format "owner/repo"
  * @param {Date} startDate - Start of reporting period
  * @param {Date} endDate - End of reporting period
+ * @param {object} [options] - Optional dependencies/overrides
  * @returns {Promise<Array>} Array of {name, description, mergedAt, prNumber, prUrl}
  */
-async function fetchRepoAdditions(repo, startDate, endDate) {
+async function fetchRepoAdditions(repo, startDate, endDate, options = {}) {
+  const { client = graphqlWithAuth, fetchImpl = globalThis.fetch } = options;
   // Fetch merged PRs from tap
-  const prs = await fetchMergedPRs(repo, startDate, endDate);
-
+  const prs = await fetchMergedPRs(repo, startDate, endDate, { client });
   console.log(`   Found ${prs.length} merged PRs in ${repo}`);
 
   // Find PRs that added new formula/cask files
   const additions = [];
   for (const pr of prs) {
-    const files = await fetchPRFiles(repo, pr.number);
+    const files = await fetchPRFiles(repo, pr.number, { fetchImpl });
 
     // Look for added formula or cask files
     const addedPackages = files.filter(
@@ -74,7 +81,9 @@ async function fetchRepoAdditions(repo, startDate, endDate) {
         .replace(/\.rb$/, "");
 
       // Fetch package description from the added file
-      const description = await fetchPackageDescription(repo, file.filename);
+      const description = await fetchPackageDescription(repo, file.filename, {
+        fetchImpl,
+      });
 
       additions.push({
         name: packageName,
@@ -100,9 +109,11 @@ async function fetchRepoAdditions(repo, startDate, endDate) {
  * @param {string} repo - Repository in format "owner/repo"
  * @param {Date} startDate - Start date
  * @param {Date} endDate - End date
+ * @param {object} [options] - Optional dependencies/overrides
  * @returns {Promise<Array>} Array of {number, title, url, mergedAt}
  */
-async function fetchMergedPRs(repo, startDate, endDate) {
+async function fetchMergedPRs(repo, startDate, endDate, options = {}) {
+  const { client = graphqlWithAuth } = options;
   const [owner, name] = repo.split("/");
 
   const query = `
@@ -136,7 +147,7 @@ async function fetchMergedPRs(repo, startDate, endDate) {
 
   while (hasNextPage) {
     const data = await retryWithBackoff(() =>
-      graphqlWithAuth(query, { owner, name, cursor })
+      client(query, { owner, name, cursor })
     );
     const prs = data.repository.pullRequests.nodes;
 
@@ -166,9 +177,11 @@ async function fetchMergedPRs(repo, startDate, endDate) {
  *
  * @param {string} repo - Repository in format "owner/repo"
  * @param {number} prNumber - PR number
+ * @param {object} [options] - Optional dependencies/overrides
  * @returns {Promise<Array>} Array of {filename, status}
  */
-async function fetchPRFiles(repo, prNumber) {
+async function fetchPRFiles(repo, prNumber, options = {}) {
+  const { fetchImpl = globalThis.fetch } = options;
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     throw new Error(
@@ -177,7 +190,7 @@ async function fetchPRFiles(repo, prNumber) {
   }
 
   const url = `https://api.github.com/repos/${repo}/pulls/${prNumber}/files?per_page=100`;
-  const response = await fetch(url, {
+  const response = await fetchImpl(url, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github.v3+json",
@@ -199,9 +212,11 @@ async function fetchPRFiles(repo, prNumber) {
  *
  * @param {string} repo - Repository in format "owner/repo"
  * @param {string} filepath - Path to formula/cask file
+ * @param {object} [options] - Optional dependencies/overrides
  * @returns {Promise<string|null>} Package description or null
  */
-async function fetchPackageDescription(repo, filepath) {
+async function fetchPackageDescription(repo, filepath, options = {}) {
+  const { fetchImpl = globalThis.fetch } = options;
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     return null;
@@ -209,7 +224,7 @@ async function fetchPackageDescription(repo, filepath) {
 
   try {
     const url = `https://api.github.com/repos/${repo}/contents/${filepath}`;
-    const response = await fetch(url, {
+    const response = await fetchImpl(url, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github.v3.raw",
@@ -236,7 +251,7 @@ async function fetchPackageDescription(repo, filepath) {
  * @param {string} content - Ruby file content
  * @returns {string|null} Description or null
  */
-function parseFormulaDescription(content) {
+export function parseFormulaDescription(content) {
   // Match: desc "Some description here"
   const descMatch = content.match(/desc\s+"([^"]+)"/);
   if (descMatch) {

--- a/scripts/tap-promotions.test.js
+++ b/scripts/tap-promotions.test.js
@@ -1,0 +1,370 @@
+/**
+ * Tests for scripts/lib/tap-promotions.mjs
+ *
+ * Covers:
+ * - parseFormulaDescription: extraction from double-quoted and single-quoted desc lines, null for missing
+ * - fetchTapPromotions and fetchExperimentalAdditions routing to proper repos
+ * - fetchRepoAdditions with injected client & fetchImpl:
+ *   - pagination of merged PRs
+ *   - UPDATED_AT DESC early exit boundary
+ *   - file filtering for added Formula/ and Casks/ .rb files
+ *   - package name normalization (removing Formula/, Casks/, .rb)
+ *   - package description fetching and fallback to "No description available"
+ *   - date range filtering on mergedAt
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const START = new Date("2026-03-01T00:00:00.000Z");
+const END = new Date("2026-03-31T23:59:59.000Z");
+
+async function load() {
+  return import("./lib/tap-promotions.mjs");
+}
+
+describe("parseFormulaDescription", () => {
+  it("extracts description enclosed in double quotes", async () => {
+    const { parseFormulaDescription } = await load();
+    const ruby = `
+class Foo < Formula
+  desc "A blazing fast utility for Bluefin"
+  homepage "https://example.com"
+end
+`;
+    assert.equal(
+      parseFormulaDescription(ruby),
+      "A blazing fast utility for Bluefin",
+    );
+  });
+
+  it("extracts description enclosed in single quotes", async () => {
+    const { parseFormulaDescription } = await load();
+    const ruby = `
+cask "bar" do
+  version "1.0.0"
+  desc 'Lightweight status monitor'
+  homepage "https://example.com"
+end
+`;
+    assert.equal(parseFormulaDescription(ruby), "Lightweight status monitor");
+  });
+
+  it("handles extra whitespace around desc and quotes", async () => {
+    const { parseFormulaDescription } = await load();
+    const ruby = `  desc    "Tool with spaces"   `;
+    assert.equal(parseFormulaDescription(ruby), "Tool with spaces");
+  });
+
+  it("returns null when no desc declaration is found", async () => {
+    const { parseFormulaDescription } = await load();
+    const ruby = `
+class EmptyDesc < Formula
+  homepage "https://example.com"
+end
+`;
+    assert.equal(parseFormulaDescription(ruby), null);
+  });
+
+  it("returns null for non-matching or empty content", async () => {
+    const { parseFormulaDescription } = await load();
+    assert.equal(parseFormulaDescription(""), null);
+    assert.equal(parseFormulaDescription("description 'wrong keyword'"), null);
+  });
+});
+
+describe("tap promotions with injected seams", () => {
+  it("fetchTapPromotions queries production repo and fetches files + descriptions", async () => {
+    const { fetchTapPromotions } = await load();
+    let requestedRepo = null;
+    const client = async (_query, vars) => {
+      requestedRepo = `${vars.owner}/${vars.name}`;
+      return {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                number: 42,
+                title: "Add fancy-tool",
+                url: "https://github.com/ublue-os/homebrew-tap/pull/42",
+                mergedAt: "2026-03-10T12:00:00.000Z",
+                updatedAt: "2026-03-10T12:00:00.000Z",
+              },
+            ],
+          },
+        },
+      };
+    };
+
+    const fetchImpl = async (url) => {
+      if (url.includes("/pulls/42/files")) {
+        return new Response(
+          JSON.stringify([
+            { filename: "Formula/fancy-tool.rb", status: "added" },
+            { filename: "README.md", status: "modified" },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/contents/Formula/fancy-tool.rb")) {
+        return new Response(
+          'class FancyTool < Formula\n  desc "Does fancy things"\nend\n',
+          { status: 200 },
+        );
+      }
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const additions = await fetchTapPromotions(START, END, {
+      client,
+      fetchImpl,
+    });
+
+    assert.equal(requestedRepo, "ublue-os/homebrew-tap");
+    assert.deepEqual(additions, [
+      {
+        name: "fancy-tool",
+        description: "Does fancy things",
+        mergedAt: "2026-03-10T12:00:00.000Z",
+        prNumber: 42,
+        prUrl: "https://github.com/ublue-os/homebrew-tap/pull/42",
+      },
+    ]);
+  });
+
+  it("fetchExperimentalAdditions queries experimental repo and supports Casks", async () => {
+    const { fetchExperimentalAdditions } = await load();
+    let requestedRepo = null;
+    const client = async (_query, vars) => {
+      requestedRepo = `${vars.owner}/${vars.name}`;
+      return {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                number: 10,
+                title: "Add desktop app",
+                url: "https://github.com/ublue-os/homebrew-experimental-tap/pull/10",
+                mergedAt: "2026-03-15T08:00:00.000Z",
+                updatedAt: "2026-03-15T08:00:00.000Z",
+              },
+            ],
+          },
+        },
+      };
+    };
+
+    const fetchImpl = async (url) => {
+      if (url.includes("/pulls/10/files")) {
+        return new Response(
+          JSON.stringify([
+            { filename: "Casks/desktop-app.rb", status: "added" },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/contents/Casks/desktop-app.rb")) {
+        return new Response(
+          'cask "desktop-app" do\n  desc "Desktop GUI app"\nend\n',
+          { status: 200 },
+        );
+      }
+      return new Response("Not Found", { status: 404 });
+    };
+
+    const additions = await fetchExperimentalAdditions(START, END, {
+      client,
+      fetchImpl,
+    });
+
+    assert.equal(requestedRepo, "ublue-os/homebrew-experimental-tap");
+    assert.deepEqual(additions, [
+      {
+        name: "desktop-app",
+        description: "Desktop GUI app",
+        mergedAt: "2026-03-15T08:00:00.000Z",
+        prNumber: 10,
+        prUrl: "https://github.com/ublue-os/homebrew-experimental-tap/pull/10",
+      },
+    ]);
+  });
+
+  it("falls back to 'No description available' if description fetch returns null", async () => {
+    const { fetchTapPromotions } = await load();
+    const client = async () => ({
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              number: 7,
+              title: "Add undescribed tool",
+              url: "https://github.com/ublue-os/homebrew-tap/pull/7",
+              mergedAt: "2026-03-20T00:00:00.000Z",
+              updatedAt: "2026-03-20T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+    });
+
+    const fetchImpl = async (url) => {
+      if (url.includes("/pulls/7/files")) {
+        return new Response(
+          JSON.stringify([{ filename: "Formula/nodesc.rb", status: "added" }]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      // Return 404 or file with no desc
+      return new Response("404 Not Found", { status: 404 });
+    };
+
+    const additions = await fetchTapPromotions(START, END, {
+      client,
+      fetchImpl,
+    });
+
+    assert.equal(additions.length, 1);
+    assert.equal(additions[0].description, "No description available");
+    assert.equal(additions[0].name, "nodesc");
+  });
+
+  it("filters out PRs merged outside the date window", async () => {
+    const { fetchTapPromotions } = await load();
+    const client = async () => ({
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              number: 1,
+              title: "Too early",
+              url: "https://github.com/ublue-os/homebrew-tap/pull/1",
+              mergedAt: "2026-02-28T23:59:59.000Z",
+              updatedAt: "2026-03-05T00:00:00.000Z",
+            },
+            {
+              number: 2,
+              title: "Inside window",
+              url: "https://github.com/ublue-os/homebrew-tap/pull/2",
+              mergedAt: "2026-03-01T00:00:00.000Z",
+              updatedAt: "2026-03-01T00:00:00.000Z",
+            },
+            {
+              number: 3,
+              title: "Too late",
+              url: "https://github.com/ublue-os/homebrew-tap/pull/3",
+              mergedAt: "2026-04-01T00:00:00.000Z",
+              updatedAt: "2026-04-01T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+    });
+
+    let filesCheckedPR = null;
+    const fetchImpl = async (url) => {
+      const match = url.match(/\/pulls\/(\d+)\/files/);
+      if (match) {
+        filesCheckedPR = match[1];
+        return new Response(
+          JSON.stringify([{ filename: "Formula/valid.rb", status: "added" }]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response('desc "Valid"', { status: 200 });
+    };
+
+    const additions = await fetchTapPromotions(START, END, {
+      client,
+      fetchImpl,
+    });
+
+    assert.equal(filesCheckedPR, "2");
+    assert.equal(additions.length, 1);
+    assert.equal(additions[0].prNumber, 2);
+  });
+
+  it("paginates pull requests and stops on early-exit when updatedAt < startDate", async () => {
+    const { fetchTapPromotions } = await load();
+    const pages = [
+      {
+        pageInfo: { hasNextPage: true, endCursor: "CURSOR_1" },
+        nodes: [
+          {
+            number: 101,
+            title: "PR 1",
+            url: "https://github.com/ublue-os/homebrew-tap/pull/101",
+            mergedAt: "2026-03-25T00:00:00.000Z",
+            updatedAt: "2026-03-25T00:00:00.000Z",
+          },
+          {
+            number: 102,
+            title: "PR 2",
+            url: "https://github.com/ublue-os/homebrew-tap/pull/102",
+            mergedAt: "2026-03-20T00:00:00.000Z",
+            updatedAt: "2026-03-20T00:00:00.000Z",
+          },
+        ],
+      },
+      {
+        pageInfo: { hasNextPage: true, endCursor: "CURSOR_2" },
+        nodes: [
+          {
+            number: 103,
+            title: "PR 3",
+            url: "https://github.com/ublue-os/homebrew-tap/pull/103",
+            mergedAt: "2026-03-05T00:00:00.000Z",
+            updatedAt: "2026-03-05T00:00:00.000Z",
+          },
+          {
+            // Oldest on page 2 has updatedAt before START -> triggers early exit
+            number: 104,
+            title: "PR 4",
+            url: "https://github.com/ublue-os/homebrew-tap/pull/104",
+            mergedAt: "2026-02-15T00:00:00.000Z",
+            updatedAt: "2026-02-20T00:00:00.000Z",
+          },
+        ],
+      },
+      {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            number: 105,
+            title: "PR 5 (should never be fetched)",
+            url: "https://github.com/ublue-os/homebrew-tap/pull/105",
+            mergedAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    ];
+
+    let pageIndex = 0;
+    const client = async (_query, vars) => {
+      const pageData = pages[pageIndex++];
+      return { repository: { pullRequests: pageData } };
+    };
+
+    const fetchImpl = async (url) => {
+      if (url.includes("/files")) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("", { status: 404 });
+    };
+
+    const additions = await fetchTapPromotions(START, END, {
+      client,
+      fetchImpl,
+    });
+
+    assert.equal(pageIndex, 2, "should have fetched exactly 2 pages before early exit");
+    assert.deepEqual(additions, []);
+  });
+});


### PR DESCRIPTION
## Test Improvement

Closes projectbluefin/documentation#1168

This PR addresses the remaining untested modules under `scripts/lib/` highlighted in issue #1168.

### Status of the 5 modules from issue #1168:
1. `scripts/lib/card-template.mjs`: Covered by `scripts/card-template.test.js` in PR #1170.
2. `scripts/lib/graphql-queries.mjs`: Covered by `scripts/graphql-queries.test.js` in PR #1184. Added `options.client` parameter injection seam test as recommended in #1168.
3. `scripts/lib/tap-promotions.mjs`: Added `options.client` and `options.fetchImpl` injectable seams, exported `parseFormulaDescription`, and created `scripts/tap-promotions.test.js` covering 10 test cases (formula/cask parsing, date window filtering, UPDATED_AT DESC early-exit, description fallback, pagination).
4. `scripts/lib/build-metrics.mjs`: Added `options.requestClient` seam, exported calculation functions (`calculateWorkflowMetrics`, `calculateStatistics`, `calculateMoMChange`), and created `scripts/build-metrics.test.js` covering 10 test cases.
5. `scripts/lib/sbom/api.js`: Covered in PR #1210 (`scripts/lib/sbom/api.test.js`).

### Verification

All tests pass deterministically:
```
node --test scripts/graphql-queries.test.js scripts/tap-promotions.test.js scripts/build-metrics.test.js
```
All default function invocations remain 100% backward-compatible.