### PR TITLE
test(scripts): silence unused-arg lint warning in build-metrics test

### DIFF
--- a/scripts/build-metrics.test.js
+++ b/scripts/build-metrics.test.js
@@ -183,7 +183,7 @@ describe("fetchBuildMetrics with injected requestClient seam", () => {
     const start = new Date("2026-03-01T00:00:00Z");
     const end = new Date("2026-03-31T23:59:59Z");
 
-    const mockRequest = async (route, params) => {
+    const mockRequest = async (route, _params) => {
       assert.equal(route, "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs");
       // Return a run based on the workflow id
       return {


### PR DESCRIPTION
Renames the unused `params` mock argument to `_params` in `scripts/build-metrics.test.js` (introduced by #1223); the repo requires zero new lint warnings in added files.

Verified: `node --test scripts/build-metrics.test.js` passes 12/12.

Assisted-by: Kimi K3 via GitHub Copilot