### PR TITLE
ci: add unit test gate for scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/test.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -35,7 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run scripts unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run unit tests
+        run: npm test

--- a/docs/skills/component-testing.md
+++ b/docs/skills/component-testing.md
@@ -97,6 +97,13 @@ memory and rendered to a string inside that same runner.
    test harness. Keep separate tests for the composed component's unavailable
    state; it must render a status and source reason rather than return `null`.
 
+   When a component imports generated data from `@site/static/data/*.json` at
+   module scope, the require shim must resolve a missing file to
+   `{ unavailable: true }` rather than throw. Those files are gitignored
+   generated output, so a clean CI checkout does not have them, and an
+   unguarded `readFileSync` fails the suite before any assertion runs.
+   `scripts/portal-static-render.test.js` is the reference pattern.
+
 4. Assert the rules that matter, not the pixels. Markup assertions are brittle
    if they pin exact coordinates; count elements, check for the presence of a
    marker, and assert that forbidden output is absent.

--- a/scripts/portal-page-loading.test.js
+++ b/scripts/portal-page-loading.test.js
@@ -26,7 +26,9 @@ function loadModule(file) {
         const rel = id.slice("@site/".length);
         const target = path.resolve(root, rel);
         if (target.endsWith(".json"))
-          return JSON.parse(fs.readFileSync(target, "utf8"));
+          return fs.existsSync(target)
+            ? JSON.parse(fs.readFileSync(target, "utf8"))
+            : { unavailable: true };
         for (const suffix of [
           ".ts",
           ".tsx",

--- a/scripts/portal-prototype-page.test.js
+++ b/scripts/portal-prototype-page.test.js
@@ -25,7 +25,9 @@ function loadModule(file) {
         const rel = id.slice("@site/".length);
         const target = path.resolve(root, rel);
         if (target.endsWith(".json"))
-          return JSON.parse(fs.readFileSync(target, "utf8"));
+          return fs.existsSync(target)
+            ? JSON.parse(fs.readFileSync(target, "utf8"))
+            : { unavailable: true };
         for (const suffix of [
           ".ts",
           ".tsx",

--- a/scripts/portal-static-render.test.js
+++ b/scripts/portal-static-render.test.js
@@ -25,7 +25,9 @@ function loadModule(file) {
         const rel = id.slice("@site/".length);
         const target = path.resolve(root, rel);
         if (target.endsWith(".json"))
-          return JSON.parse(fs.readFileSync(target, "utf8"));
+          return fs.existsSync(target)
+            ? JSON.parse(fs.readFileSync(target, "utf8"))
+            : { unavailable: true };
         for (const suffix of [
           ".ts",
           ".tsx",


### PR DESCRIPTION
## Summary
Adds a CI test workflow running `npm test` on PRs and pushes that touch `scripts/`, `package.json`, or package-lock files.

Closes projectbluefin/documentation#942