### PR TITLE
fix(analytics): calculate and format hero deltas for the selected range

### DIFF
--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -163,7 +163,7 @@ export default function CountmeAnalyticsCharts({
   }, [weeks, heroRange]);
 
   // Delta calculation for Bluefin fleet
-  const firstWeek = weeks[0] || ({} as CountmeWeek);
+  const firstWeek = heroFilteredWeeks[0] || ({} as CountmeWeek);
   const initialTotalBluefin =
     sumPresent([
       firstWeek.bluefin,
@@ -179,6 +179,7 @@ export default function CountmeAnalyticsCharts({
           100
         ).toFixed(1)
       : "0.0";
+  const bluefinDeltaIsPositive = parseFloat(bluefinDeltaPct) >= 0;
 
   // Filtered weeks for comparative time-series charts
   const filteredWeeks = useMemo(() => {
@@ -517,7 +518,8 @@ export default function CountmeAnalyticsCharts({
             </div>
             <div className={styles.heroMeta}>
               <span style={{ fontWeight: 700, color: "#39d2c0" }}>
-                +{bluefinDeltaPct}% overall
+                {bluefinDeltaIsPositive ? "+" : ""}
+                {bluefinDeltaPct}% overall
               </span>
               <span>latest week ({latestWeek.week})</span>
             </div>
@@ -563,7 +565,7 @@ export default function CountmeAnalyticsCharts({
         <EChart
           option={heroChartOption}
           title="Bluefin Systems"
-          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, up ${bluefinDeltaPct}% across ${weeks.length} tracked weeks.`}
+          summary={`Project Bluefin weekly active systems: currently ${currentTotalBluefin.toLocaleString()} systems as of week ${latestWeek.week}, ${bluefinDeltaIsPositive ? "up" : "down"} ${Math.abs(parseFloat(bluefinDeltaPct))}% across ${heroFilteredWeeks.length} tracked weeks.`}
           points={realHeroPoints}
           minPoints={2}
           height={320}


### PR DESCRIPTION
Fixes #1087.

## Problem

`CountmeAnalyticsCharts`'s hero KPI:
- formatted the delta as `+${bluefinDeltaPct}%`, so a negative delta rendered as `+-4.2%`.
- computed `initialTotalBluefin` from `weeks[0]` (the all-time first week) regardless of the selected hero range, so switching between 12-week/24-week/all-history left the delta baseline tied to the complete history instead of the start of the selected range.

## Fix

`src/components/analytics/CountmeAnalyticsCharts.tsx`:
- `firstWeek` now comes from `heroFilteredWeeks[0]` instead of `weeks[0]`, so the delta baseline moves with the selected `heroRange`.
- Added `bluefinDeltaIsPositive` and use it to format the sign conditionally (`+` only when non-negative), matching the existing convention in `ReportCountmeTrend.tsx` (`isPositive ? \`+${changePct}%\` : \`${changePct}%\``) instead of hardcoding `+`.
- The chart's accessible `summary` text now says "up"/"down" based on the same sign, uses `Math.abs(...)` so it never reads "down -4.2%", and reports `heroFilteredWeeks.length` (the selected range's week count) instead of the all-time `weeks.length`.

## Verification

No React component test harness exists in this repo (`test` only runs `scripts/**/*.test.js`; no `.test.tsx`/testing-library anywhere), so I traced the extracted logic in a throwaway script with synthetic week data (fleet count rising for 18 weeks then declining for 12):

- `range=all`: baseline = week 0 (1000) → `+195.0% overall`, 30 tracked weeks.
- `range=24w`: baseline = week 6 (2200) → `+34.1% overall`, 24 tracked weeks.
- `range=12w`: baseline = week 18, the peak (4600) → `-35.9% overall` (no `+-`), "down 35.9% across 12 tracked weeks" — reproducing and then fixing the exact `+-35.9%` glitch from the issue.

Confirmed the pre-fix code reproduces both bugs (baseline stuck at the all-time first week regardless of range; `+${"-35.9"}%` → `+-35.9%`).

— hive: backend=omp
