### PR TITLE
Factory: Optimize layout by combining data sections into 2-column rows on desktop

### DIFF
--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -2293,7 +2293,7 @@
 
 .hiveTaskGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 0.75rem;
 }
 

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -4201,27 +4201,11 @@ export function LiveSection({ s }: { s: FactoryLive }): React.JSX.Element {
         </section>
       )}
 
-      <GovernorPanel governor={snapshot?.governor} registry={registryData} />
-      <VictoryLog victories={queueData?.victories ?? null} />
-      {advisoryItems.length > 0 && (
-        <section className={styles.panel}>
-          <Heading as="h2" className={styles.panelTitle}>
-            What Frames Are Working On
-          </Heading>
-          <p className={styles.panelMeta}>
-            Advisory digest — findings, bugs, CI failures logged by each Frame
-          </p>
-          <AgentWorkLog
-            agents={agents}
-            items={advisoryItems}
-            advisoryIssue={snapshot?.advisoryIssue}
-            config={config}
-          />
-        </section>
-      )}
-      {/* Registry Health Checks */}
-      {registryData?.health?.checks &&
-        registryData.health.checks.length > 0 && (
+      {/* Governor and System Health */}
+      {(() => {
+        const hasHealthChecks =
+          registryData?.health?.checks && registryData.health.checks.length > 0;
+        const healthPanel = hasHealthChecks ? (
           <section className={styles.panel}>
             <Heading as="h2" className={styles.panelTitle}>
               System Health
@@ -4319,7 +4303,41 @@ export function LiveSection({ s }: { s: FactoryLive }): React.JSX.Element {
               </p>
             )}
           </section>
-        )}
+        ) : null;
+
+        return hasHealthChecks ? (
+          <div className={styles.twoCol}>
+            <GovernorPanel
+              governor={snapshot?.governor}
+              registry={registryData}
+            />
+            {healthPanel}
+          </div>
+        ) : (
+          <GovernorPanel
+            governor={snapshot?.governor}
+            registry={registryData}
+          />
+        );
+      })()}
+
+      <VictoryLog victories={queueData?.victories ?? null} />
+      {advisoryItems.length > 0 && (
+        <section className={styles.panel}>
+          <Heading as="h2" className={styles.panelTitle}>
+            What Frames Are Working On
+          </Heading>
+          <p className={styles.panelMeta}>
+            Advisory digest — findings, bugs, CI failures logged by each Frame
+          </p>
+          <AgentWorkLog
+            agents={agents}
+            items={advisoryItems}
+            advisoryIssue={snapshot?.advisoryIssue}
+            config={config}
+          />
+        </section>
+      )}
     </>
   );
 }
@@ -4396,9 +4414,7 @@ export function CommunitySection({ s }: { s: FactoryLive }): React.JSX.Element {
       <MergedPRFeed prs={mergedPRs} />
 
       {/* ── History Zone ── */}
-      <div className={styles.twoCol}>
-        <HistoryTrends history={hiveHistory} />
-      </div>
+      <HistoryTrends history={hiveHistory} />
 
       {/* Velocity + Org stats */}
       <div className={styles.twoCol}>

--- a/src/components/factory/panels/ApplicationsPanels.module.css
+++ b/src/components/factory/panels/ApplicationsPanels.module.css
@@ -53,3 +53,11 @@
 .link:hover {
   text-decoration: underline;
 }
+
+.twoCol {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: var(--fx-space-4);
+  align-items: start;
+  margin-bottom: var(--fx-space-5);
+}

--- a/src/components/factory/panels/ApplicationsPanels.tsx
+++ b/src/components/factory/panels/ApplicationsPanels.tsx
@@ -262,90 +262,92 @@ export default function ApplicationsPanels(): React.JSX.Element {
         <Unavailable what="Release cadence" reason="Loading release history…" />
       )}
 
-      {/* 4. Flathub downloads attributed to Bluefin */}
-      {flReady && bluefinOs ? (
-        <div className={panelStyles.section}>
-          <h2 className={panelStyles.heading}>
-            Flathub downloads attributed to Bluefin
-          </h2>
-          <div className={styles.bigNumber}>
-            {formatNumber(bluefinOs.downloads)}
+      {/* 4. Flathub downloads and 5. Peer comparison */}
+      <div className={styles.twoCol}>
+        {flReady && bluefinOs ? (
+          <div className={panelStyles.section}>
+            <h2 className={panelStyles.heading}>
+              Flathub downloads attributed to Bluefin
+            </h2>
+            <div className={styles.bigNumber}>
+              {formatNumber(bluefinOs.downloads)}
+            </div>
+            <div className={styles.bigLabel}>
+              {(bluefinOs.share * 100).toFixed(3)}% of all Flathub downloads
+            </div>
+            <EChart
+              title="Bluefin Flathub downloads by base version"
+              summary={`${formatNumber(bluefinOs.downloads)} total downloads across ${Object.keys(bluefinOs.versions).length} Bluefin base versions.`}
+              points={Object.keys(bluefinOs.versions).length}
+              minPoints={1}
+              height={220}
+              option={{
+                xAxis: {
+                  type: "category",
+                  data: Object.keys(bluefinOs.versions).sort(),
+                },
+                yAxis: { type: "value", name: "Downloads" },
+                series: [
+                  {
+                    type: "bar",
+                    name: "Downloads",
+                    data: gapSafe(
+                      Object.keys(bluefinOs.versions)
+                        .sort()
+                        .map((k) => bluefinOs.versions[k]),
+                    ),
+                    itemStyle: { color: seriesColor(0) },
+                  },
+                ],
+              }}
+            />
           </div>
-          <div className={styles.bigLabel}>
-            {(bluefinOs.share * 100).toFixed(3)}% of all Flathub downloads
-          </div>
+        ) : flathub?.unavailable ? (
+          <Unavailable
+            what="Flathub attribution"
+            reason={flathub.stateReason ?? "Flathub data is unavailable."}
+          />
+        ) : flReason ? (
+          <Unavailable what="Flathub attribution" reason={flReason} />
+        ) : (
+          <Unavailable
+            what="Flathub attribution"
+            reason="Loading Flathub data…"
+          />
+        )}
+
+        {/* 5. Peer comparison (log scale) */}
+        {flReady && peerEntries.length > 0 ? (
           <EChart
-            title="Bluefin Flathub downloads by base version"
-            summary={`${formatNumber(bluefinOs.downloads)} total downloads across ${Object.keys(bluefinOs.versions).length} Bluefin base versions.`}
-            points={Object.keys(bluefinOs.versions).length}
-            minPoints={1}
-            height={220}
+            title="Bluefin vs peer cloud-native desktops on Flathub (log scale)"
+            summary={`Bluefin: ${formatNumber(bluefinOs?.downloads ?? 0)}. Bazzite and Fedora are 1–2 orders of magnitude larger; a logarithmic scale is used so all bars remain visible.`}
+            points={peerEntries.length}
+            minPoints={2}
+            height={280}
             option={{
               xAxis: {
                 type: "category",
-                data: Object.keys(bluefinOs.versions).sort(),
+                data: peerEntries.map((e) => e.label),
               },
-              yAxis: { type: "value", name: "Downloads" },
+              yAxis: {
+                type: "log",
+                name: "Downloads (log scale)",
+                min: 1,
+              },
               series: [
                 {
                   type: "bar",
-                  name: "Downloads",
-                  data: gapSafe(
-                    Object.keys(bluefinOs.versions)
-                      .sort()
-                      .map((k) => bluefinOs.versions[k]),
-                  ),
-                  itemStyle: { color: seriesColor(0) },
+                  name: "Flathub downloads",
+                  data: gapSafe(peerEntries.map((e) => e.downloads)),
+                  itemStyle: { color: seriesColor(2) },
                 },
               ],
             }}
           />
-        </div>
-      ) : flathub?.unavailable ? (
-        <Unavailable
-          what="Flathub attribution"
-          reason={flathub.stateReason ?? "Flathub data is unavailable."}
-        />
-      ) : flReason ? (
-        <Unavailable what="Flathub attribution" reason={flReason} />
-      ) : (
-        <Unavailable
-          what="Flathub attribution"
-          reason="Loading Flathub data…"
-        />
-      )}
-
-      {/* 5. Peer comparison (log scale) */}
-      {flReady && peerEntries.length > 0 ? (
-        <EChart
-          title="Bluefin vs peer cloud-native desktops on Flathub (log scale)"
-          summary={`Bluefin: ${formatNumber(bluefinOs?.downloads ?? 0)}. Bazzite and Fedora are 1–2 orders of magnitude larger; a logarithmic scale is used so all bars remain visible.`}
-          points={peerEntries.length}
-          minPoints={2}
-          height={280}
-          option={{
-            xAxis: {
-              type: "category",
-              data: peerEntries.map((e) => e.label),
-            },
-            yAxis: {
-              type: "log",
-              name: "Downloads (log scale)",
-              min: 1,
-            },
-            series: [
-              {
-                type: "bar",
-                name: "Flathub downloads",
-                data: gapSafe(peerEntries.map((e) => e.downloads)),
-                itemStyle: { color: seriesColor(2) },
-              },
-            ],
-          }}
-        />
-      ) : (
-        <Unavailable what="Peer comparison" reason="Loading Flathub data…" />
-      )}
+        ) : (
+          <Unavailable what="Peer comparison" reason="Loading Flathub data…" />
+        )}
+      </div>
 
       {/* 6. Flathub platform context — downloads per day */}
       {flReady && flathub.downloadsPerDay.length > 0 ? (

--- a/src/components/factory/panels/BuildsPanels.tsx
+++ b/src/components/factory/panels/BuildsPanels.tsx
@@ -181,34 +181,50 @@ export default function BuildsPanels({
           flight (not shown below)
         </div>
       )}
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>Lane</th>
-            <th>Started</th>
-            <th>Duration</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {recentTerminal.map((r, i) => {
-            const lane = runToLane.get(r);
-            const sev = r.status === "passed" ? "ok" : "alert";
-            return (
-              <tr key={i}>
-                <td>{lane?.label ?? "—"}</td>
-                <td>{fmtTime(r.t)}</td>
-                <td>{r.durationMin} min</td>
-                <td>
-                  <span aria-label={FX_SEVERITY[sev].word}>
-                    {FX_SEVERITY[sev].glyph}
-                  </span>
-                </td>
+      {(() => {
+        const mid = Math.ceil(recentTerminal.length / 2);
+        const col1 = recentTerminal.slice(0, mid);
+        const col2 = recentTerminal.slice(mid);
+        const renderTable = (runs: typeof recentTerminal, keyPrefix: string) => (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Lane</th>
+                <th>Started</th>
+                <th>Duration</th>
+                <th>Status</th>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            </thead>
+            <tbody>
+              {runs.map((r, i) => {
+                const lane = runToLane.get(r);
+                const sev = r.status === "passed" ? "ok" : "alert";
+                return (
+                  <tr key={`${keyPrefix}-${i}`}>
+                    <td>{lane?.label ?? "—"}</td>
+                    <td>{fmtTime(r.t)}</td>
+                    <td>{r.durationMin} min</td>
+                    <td>
+                      <span aria-label={FX_SEVERITY[sev].word}>
+                        {FX_SEVERITY[sev].glyph}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        );
+
+        return col2.length > 0 ? (
+          <div className={styles.twoCol}>
+            <div>{renderTable(col1, "col1")}</div>
+            <div>{renderTable(col2, "col2")}</div>
+          </div>
+        ) : (
+          renderTable(col1, "col1")
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/factory/panels/ImagesPanels.module.css
+++ b/src/components/factory/panels/ImagesPanels.module.css
@@ -124,6 +124,14 @@
   color: var(--fx-text);
 }
 
+.twoCol {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: var(--fx-space-4);
+  align-items: start;
+  margin-bottom: var(--fx-space-5);
+}
+
 .labBlock {
   padding: var(--fx-space-4);
   background: var(--fx-surface);

--- a/src/components/factory/panels/ImagesPanels.tsx
+++ b/src/components/factory/panels/ImagesPanels.tsx
@@ -236,21 +236,21 @@ export default function ImagesPanels(): React.JSX.Element {
         height={Math.max(280, timelineLanes.length * 24)}
       />
 
-      {/* Freshness brackets */}
-      <EChart
-        option={bracketOption}
-        title="Freshness brackets"
-        summary={`${stateCounts.fresh} fresh, ${stateCounts.stale} stale, ${stateCounts.awaiting} awaiting across ${allStreams.length} lanes`}
-        points={allStreams.length}
-      />
-
-      {/* Availability by family */}
-      <EChart
-        option={familyOption}
-        title="Availability by family"
-        summary={`${families.length} families; ${awaitingStreams.length} lanes still awaiting first publish`}
-        points={families.length}
-      />
+      {/* Freshness brackets and Availability by family */}
+      <div className={styles.twoCol}>
+        <EChart
+          option={bracketOption}
+          title="Freshness brackets"
+          summary={`${stateCounts.fresh} fresh, ${stateCounts.stale} stale, ${stateCounts.awaiting} awaiting across ${allStreams.length} lanes`}
+          points={allStreams.length}
+        />
+        <EChart
+          option={familyOption}
+          title="Availability by family"
+          summary={`${families.length} families; ${awaitingStreams.length} lanes still awaiting first publish`}
+          points={families.length}
+        />
+      </div>
 
       {/* Provenance */}
       <div className={styles.provenanceBlock}>

--- a/src/components/factory/panels/MetricsPanels.tsx
+++ b/src/components/factory/panels/MetricsPanels.tsx
@@ -395,15 +395,22 @@ function HomebrewPanel({
     series: [
       {
         type: "bar",
-        data: barItems.map((r, i) => ({
-          value: r.count,
-          itemStyle: {
-            color:
-              r.id === "bluefin" || r.id === "bluefin-lts"
-                ? seriesColor(0)
-                : seriesColor(3),
-          },
-        })),
+        data: barItems.map((r, i) => {
+          const isBluefin = r.id === "bluefin" || r.id === "bluefin-lts";
+          const isMac =
+            r.label.toLowerCase().includes("macos") ||
+            r.id.toLowerCase().includes("macos") ||
+            r.id.toLowerCase().includes("darwin");
+          const color = isBluefin
+            ? seriesColor(0)
+            : isMac
+              ? seriesColor(1)
+              : seriesColor(2);
+          return {
+            value: r.count,
+            itemStyle: { color },
+          };
+        }),
         name: "Installs",
       },
     ],

--- a/src/components/factory/panels/TestsPanels.tsx
+++ b/src/components/factory/panels/TestsPanels.tsx
@@ -361,44 +361,60 @@ export default function TestsPanels(): React.JSX.Element {
           flight (not shown below)
         </div>
       )}
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>Suite</th>
-            <th>Started</th>
-            <th>Duration</th>
-            <th>Status</th>
-            <th>Link</th>
-          </tr>
-        </thead>
-        <tbody>
-          {recentTerminal.map((r, i) => {
-            const su = runToSuite.get(r);
-            const sev = r.status === "passed" ? "ok" : "alert";
-            return (
-              <tr key={i}>
-                <td>{su?.label ?? "—"}</td>
-                <td>{fmtTime(r.t)}</td>
-                <td>{r.durationMin} min</td>
-                <td>
-                  <span aria-label={FX_SEVERITY[sev].word}>
-                    {FX_SEVERITY[sev].glyph}
-                  </span>
-                </td>
-                <td>
-                  {r.url ? (
-                    <a href={r.url} target="_blank" rel="noopener noreferrer">
-                      ↗
-                    </a>
-                  ) : (
-                    "—"
-                  )}
-                </td>
+      {(() => {
+        const mid = Math.ceil(recentTerminal.length / 2);
+        const col1 = recentTerminal.slice(0, mid);
+        const col2 = recentTerminal.slice(mid);
+        const renderTable = (runs: typeof recentTerminal, keyPrefix: string) => (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Suite</th>
+                <th>Started</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th>Link</th>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            </thead>
+            <tbody>
+              {runs.map((r, i) => {
+                const su = runToSuite.get(r);
+                const sev = r.status === "passed" ? "ok" : "alert";
+                return (
+                  <tr key={`${keyPrefix}-${i}`}>
+                    <td>{su?.label ?? "—"}</td>
+                    <td>{fmtTime(r.t)}</td>
+                    <td>{r.durationMin} min</td>
+                    <td>
+                      <span aria-label={FX_SEVERITY[sev].word}>
+                        {FX_SEVERITY[sev].glyph}
+                      </span>
+                    </td>
+                    <td>
+                      {r.url ? (
+                        <a href={r.url} target="_blank" rel="noopener noreferrer">
+                          ↗
+                        </a>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        );
+
+        return col2.length > 0 ? (
+          <div className={styles.twoCol}>
+            <div>{renderTable(col1, "col1")}</div>
+            <div>{renderTable(col2, "col2")}</div>
+          </div>
+        ) : (
+          renderTable(col1, "col1")
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/factory/panels/panels.module.css
+++ b/src/components/factory/panels/panels.module.css
@@ -38,6 +38,9 @@
   list-style: none;
   padding: 0;
   margin: 0 0 var(--fx-space-5);
+  display: grid;
+  gap: var(--fx-space-2);
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 }
 
 .triageItem {
@@ -48,7 +51,7 @@
   background: var(--fx-surface);
   border: 1px solid var(--fx-border);
   border-radius: var(--fx-radius-md);
-  margin-bottom: var(--fx-space-2);
+  margin-bottom: 0;
 }
 
 .triageGlyph {
@@ -79,7 +82,7 @@
 .sparklineGrid {
   display: grid;
   gap: var(--fx-space-3);
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   margin-bottom: var(--fx-space-5);
 }
 
@@ -151,4 +154,11 @@
   font-weight: var(--fx-weight-bold);
   color: var(--fx-text-strong);
   margin-bottom: var(--fx-space-3);
+}
+
+.twoCol {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: var(--fx-space-4);
+  align-items: start;
 }


### PR DESCRIPTION
Fixes #1054

### Summary of Changes

1. **Live Dashboard Section**: Grouped Governor and System Health into a 2-column layout when registry health checks are present.
2. **Images Panels**: Paired "Freshness brackets" and "Availability by family" in a single 2-column row on desktop.
3. **Builds Panels**: Divided "Recent Terminal Runs" into two columns of tables to optimize vertical space on desktop.
4. **Tests Panels - Triage List**: Made `.triageList` use a 2-column responsive grid on desktop.
5. **Tests Panels - Sparkline Grid**: Increased sparkline grid min-width from 280px to 340px for comfortable rendering.
6. **Tests Panels - Recent Runs**: Divided "Recent runs" into two columns of tables on desktop.
7. **Applications Panels**: Paired "Bluefin Flathub downloads by base version" and "Bluefin vs peer desktops" in a 2-column row on desktop.
8. **Metrics Panels - Homebrew Rankings**: Assigned 3 distinct colors to differentiate Bluefin vs macOS vs other Linux distributions.
9. **Hive Task Leaderboard**: Increased card min-width from 180px to 220px in `.hiveTaskGrid` to prevent badges and usernames from wrapping awkwardly.
10. **Factory Trends**: Preserved Factory Trends in a clean, full-width single row.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `54397e08`