### PR TITLE
feat(analytics): put the charts on the Bluefin palette and the real image matrix

### DIFF
--- a/docs/skills/factory-dashboard-content.md
+++ b/docs/skills/factory-dashboard-content.md
@@ -192,24 +192,58 @@ No match means fetch it at runtime from `/data/thing.json` and render
 `Unavailable` with the reason on failure, the way `FactoryDataProvider` and
 `CountmeAnalyticsCharts` do.
 
-### The catalogue drives the grid, not the snapshot
+### The catalogue drives the grid, and source drives the catalogue
 
 `/analytics` plots every image family `projectbluefin/common` ships into against
 every promotion stream. The row set comes from `BLUEFIN_FAMILY_IMAGES` in
-`src/components/analytics/CountmeAnalyticsCharts.tsx`, derived from
-`projectbluefin/common` → `docs/skills/image-registry.md`; the GHCR snapshot only
+`src/components/analytics/CountmeAnalyticsCharts.tsx`; the GHCR snapshot only
 fills the cells in.
 
 That order matters. If the snapshot drove the rows, an image that stopped
 publishing would quietly vanish from the grid and the page would look healthy.
 Driven by the catalogue, it keeps its row and the cell reads `—`.
 
-Three distinctions the matrix has to keep straight:
+**The catalogue is derived from each repository's `execute-release.yml`
+promotion matrix — not from `common` → `docs/skills/image-registry.md`.** That
+file is a convenient summary and it was wrong on three counts when this chart
+was built against it:
 
-- A stream a family **does not promote through** (`bluefin:lts`) is not the same
-  as one it should publish and has not.
-- **Retired tags stay out.** `:latest` and `:gts` still sit in GHCR on old
-  digests. They are not columns; the panel note says so.
+- It claims `bluefin-lts` promotes `:testing` → `:lts` with `:stable` as a
+  floating alias. Every repo's release workflow targets `stable`. There is no
+  `:lts` promotion, so an `:lts` column is a column of dashes.
+- It lists `bluefin-lts-hwe` and `bluefin-lts-hwe-nvidia` as live. They answer
+  in the registry but appear in no promotion matrix — they are retired, and
+  charting them as lanes shows two permanently-stale rows that nobody owns.
+- It omits `bluefin-lts-nvidia`, `dakota-gaming` and `dakota-nvidia-gaming`
+  entirely. All three are promoted; none could appear on the dashboard, because
+  `FALLBACK_LANES` in `scripts/fetch-ghcr-packages.js` had been written from the
+  same summary.
+
+Re-derive before editing either list:
+
+```bash
+for r in bluefin bluefin-lts dakota; do
+  gh api "repos/projectbluefin/$r/contents/.github/workflows/execute-release.yml" \
+    --jq .content | base64 -d | grep -E '"image"'
+done
+
+# Cross-check against the registry, which answers anonymously:
+tok=$(curl -s "https://ghcr.io/token?scope=repository:projectbluefin/dakota-gaming:pull" | jq -r .token)
+curl -s -H "Authorization: Bearer $tok" https://ghcr.io/v2/projectbluefin/dakota-gaming/tags/list | jq '.tags'
+```
+
+**`FALLBACK_LANES` is not a nicety — in CI it is the only list.**
+`github.token` is repository-scoped and cannot list an org's packages, so the
+Packages API returns nothing and the fetcher falls back to those lanes every
+time. An image missing from it is an image the dashboard can never show,
+however correct the component is. `scripts/fetch-ghcr-packages.test.js` pins
+`PROMOTED_IMAGES ⊆ FALLBACK_LANES`.
+
+Two more distinctions the matrix keeps straight:
+
+- **Retired tags stay out of the columns.** `:latest`, `:gts` and `:lts` still
+  sit on some images from older schemes. They are named in the panel note and
+  the retired images are named on their family card.
 - **Bluefin Server ships a DDI**, not a container tag, so it is a counted family
   with no row in the OCI matrix at all — `delivery: "ddi"` marks it.
 

--- a/scripts/analytics-charts-series.test.js
+++ b/scripts/analytics-charts-series.test.js
@@ -1,10 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
 const path = require("node:path");
-const ts = require("typescript");
 const React = require("react");
 const { renderToStaticMarkup } = require("react-dom/server");
+const { loadTsxModule } = require("./lib/load-tsx");
 
 const tsxPath = path.join(
   __dirname,
@@ -14,31 +13,10 @@ const tsxPath = path.join(
   "analytics",
   "CountmeAnalyticsCharts.tsx",
 );
-const chartThemePath = path.join(
-  __dirname,
-  "..",
-  "src",
-  "components",
-  "factory",
-  "chartTheme.ts",
-);
-
 function loadComponent(datasetFixture) {
-  const source = fs.readFileSync(tsxPath, "utf8");
-  const { outputText } = ts.transpileModule(source, {
-    compilerOptions: {
-      jsx: ts.JsxEmit.React,
-      target: ts.ScriptTarget.ES2020,
-      module: ts.ModuleKind.CommonJS,
-    },
-  });
-
-  const chartTheme = require(chartThemePath);
-  const mod = { exports: {} };
-
   const capturedECharts = [];
 
-  const requireShim = (id) => {
+  const mocks = (id) => {
     if (id.endsWith(".css")) return {};
     if (id === "@docusaurus/useBaseUrl") {
       return { __esModule: true, default: (p) => p };
@@ -90,7 +68,6 @@ function loadComponent(datasetFixture) {
           }),
       };
     }
-    if (id.endsWith("chartTheme")) return chartTheme;
     if (id === "@site/static/data/countme-history.json") {
       return (
         datasetFixture ||
@@ -99,15 +76,10 @@ function loadComponent(datasetFixture) {
         )
       );
     }
-    return require(id);
+    return undefined;
   };
 
-  new Function("require", "module", "exports", outputText)(
-    requireShim,
-    mod,
-    mod.exports,
-  );
-  return { mod: mod.exports, capturedECharts };
+  return { mod: loadTsxModule(tsxPath, mocks), capturedECharts };
 }
 
 const SAMPLE_DATASET = {

--- a/scripts/countme-analytics-charts.test.js
+++ b/scripts/countme-analytics-charts.test.js
@@ -25,120 +25,127 @@ function loadComponent() {
     },
   });
   const mod = { exports: {} };
-  new Function("require", "module", "exports", outputText)(
-    (id) => {
-      if (id.endsWith(".css")) return {};
-      if (id === "@docusaurus/useBaseUrl") {
-        return { __esModule: true, default: (p) => p };
-      }
-      if (id === "@docusaurus/Link") {
-        return {
-          __esModule: true,
-          default: ({ to, children, ...rest }) =>
-            React.createElement("a", { href: to, ...rest }, children),
-        };
-      }
-      if (id === "@theme/Heading") {
-        return {
-          __esModule: true,
-          default: ({ as: Tag = "h3", children, ...rest }) =>
-            React.createElement(Tag, rest, children),
-        };
-      }
-      if (id.includes("EChart")) {
-        return {
-          __esModule: true,
-          default: (props) =>
-            React.createElement("div", {
-              "data-testid": "echart",
-              "data-title": props.title,
-              "data-summary": props.summary,
-              "data-points": String(props.points),
-              "data-option": JSON.stringify(props.option),
-            }),
-        };
-      }
-      if (id.includes("Unavailable")) {
-        return {
-          __esModule: true,
-          default: (props) =>
-            React.createElement("div", {
-              "data-testid": "unavailable",
-              "data-what": props.what,
-              "data-reason": props.reason,
-            }),
-        };
-      }
-      if (id.includes("Sparkline")) {
-        return {
-          __esModule: true,
-          default: (props) =>
-            React.createElement("span", {
-              "data-testid": "sparkline",
-              "data-data": JSON.stringify(props.data),
-              "data-show-end": String(props.showEnd),
-              "data-empty-label": props.emptyLabel,
-              "data-label": props.label,
-            }),
-        };
-      }
-      if (id.includes("countme-history.json")) {
-        return {
-          generatedAt: "2026-08-08T23:59:55.087Z",
-          source:
-            "https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv",
-          method: "ublue-countme-v1",
-          unit: "estimated weekly active systems",
-          variants: ["bluefin", "bluefin-lts", "aurora", "bazzite", "fedora"],
-          weeks: [
+
+  // Local modules are transpiled and handed the shim again, not node's require:
+  // a relative .ts import inside a relative .ts import is still a .ts import,
+  // and node cannot resolve it.
+  const shim = (from) => (id) => {
+    if (id.endsWith(".css")) return {};
+    if (id === "react") return React;
+    if (id === "@docusaurus/useBaseUrl") {
+      return { __esModule: true, default: (p) => p };
+    }
+    if (id === "@docusaurus/Link") {
+      return {
+        __esModule: true,
+        default: ({ to, children, ...rest }) =>
+          React.createElement("a", { href: to, ...rest }, children),
+      };
+    }
+    if (id === "@theme/Heading") {
+      return {
+        __esModule: true,
+        default: ({ as: Tag = "h3", children, ...rest }) =>
+          React.createElement(Tag, rest, children),
+      };
+    }
+    if (id.includes("EChart")) {
+      return {
+        __esModule: true,
+        default: (props) =>
+          React.createElement("div", {
+            "data-testid": "echart",
+            "data-title": props.title,
+            "data-summary": props.summary,
+            "data-points": String(props.points),
+            "data-option": JSON.stringify(props.option),
+          }),
+      };
+    }
+    if (id.includes("Unavailable")) {
+      return {
+        __esModule: true,
+        default: (props) =>
+          React.createElement("div", {
+            "data-testid": "unavailable",
+            "data-what": props.what,
+            "data-reason": props.reason,
+          }),
+      };
+    }
+    if (id.includes("Sparkline")) {
+      return {
+        __esModule: true,
+        default: (props) =>
+          React.createElement("span", {
+            "data-testid": "sparkline",
+            "data-data": JSON.stringify(props.data),
+            "data-color": props.color,
+            "data-show-end": String(props.showEnd),
+            "data-empty-label": props.emptyLabel,
+            "data-label": props.label,
+          }),
+      };
+    }
+    if (id.includes("countme-history.json")) {
+      return {
+        generatedAt: "2026-08-08T23:59:55.087Z",
+        source:
+          "https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv",
+        method: "ublue-countme-v1",
+        unit: "estimated weekly active systems",
+        variants: ["bluefin", "bluefin-lts", "aurora", "bazzite", "fedora"],
+        weeks: [
+          {
+            week: "2026-07-20",
+            fedora: 1073642,
+            bazzite: 88548,
+            aurora: 2669,
+            bluefin: 4095,
+            "bluefin-lts": 100,
+          },
+          {
+            week: "2026-07-27",
+            fedora: 1102473,
+            bluefin: 3761,
+            bazzite: 89550,
+            aurora: 2826,
+            "bluefin-lts": 159,
+          },
+        ],
+        unavailable: false,
+        stateReason: null,
+      };
+    }
+    if (id.startsWith(".")) {
+      const base = path.resolve(path.dirname(from), id);
+      for (const ext of ["", ".ts", ".tsx", "/index.ts", "/index.tsx"]) {
+        if (ext && fs.existsSync(base + ext)) {
+          const { outputText: innerOutput } = ts.transpileModule(
+            fs.readFileSync(base + ext, "utf8"),
             {
-              week: "2026-07-20",
-              fedora: 1073642,
-              bazzite: 88548,
-              aurora: 2669,
-              bluefin: 4095,
-              "bluefin-lts": 100,
-            },
-            {
-              week: "2026-07-27",
-              fedora: 1102473,
-              bluefin: 3761,
-              bazzite: 89550,
-              aurora: 2826,
-              "bluefin-lts": 159,
-            },
-          ],
-          unavailable: false,
-          stateReason: null,
-        };
-      }
-      if (id.startsWith(".")) {
-        const base = path.resolve(path.dirname(TSX_PATH), id);
-        for (const ext of [".ts", ".tsx", "/index.ts", "/index.tsx"]) {
-          if (fs.existsSync(base + ext)) {
-            const innerSource = fs.readFileSync(base + ext, "utf8");
-            const { outputText: innerOutput } = ts.transpileModule(
-              innerSource,
-              {
-                compilerOptions: {
-                  jsx: ts.JsxEmit.React,
-                  target: ts.ScriptTarget.ES2020,
-                  module: ts.ModuleKind.CommonJS,
-                },
+              compilerOptions: {
+                jsx: ts.JsxEmit.React,
+                target: ts.ScriptTarget.ES2020,
+                module: ts.ModuleKind.CommonJS,
               },
-            );
-            const innerMod = { exports: {} };
-            new Function("require", "module", "exports", innerOutput)(
-              require,
-              innerMod,
-              innerMod.exports,
-            );
-            return innerMod.exports;
-          }
+            },
+          );
+          const innerMod = { exports: {} };
+          new Function("require", "module", "exports", innerOutput)(
+            shim(base + ext),
+            innerMod,
+            innerMod.exports,
+          );
+          return innerMod.exports;
         }
       }
-      return require(id);
-    },
+    }
+    return require(id);
+  };
+
+  new Function("require", "module", "exports", outputText)(
+    shim(TSX_PATH),
     mod,
     mod.exports,
   );
@@ -352,24 +359,40 @@ test("unified fleet EChart preserves missing weeks as gaps and 0 as 0", () => {
   );
 });
 
-test("every catalogued OCI image gets a matrix row, registry or not", () => {
+const PROMOTED = [
+  "bluefin",
+  "bluefin-nvidia",
+  "bluefin-lts",
+  "bluefin-lts-nvidia",
+  "dakota",
+  "dakota-nvidia",
+  "dakota-gaming",
+  "dakota-nvidia-gaming",
+];
+
+test("the matrix rows are the images the release workflows promote", () => {
   const { matrixRows, BLUEFIN_FAMILY_IMAGES: families } = mod;
   const images = matrixRows().map((r) => r.image);
 
-  assert.deepEqual(images, [
-    "bluefin",
-    "bluefin-nvidia",
-    "bluefin-lts",
-    "bluefin-lts-hwe",
-    "bluefin-lts-hwe-nvidia",
-    "dakota",
-    "dakota-nvidia",
-  ]);
+  // Each repo's execute-release.yml promotion matrix, verbatim. The -hwe images
+  // are still in the registry but in nobody's matrix, so they are named on the
+  // family card as retired rather than charted as permanently stale lanes.
+  assert.deepEqual(images, PROMOTED);
+
+  const lts = families.find((f) => f.id === "bluefin-lts");
+  assert.deepEqual(lts.retired, ["bluefin-lts-hwe", "bluefin-lts-hwe-nvidia"]);
+  for (const name of lts.retired) assert.ok(!images.includes(name));
 
   // Bluefin Server delivers a DDI, not a container tag, so it has no lane here
   // even though it is a counted family.
   assert.ok(families.some((f) => f.id === "server"));
   assert.ok(!images.includes("server"));
+});
+
+test("the promotion axis is testing then stable, and nothing else", () => {
+  // :lts, :gts and :latest linger on some images from retired schemes. A column
+  // that is a dash down most of the grid is not a measurement.
+  assert.deepEqual(mod.STREAM_COLUMNS, ["testing", "stable"]);
 });
 
 test("an image the registry does not carry stays in the grid as a gap", () => {
@@ -384,23 +407,28 @@ test("an image the registry does not carry stays in the grid as a gap", () => {
   }
 });
 
-test("a stream a family does not promote through is named, not blamed", () => {
+test("a retired tag on an image is not mistaken for a promotion lane", () => {
   const { matrixRows, buildStreamMatrix } = mod;
-  const rows = matrixRows();
-  const cells = buildStreamMatrix(rows, [
+  const cells = buildStreamMatrix(matrixRows(), [
     {
       name: "bluefin",
       family: "os",
-      streams: [{ tag: "lts", ageDays: 99, state: "stale", publishedAt: null }],
+      streams: [
+        { tag: "lts", ageDays: 99, state: "stale", publishedAt: null },
+        { tag: "testing", ageDays: 1, state: "fresh", publishedAt: null },
+      ],
     },
   ]);
 
-  const retired = cells.find(
-    (c) => c.image === "bluefin" && c.stream === "lts",
+  assert.ok(
+    !cells.some((c) => c.stream === "lts"),
+    ":lts is not a column, so a stale :lts tag cannot colour the grid",
   );
-  assert.equal(retired.level, "unknown");
-  assert.equal(retired.ageDays, null);
-  assert.match(retired.reason, /does not promote through :lts/);
+  const testing = cells.find(
+    (c) => c.image === "bluefin" && c.stream === "testing",
+  );
+  assert.equal(testing.ageDays, 1);
+  assert.equal(testing.level, "ok");
 });
 
 test("freshness splits stale by drift and treats a missing tag as unknown", () => {
@@ -478,25 +506,13 @@ test("the matrix plots every catalogued image against every stream", () => {
   assert.ok(chart, "matrix echart must be present");
 
   const option = JSON.parse(chart[1].replace(/&quot;/g, '"'));
-  assert.deepEqual(option.yAxis.data, [
-    "bluefin",
-    "bluefin-nvidia",
-    "bluefin-lts",
-    "bluefin-lts-hwe",
-    "bluefin-lts-hwe-nvidia",
-    "dakota",
-    "dakota-nvidia",
-  ]);
-  assert.deepEqual(option.xAxis.data, [":testing", ":stable", ":lts"]);
-  assert.equal(option.series[0].data.length, 21);
+  assert.deepEqual(option.yAxis.data, PROMOTED);
+  assert.deepEqual(option.xAxis.data, [":testing", ":stable"]);
+  assert.equal(option.series[0].data.length, PROMOTED.length * 2);
 
   // Every cell carries its own number, never a bare colour swatch.
   const published = option.series[0].data.filter((c) => c.text !== "—");
-  assert.deepEqual(published.map((c) => c.text).sort(), [
-    "■ 72d",
-    "● 1d",
-    "● 1d",
-  ]);
+  assert.deepEqual(published.map((c) => c.text).sort(), ["● 1d", "● 1d"]);
 });
 
 test("the matrix says why it is empty rather than rendering nothing", () => {

--- a/scripts/countme-family-sparklines.test.js
+++ b/scripts/countme-family-sparklines.test.js
@@ -1,10 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
 const path = require("node:path");
-const ts = require("typescript");
 const React = require("react");
 const { renderToStaticMarkup } = require("react-dom/server");
+const { loadTsxModule } = require("./lib/load-tsx");
 
 const tsxPath = path.join(
   __dirname,
@@ -14,29 +13,8 @@ const tsxPath = path.join(
   "analytics",
   "CountmeAnalyticsCharts.tsx",
 );
-const chartThemePath = path.join(
-  __dirname,
-  "..",
-  "src",
-  "components",
-  "factory",
-  "chartTheme.ts",
-);
-
 function loadComponent(datasetFixture) {
-  const source = fs.readFileSync(tsxPath, "utf8");
-  const { outputText } = ts.transpileModule(source, {
-    compilerOptions: {
-      jsx: ts.JsxEmit.React,
-      target: ts.ScriptTarget.ES2020,
-      module: ts.ModuleKind.CommonJS,
-    },
-  });
-
-  const chartTheme = require(chartThemePath);
-  const mod = { exports: {} };
-
-  const requireShim = (id) => {
+  const mocks = (id) => {
     if (id.endsWith(".css")) return {};
     if (id === "@docusaurus/useBaseUrl") {
       return { __esModule: true, default: (p) => p };
@@ -83,7 +61,6 @@ function loadComponent(datasetFixture) {
           }),
       };
     }
-    if (id.endsWith("chartTheme")) return chartTheme;
     if (id === "@site/static/data/countme-history.json") {
       return (
         datasetFixture ||
@@ -113,15 +90,10 @@ function loadComponent(datasetFixture) {
         stateReason: null,
       };
     }
-    return require(id);
+    return undefined;
   };
 
-  new Function("require", "module", "exports", outputText)(
-    requireShim,
-    mod,
-    mod.exports,
-  );
-  return mod.exports;
+  return loadTsxModule(tsxPath, mocks);
 }
 
 test("BLUEFIN_FAMILY_IMAGES covers every family common ships into", () => {

--- a/scripts/echart-theme.test.js
+++ b/scripts/echart-theme.test.js
@@ -129,3 +129,35 @@ test("toTableRows pivots a heatmap back into the grid a sighted reader sees", ()
     ["dakota", "■ 72d", "no data"],
   ]);
 });
+
+test("readableInk flips with the swatch, whatever notation it arrives in", () => {
+  // getComputedStyle serialises a custom property to hex or rgb() even when
+  // tokens.css wrote hsl(), so an hsl-only reader silently returned one ink for
+  // everything — which shipped white labels on a near-white heatmap cell.
+  const onLight = ["#c7d7ff", "rgb(199, 215, 255)", "hsl(217, 100%, 89%)"];
+  const onDark = ["#22306b", "rgb(34, 48, 107)", "hsl(224, 52%, 28%)"];
+
+  const inks = new Set(onLight.map(theme.readableInk));
+  assert.equal(inks.size, 1, "one swatch, one ink, however it is written");
+
+  for (const pale of onLight) {
+    for (const deep of onDark) {
+      assert.notEqual(
+        theme.readableInk(pale),
+        theme.readableInk(deep),
+        `${pale} and ${deep} cannot share an ink`,
+      );
+    }
+  }
+});
+
+test("withAlpha survives whatever notation the token resolved to", () => {
+  assert.equal(theme.withAlpha("#4285f4", 0.4), "rgba(66, 133, 244, 0.4)");
+  assert.equal(
+    theme.withAlpha("rgb(66, 133, 244)", 0.4),
+    "rgba(66, 133, 244, 0.4)",
+  );
+  // An unparseable value is returned untouched rather than mangled into a
+  // string zrender will silently drop.
+  assert.equal(theme.withAlpha("currentColor", 0.4), "currentColor");
+});

--- a/scripts/factory-theming.test.js
+++ b/scripts/factory-theming.test.js
@@ -27,20 +27,29 @@ const themed = [
 /** Severity is deliberately hue-fixed, so hsl() is allowed; raw hex is not. */
 const HEX = /#[0-9a-fA-F]{6}\b/g;
 
+/**
+ * Blank out comment bodies, keeping newlines so line numbers still line up.
+ *
+ * The previous per-line check only recognised a comment when the line itself
+ * started with `*`, `//` or `/*`, so a wrapped block comment looked like code.
+ * That is the same trap the declaration test below already documents: parse the
+ * construct, do not pattern-match the line.
+ */
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, (m) => " ".repeat(m.length));
+}
+
 test("no themed file hardcodes a hex colour", () => {
   const offenders = [];
   for (const rel of themed) {
-    const src = fs.readFileSync(path.join(repo, rel), "utf8");
+    const src = stripComments(fs.readFileSync(path.join(repo, rel), "utf8"));
     src.split("\n").forEach((line, i) => {
-      // A comment may name a retired colour to explain why it is retired.
-      const isComment =
-        line.trimStart().startsWith("*") ||
-        line.trimStart().startsWith("//") ||
-        line.trimStart().startsWith("/*");
-      if (isComment) return;
       // The categorical series palette is a palette by definition: chart
-      // series need distinguishable hues that no Infima variable supplies.
-      // It is declared once, in tokens.css, and consumed as --fx-cat-*.
+      // series need distinguishable steps that no single Infima variable
+      // supplies. It is declared once, in tokens.css, and consumed as
+      // --fx-cat-*.
       if (/^\s*--fx-cat-\d:/.test(line)) return;
       const found = line.match(HEX);
       if (found) offenders.push(`${rel}:${i + 1} ${found.join(" ")}`);
@@ -51,6 +60,80 @@ test("no themed file hardcodes a hex colour", () => {
     [],
     `use a --fx-* token so the dashboard follows the site theme:\n${offenders.join("\n")}`,
   );
+});
+
+test("the chart palette is anchored on the Bluefin brand accent", () => {
+  const tokens = fs.readFileSync(
+    path.join(repo, "src/components/factory/tokens.css"),
+    "utf8",
+  );
+
+  // The wordmark ligature colour in docs/press-kit.md, and --color-blue in
+  // projectbluefin/website. It is the one value the ramp is built around.
+  const anchors = [...tokens.matchAll(/--fx-cat-1:\s*(#[0-9a-f]{6})/gi)].map(
+    (m) => m[1].toLowerCase(),
+  );
+  assert.ok(anchors.length >= 2, "both themes must declare --fx-cat-1");
+  assert.deepEqual([...new Set(anchors)], ["#4285f4"]);
+
+  // Severity is one hue at four intensities. Amber is what this replaced: a
+  // traffic-light ramp reads as a different product inside a blue dashboard.
+  const sevHues = [
+    ...tokens.matchAll(/--fx-sev-(?:ok|watch|alert):\s*hsl\((\d+)/g),
+  ].map((m) => m[1]);
+  assert.ok(sevHues.length >= 6, "both themes must declare the severity ramp");
+  assert.deepEqual(
+    [...new Set(sevHues)],
+    ["217"],
+    "severity must stay on the brand hue in both themes",
+  );
+});
+
+test("the canvas fallback ramp matches the dark tokens it stands in for", () => {
+  const tokens = fs.readFileSync(
+    path.join(repo, "src/components/factory/tokens.css"),
+    "utf8",
+  );
+  const theme = fs.readFileSync(
+    path.join(repo, "src/components/factory/chartTheme.ts"),
+    "utf8",
+  );
+
+  // Canvas cannot read a CSS variable, so chartTheme.ts carries a copy for
+  // charts mounted outside .fxRoot. A copy that drifts is how the dashboard
+  // ended up with two palettes; this is the gate that notices.
+  const darkBlock = /\[data-theme="dark"\]\s*\.fxRoot\s*\{([\s\S]*?)\n\}/.exec(
+    tokens,
+  );
+  assert.ok(darkBlock, "tokens.css must carry a dark override block");
+
+  const darkCats = [
+    ...darkBlock[1].matchAll(/--fx-cat-\d:\s*(#[0-9a-f]{6})/gi),
+  ].map((m) => m[1].toLowerCase());
+  assert.equal(darkCats.length, 6, "the dark block restates all six cat steps");
+
+  const fallbackCats = [
+    ...(/const CATEGORICAL = \[([\s\S]*?)\]/.exec(theme)?.[1] ?? "").matchAll(
+      /"(#[0-9a-f]{6})"/gi,
+    ),
+  ].map((m) => m[1].toLowerCase());
+  assert.deepEqual(
+    fallbackCats,
+    darkCats,
+    "CATEGORICAL must equal the dark --fx-cat-* ramp, step for step",
+  );
+
+  for (const [, level, color] of darkBlock[1].matchAll(
+    /--fx-sev-(ok|watch|alert):\s*(hsl\([^)]+\))/g,
+  )) {
+    assert.match(
+      theme,
+      new RegExp(
+        `${level}:\\s*\\{\\s*color:\\s*"${color.replace(/[()%,]/g, "\\$&")}"`,
+      ),
+      `FX_SEVERITY.${level} must equal the dark --fx-sev-${level}`,
+    );
+  }
 });
 
 test("tokens derive from Infima rather than redefining a palette", () => {

--- a/scripts/fetch-ghcr-packages.js
+++ b/scripts/fetch-ghcr-packages.js
@@ -200,13 +200,24 @@ export function buildPayload(
  * it works, still discovers everything.
  */
 export const FALLBACK_LANES = [
+  // OS images, in the order each repo's execute-release.yml promotes them.
+  // Derived from source, not from common/docs/skills/image-registry.md — that
+  // file still lists :lts as a promotion target and omits bluefin-lts-nvidia
+  // and the two dakota gaming images. Re-derive with:
+  //   gh api repos/projectbluefin/<repo>/contents/.github/workflows/execute-release.yml \
+  //     --jq .content | base64 -d | grep source_tag
   "bluefin",
-  "bluefin-lts",
-  "bluefin-lts-hwe",
   "bluefin-nvidia",
-  "bluefin-lts-hwe-nvidia",
+  "bluefin-lts",
+  "bluefin-lts-nvidia",
   "dakota",
   "dakota-nvidia",
+  "dakota-gaming",
+  "dakota-nvidia-gaming",
+  // Still in the registry, no longer in any promotion matrix. Kept so the
+  // Images view can say a lane is retired rather than silently dropping it.
+  "bluefin-lts-hwe",
+  "bluefin-lts-hwe-nvidia",
   "base",
   "static",
   "skopeo",
@@ -216,6 +227,25 @@ export const FALLBACK_LANES = [
   "brew",
   "common",
   "testsuite",
+];
+
+/**
+ * The OS images every repo's `execute-release.yml` promotes `:testing` →
+ * `:stable`, and nothing else.
+ *
+ * `FALLBACK_LANES` is deliberately wider: it also carries retired lanes so a
+ * panel can name them. Anything charted as a live promotion lane comes from
+ * here.
+ */
+export const PROMOTED_IMAGES = [
+  "bluefin",
+  "bluefin-nvidia",
+  "bluefin-lts",
+  "bluefin-lts-nvidia",
+  "dakota",
+  "dakota-nvidia",
+  "dakota-gaming",
+  "dakota-nvidia-gaming",
 ];
 
 /** Tags worth an inspect call. Everything else is noise or a cosign artefact. */

--- a/scripts/fetch-ghcr-packages.test.js
+++ b/scripts/fetch-ghcr-packages.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   FALLBACK_LANES,
+  PROMOTED_IMAGES,
   buildPackage,
   buildPayload,
   classifyFamily,
@@ -213,4 +214,41 @@ test("fallbackTagsOf keeps reported streams and drops cosign artefacts", () => {
 
 test("fallbackTagsOf returns an empty list rather than throwing on no tags", () => {
   assert.deepEqual(fallbackTagsOf([]), []);
+});
+
+test("every promoted image is a lane the fetcher actually reads", () => {
+  // FALLBACK_LANES is the only list consulted when the Packages API returns
+  // nothing, which is the normal case in CI — github.token is repository-scoped
+  // and cannot list an org's packages. An image missing from it is an image the
+  // dashboard can never show, however correct the component is.
+  for (const image of PROMOTED_IMAGES) {
+    assert.ok(
+      FALLBACK_LANES.includes(image),
+      `${image} is promoted but is not a fallback lane`,
+    );
+  }
+});
+
+test("the promoted set matches each repo's execute-release.yml", () => {
+  // Verbatim from the promotion matrices. Re-derive before editing:
+  //   gh api repos/projectbluefin/<repo>/contents/.github/workflows/execute-release.yml \
+  //     --jq .content | base64 -d | grep -E '"image"'
+  assert.deepEqual(PROMOTED_IMAGES, [
+    "bluefin",
+    "bluefin-nvidia",
+    "bluefin-lts",
+    "bluefin-lts-nvidia",
+    "dakota",
+    "dakota-nvidia",
+    "dakota-gaming",
+    "dakota-nvidia-gaming",
+  ]);
+
+  // The -hwe images still answer in the registry but are in no promotion
+  // matrix. They stay as lanes so a panel can call them retired; they are not
+  // promoted images.
+  for (const retired of ["bluefin-lts-hwe", "bluefin-lts-hwe-nvidia"]) {
+    assert.ok(FALLBACK_LANES.includes(retired));
+    assert.ok(!PROMOTED_IMAGES.includes(retired));
+  }
 });

--- a/scripts/lib/load-tsx.js
+++ b/scripts/lib/load-tsx.js
@@ -1,0 +1,59 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+
+/**
+ * Load a TypeScript/TSX module for a test, with the imports a test cannot run.
+ *
+ * Components under `src/` import Docusaurus internals, CSS modules, and build-time
+ * JSON that only exist inside a bundler. Each test supplies a `mock(id)` for those
+ * and gets the real module back.
+ *
+ * Relative imports are transpiled and handed this same loader, not node's
+ * `require`. A relative `.ts` import inside a relative `.ts` import is still a
+ * `.ts` import, and passing node's `require` down means the first nested local
+ * module throws `MODULE_NOT_FOUND` — which is exactly how three analytics tests
+ * broke the first time a component grew a second local dependency.
+ *
+ * @param {string} entryPath absolute path to the .ts/.tsx entry
+ * @param {(id: string) => unknown} mock returns exports for an id, or undefined
+ *   to fall through to relative resolution and then node's require
+ */
+function loadTsxModule(entryPath, mock = () => undefined) {
+  const compilerOptions = {
+    jsx: ts.JsxEmit.React,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+  };
+
+  const evaluate = (filePath) => {
+    const { outputText } = ts.transpileModule(
+      fs.readFileSync(filePath, "utf8"),
+      { compilerOptions },
+    );
+    const mod = { exports: {} };
+    new Function("require", "module", "exports", outputText)(
+      shimFor(filePath),
+      mod,
+      mod.exports,
+    );
+    return mod.exports;
+  };
+
+  const shimFor = (from) => (id) => {
+    const mocked = mock(id);
+    if (mocked !== undefined) return mocked;
+
+    if (id.startsWith(".")) {
+      const base = path.resolve(path.dirname(from), id);
+      for (const ext of [".ts", ".tsx", "/index.ts", "/index.tsx"]) {
+        if (fs.existsSync(base + ext)) return evaluate(base + ext);
+      }
+    }
+    return require(id);
+  };
+
+  return evaluate(entryPath);
+}
+
+module.exports = { loadTsxModule };

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -7,10 +7,11 @@ import Unavailable from "../factory/Unavailable";
 import Sparkline from "../Sparkline";
 import {
   gapSafe,
-  seriesColor,
-  FX_SEVERITY,
+  readableInk,
+  withAlpha,
   type SeverityLevel,
 } from "../factory/chartTheme";
+import { useFactoryTheme } from "../factory/useFactoryTheme";
 import "../factory/tokens.css";
 import styles from "./CountmeAnalyticsCharts.module.css";
 import countmeHistoryData from "@site/static/data/countme-history.json";
@@ -103,15 +104,21 @@ type HeroRange = "12w" | "24w" | "all";
 type EcosystemMode = "absolute" | "share";
 
 /**
- * The promotion streams the factory actually publishes, in promotion order.
+ * The promotion axis, in promotion order.
  *
- * Source: `projectbluefin/common` → `docs/skills/image-registry.md`. `bluefin`
- * and `dakota` promote `:testing` → `:stable`; `bluefin-lts` promotes
- * `:testing` → `:lts` with `:stable` as a floating alias. Retired tags
- * (`:latest`, `:gts`) still sit in the registry and are deliberately not
- * columns here — nothing promotes through them.
+ * Read from source, not from `projectbluefin/common` →
+ * `docs/skills/image-registry.md`, which still claims `bluefin-lts` promotes to
+ * `:lts`. Every repo's `execute-release.yml` targets `stable`:
+ *
+ *   bluefin      {"source_tag":"testing","target_tag":"stable"}
+ *   bluefin-lts  {"source_tag":"testing","target_tag":"stable"}
+ *   dakota       {"source_tag":"<build sha>","target_tag":"stable"}
+ *
+ * `:lts`, `:gts` and `:latest` still sit on some images as leftovers from
+ * retired schemes. Nothing promotes through them, so they are not columns — a
+ * column that is a dash down most of the grid teaches nobody anything.
  */
-export const STREAM_COLUMNS = ["testing", "stable", "lts"] as const;
+export const STREAM_COLUMNS = ["testing", "stable"] as const;
 export type StreamTag = (typeof STREAM_COLUMNS)[number];
 
 export interface ProjectBluefinImageSpec {
@@ -120,26 +127,37 @@ export interface ProjectBluefinImageSpec {
   edition: string;
   /** Upstream the image is composed from. */
   base: string;
-  color: string;
+  /** Index into the resolved `--fx-cat-*` ramp. Never a literal colour. */
+  cat: number;
   link: string;
   status: "active" | "bootstrapping" | "provisioning";
   statusText: string;
-  /** Published GHCR package names in this family, in registry order. */
+  /** GHCR packages this family promotes, in release-workflow order. */
   images: string[];
-  /** Streams this family promotes through. */
-  streams: StreamTag[];
+  /** Packages still in the registry that no release workflow promotes. */
+  retired?: string[];
   /** `oci` families appear in the stream matrix; `ddi` families ship no container tags. */
   delivery: "oci" | "ddi";
 }
 
 /**
  * Every image family `projectbluefin/common` ships into, with the GHCR packages
- * each one publishes.
+ * each one promotes.
  *
- * Source of truth: `projectbluefin/common` → `docs/skills/image-registry.md`.
- * `id` is the first-party countme `repo` identifier; `images` are the published
- * flavors under the Justfile `image_name` rule (`flavor=main` → `{image}`,
- * otherwise `{image}-{flavor}`).
+ * **Derived from each repo's `execute-release.yml` promotion matrix, not from
+ * `common` → `docs/skills/image-registry.md`.** That file was the source here
+ * and it is wrong on three counts: it claims `bluefin-lts` promotes to `:lts`,
+ * it lists the retired `-hwe` images as live, and it omits `bluefin-lts-nvidia`
+ * and both dakota gaming images entirely. Re-derive before editing this list:
+ *
+ * ```bash
+ * for r in bluefin bluefin-lts dakota; do
+ *   gh api "repos/projectbluefin/$r/contents/.github/workflows/execute-release.yml" \
+ *     --jq .content | base64 -d | grep -E '"image"'
+ * done
+ * ```
+ *
+ * `id` is the first-party countme `repo` identifier.
  */
 export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
   {
@@ -147,12 +165,11 @@ export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Bluefin",
     edition: "Flagship Workstation",
     base: "Fedora",
-    color: "#58a6ff",
+    cat: 0,
     link: "/downloads",
     status: "active",
     statusText: "Active Tracking",
     images: ["bluefin", "bluefin-nvidia"],
-    streams: ["testing", "stable"],
     delivery: "oci",
   },
   {
@@ -160,12 +177,12 @@ export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Bluefin LTS",
     edition: "Enterprise Workstation",
     base: "CentOS Stream 10",
-    color: "#bc8cff",
+    cat: 1,
     link: "/lts",
     status: "active",
     statusText: "Active · EPEL",
-    images: ["bluefin-lts", "bluefin-lts-hwe", "bluefin-lts-hwe-nvidia"],
-    streams: ["testing", "stable", "lts"],
+    images: ["bluefin-lts", "bluefin-lts-nvidia"],
+    retired: ["bluefin-lts-hwe", "bluefin-lts-hwe-nvidia"],
     delivery: "oci",
   },
   {
@@ -173,12 +190,16 @@ export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Project Bluefin Dakota",
     edition: "Next-Gen BuildStream",
     base: "GNOME OS / BuildStream 2",
-    color: "#39d2c0",
+    cat: 2,
     link: "/dakota",
     status: "bootstrapping",
     statusText: "Alpha · Collecting",
-    images: ["dakota", "dakota-nvidia"],
-    streams: ["testing", "stable"],
+    images: [
+      "dakota",
+      "dakota-nvidia",
+      "dakota-gaming",
+      "dakota-nvidia-gaming",
+    ],
     delivery: "oci",
   },
   {
@@ -186,12 +207,11 @@ export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Project Bluefin Utah",
     edition: "Modular Hummingbird",
     base: "Fedora Hummingbird",
-    color: "#f0883e",
+    cat: 3,
     link: "/utah",
     status: "provisioning",
     statusText: "Pre-alpha · Provisioning",
     images: [],
-    streams: [],
     delivery: "oci",
   },
   {
@@ -199,12 +219,11 @@ export const BLUEFIN_FAMILY_IMAGES: ProjectBluefinImageSpec[] = [
     name: "Bluefin Server",
     edition: "Image-Based Server",
     base: "freedesktop-sdk 26.08",
-    color: "#79b8ff",
+    cat: 4,
     link: "https://github.com/projectbluefin/server",
     status: "provisioning",
     statusText: "Alpha · DDI delivery",
     images: [],
-    streams: [],
     delivery: "ddi",
   },
 ];
@@ -246,18 +265,6 @@ const LEVEL_ORDINAL: Record<SeverityLevel, number> = {
   watch: 2,
   alert: 3,
 };
-
-/**
- * Ink that stays readable on a severity swatch.
- *
- * The four severity colours span roughly 45–68% lightness, which crosses the
- * point where white stops being the higher-contrast choice. Read the lightness
- * out of the `hsl()` literal rather than picking one ink and hoping.
- */
-export function contrastInk(hslColor: string): string {
-  const lightness = Number(/,\s*([\d.]+)%\s*\)/.exec(hslColor)?.[1]);
-  return Number.isFinite(lightness) && lightness >= 55 ? "#10130f" : "#f8fafc";
-}
 
 export interface MatrixRow {
   image: string;
@@ -303,19 +310,17 @@ export function buildStreamMatrix(
       const published = byName
         .get(row.image)
         ?.streams?.find((s) => s.tag === stream);
-      const applicable = row.family.streams.includes(stream);
       cells.push({
         x,
         y,
         image: row.image,
         stream,
-        level: applicable ? freshnessLevel(published) : "unknown",
-        ageDays: applicable ? parseCount(published?.ageDays) : null,
+        level: freshnessLevel(published),
+        ageDays: parseCount(published?.ageDays),
         publishedAt: published?.publishedAt ?? null,
-        reason: applicable
-          ? (published?.stateReason ??
-            (published ? null : "no version published under this tag"))
-          : `${row.family.name} does not promote through :${stream}`,
+        reason:
+          published?.stateReason ??
+          (published ? null : "no version published under this tag"),
       });
     });
   });
@@ -364,6 +369,9 @@ export default function CountmeAnalyticsCharts({
   const data = dataset ?? (countmeHistoryData as unknown as CountmeDataset);
   const weeks = data?.weeks || [];
 
+  const [themeRef, fxTheme] = useFactoryTheme();
+  const cat = fxTheme.categorical;
+  const sev = fxTheme.severity;
   const [heroRange, setHeroRange] = useState<HeroRange>("all");
   const [ecoMode, setEcoMode] = useState<EcosystemMode>("absolute");
   const [fetchedRegistry, setFetchedRegistry] = useState<GhcrDataset | null>(
@@ -451,8 +459,8 @@ export default function CountmeAnalyticsCharts({
                 data: p50,
                 showSymbol: false,
                 smooth: true,
-                lineStyle: { width: 2, type: [6, 3], color: seriesColor(4) },
-                itemStyle: { color: seriesColor(4) },
+                lineStyle: { width: 2, type: [6, 3], color: cat[5] },
+                itemStyle: { color: cat[5] },
                 connectNulls: false,
               },
               {
@@ -463,8 +471,8 @@ export default function CountmeAnalyticsCharts({
                 showSymbol: false,
                 smooth: true,
                 lineStyle: { opacity: 0 },
-                itemStyle: { color: "rgba(88, 166, 255, 0.35)" },
-                areaStyle: { color: "rgba(88, 166, 255, 0.2)" },
+                itemStyle: { color: withAlpha(cat[0], 0.35) },
+                areaStyle: { color: cat[0], opacity: 0.18 },
                 connectNulls: false,
               },
             ]
@@ -477,8 +485,8 @@ export default function CountmeAnalyticsCharts({
           showSymbol: true,
           symbolSize: 6,
           z: 5,
-          itemStyle: { color: seriesColor(0) },
-          lineStyle: { width: 3, color: seriesColor(0) },
+          itemStyle: { color: cat[0] },
+          lineStyle: { width: 3, color: cat[0] },
           connectNulls: false,
         },
       ],
@@ -524,7 +532,7 @@ export default function CountmeAnalyticsCharts({
         pieces: (Object.keys(LEVEL_ORDINAL) as SeverityLevel[]).map(
           (level) => ({
             value: LEVEL_ORDINAL[level],
-            color: FX_SEVERITY[level].color,
+            color: sev[level].color,
           }),
         ),
       },
@@ -533,16 +541,16 @@ export default function CountmeAnalyticsCharts({
           name: "Stream freshness",
           type: "heatmap",
           data: cells.map((c) => {
-            const sev = FX_SEVERITY[c.level];
+            const level = sev[c.level];
             return {
               value: [c.x, c.y, LEVEL_ORDINAL[c.level]],
-              text: c.ageDays === null ? "—" : `${sev.glyph} ${c.ageDays}d`,
-              label: { color: contrastInk(sev.color) },
+              text: c.ageDays === null ? "—" : `${level.glyph} ${c.ageDays}d`,
+              label: { color: readableInk(level.color) },
               tip: [
                 `${c.image}:${c.stream}`,
                 c.ageDays === null
                   ? "No published version"
-                  : `Published ${c.ageDays} day${c.ageDays === 1 ? "" : "s"} ago — ${sev.word}`,
+                  : `Published ${c.ageDays} day${c.ageDays === 1 ? "" : "s"} ago — ${level.word}`,
                 c.publishedAt
                   ? `Last push ${c.publishedAt.slice(0, 10)}`
                   : null,
@@ -559,17 +567,17 @@ export default function CountmeAnalyticsCharts({
             formatter: (p: { data: { text: string } }) => p.data.text,
           },
           itemStyle: {
-            borderColor: "rgba(127, 127, 127, 0.28)",
+            borderColor: withAlpha(fxTheme.palette.border, 0.9),
             borderWidth: 2,
             borderRadius: 6,
           },
           emphasis: {
-            itemStyle: { borderColor: seriesColor(0), borderWidth: 3 },
+            itemStyle: { borderColor: cat[0], borderWidth: 3 },
           },
         },
       ],
     }),
-    [rows, cells],
+    [rows, cells, sev, cat, fxTheme.palette.border],
   );
 
   // ── Family ridgeline ───────────────────────────────────────────────────
@@ -620,7 +628,7 @@ export default function CountmeAnalyticsCharts({
               : `${current.toLocaleString()} systems`,
           left: 0,
           top: LANE_TOP + i * (LANE_HEIGHT + LANE_GAP) + 10,
-          textStyle: { color: family.color, fontSize: 13, fontWeight: 600 },
+          textStyle: { color: cat[family.cat], fontSize: 13, fontWeight: 600 },
           subtextStyle: { fontSize: 12 },
         };
       }),
@@ -643,33 +651,36 @@ export default function CountmeAnalyticsCharts({
         max: ridgelineMax,
         show: false,
       })),
-      series: BLUEFIN_FAMILY_IMAGES.map((family, i) => ({
-        name: family.name,
-        type: "line",
-        xAxisIndex: i,
-        yAxisIndex: i,
-        data: laneSeriesData[i],
-        smooth: true,
-        symbol: "none",
-        connectNulls: false,
-        lineStyle: { width: 2, color: family.color },
-        itemStyle: { color: family.color },
-        areaStyle: {
-          color: {
-            type: "linear",
-            x: 0,
-            y: 0,
-            x2: 0,
-            y2: 1,
-            colorStops: [
-              { offset: 0, color: `${family.color}66` },
-              { offset: 1, color: `${family.color}0d` },
-            ],
+      series: BLUEFIN_FAMILY_IMAGES.map((family, i) => {
+        const laneColor = cat[family.cat];
+        return {
+          name: family.name,
+          type: "line",
+          xAxisIndex: i,
+          yAxisIndex: i,
+          data: laneSeriesData[i],
+          smooth: true,
+          symbol: "none",
+          connectNulls: false,
+          lineStyle: { width: 2, color: laneColor },
+          itemStyle: { color: laneColor },
+          areaStyle: {
+            color: {
+              type: "linear",
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: withAlpha(laneColor, 0.4) },
+                { offset: 1, color: withAlpha(laneColor, 0.05) },
+              ],
+            },
           },
-        },
-      })),
+        };
+      }),
     }),
-    [weeks, laneSeriesData, ridgelineMax, latestWeek],
+    [weeks, laneSeriesData, ridgelineMax, latestWeek, cat],
   );
 
   // ── Ecosystem streamgraph ──────────────────────────────────────────────
@@ -677,21 +688,21 @@ export default function CountmeAnalyticsCharts({
     () => [
       {
         name: "Bazzite (Gaming)",
-        color: "#f0883e",
+        color: cat[2],
         values: weeks.map((w) => parseCount(w.bazzite)),
       },
       {
         name: "Bluefin family (Workstation)",
-        color: seriesColor(0),
+        color: cat[0],
         values: weeks.map(fleetOf),
       },
       {
         name: "Aurora (KDE)",
-        color: "#39d2c0",
+        color: cat[4],
         values: weeks.map((w) => parseCount(w.aurora)),
       },
     ],
-    [weeks],
+    [weeks, cat],
   );
 
   const ecoTotals = useMemo(
@@ -744,7 +755,7 @@ export default function CountmeAnalyticsCharts({
 
   if (data?.unavailable || !weeks.length) {
     return (
-      <div className={`fxRoot ${styles.container}`}>
+      <div ref={themeRef} className={`fxRoot ${styles.container}`}>
         <Unavailable
           what="Countme Analytics"
           reason={
@@ -766,7 +777,7 @@ export default function CountmeAnalyticsCharts({
   const packageIndex = new Map(ghcrPackages.map((p) => [p.name, p]));
 
   return (
-    <div className={`fxRoot ${styles.container}`}>
+    <div ref={themeRef} className={`fxRoot ${styles.container}`}>
       {/* ── 1. Fleet trend with rolling median band ─────────────────────── */}
       <section className={styles.heroCard}>
         <header className={styles.heroHeader}>
@@ -870,11 +881,11 @@ export default function CountmeAnalyticsCharts({
                   <span
                     aria-hidden="true"
                     className={styles.legendGlyph}
-                    style={{ color: FX_SEVERITY[level].color }}
+                    style={{ color: sev[level].color }}
                   >
-                    {FX_SEVERITY[level].glyph}
+                    {sev[level].glyph}
                   </span>
-                  {FX_SEVERITY[level].word}
+                  {sev[level].word}
                 </span>
               ),
             )}
@@ -903,12 +914,12 @@ export default function CountmeAnalyticsCharts({
         )}
 
         <p className={styles.chartNote}>
-          <strong>Streams:</strong> <code>bluefin</code> and <code>dakota</code>{" "}
-          promote <code>:testing</code> &rarr; <code>:stable</code>.{" "}
-          <code>bluefin-lts</code> promotes <code>:testing</code> &rarr;{" "}
-          <code>:lts</code>, with <code>:stable</code> as a floating alias.
-          Retired <code>:latest</code> and <code>:gts</code> tags still sit in
-          the registry and are deliberately excluded.
+          <strong>Streams:</strong> every image promotes <code>:testing</code>{" "}
+          &rarr; <code>:stable</code>, which is the whole axis. Read from each
+          repository&rsquo;s <code>execute-release.yml</code> promotion matrix.
+          The <code>:lts</code>, <code>:gts</code> and <code>:latest</code> tags
+          still sit on some images as leftovers from retired schemes; nothing
+          promotes through them, so they are not columns here.
         </p>
       </section>
 
@@ -1007,7 +1018,7 @@ export default function CountmeAnalyticsCharts({
                     domain={[0, ridgelineMax]}
                     width={220}
                     height={32}
-                    color={img.color}
+                    color={cat[img.cat]}
                     areaColor="currentColor"
                     areaOpacity={0.12}
                     showEnd={isTracked}
@@ -1037,7 +1048,7 @@ export default function CountmeAnalyticsCharts({
                       <li key={name} className={styles.variantRow}>
                         <code className={styles.variantName}>{name}</code>
                         <span className={styles.variantStreams}>
-                          {img.streams.map((stream) => {
+                          {STREAM_COLUMNS.map((stream) => {
                             const published = packageIndex
                               .get(name)
                               ?.streams?.find((s) => s.tag === stream);
@@ -1047,16 +1058,16 @@ export default function CountmeAnalyticsCharts({
                               <span
                                 key={stream}
                                 className={styles.streamChip}
-                                title={`${name}:${stream} — ${FX_SEVERITY[level].word}${
+                                title={`${name}:${stream} — ${sev[level].word}${
                                   age === null ? "" : `, ${age} days old`
                                 }`}
                               >
                                 <span
                                   aria-hidden="true"
                                   className={styles.legendGlyph}
-                                  style={{ color: FX_SEVERITY[level].color }}
+                                  style={{ color: sev[level].color }}
                                 >
-                                  {FX_SEVERITY[level].glyph}
+                                  {sev[level].glyph}
                                 </span>
                                 {stream} {age === null ? "—" : `${age}d`}
                               </span>
@@ -1066,6 +1077,17 @@ export default function CountmeAnalyticsCharts({
                       </li>
                     ))
                   )}
+                  {img.retired?.length ? (
+                    <li className={styles.variantEmpty}>
+                      Retired, still in the registry:{" "}
+                      {img.retired.map((name, i) => (
+                        <React.Fragment key={name}>
+                          {i > 0 && ", "}
+                          <code>{name}</code>
+                        </React.Fragment>
+                      ))}
+                    </li>
+                  ) : null}
                 </ul>
 
                 <div className={styles.familyFooter}>

--- a/src/components/factory/EChart.tsx
+++ b/src/components/factory/EChart.tsx
@@ -2,35 +2,12 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   toTableRows,
   FX_CHART_THEME,
-  FX_COLORS,
-  FX_COLOR_TOKENS,
   fxEchartsTheme,
-  type FxPalette,
+  resolveFxTheme,
 } from "./chartTheme";
 import styles from "./FactoryShell.module.css";
 
 const FX_THEME_NAME = "fx";
-
-/**
- * Read the `--fx-*` tokens off the mounted element.
- *
- * Canvas cannot resolve CSS custom properties, so a chart that hard-codes its
- * text colour is illegible in whichever theme it was not written for. Outside
- * `.fxRoot` the tokens are absent and the dark literals stand in.
- */
-function resolvePalette(el: HTMLElement): FxPalette {
-  const cs = getComputedStyle(el);
-  const read = (slot: keyof FxPalette): string =>
-    cs.getPropertyValue(FX_COLOR_TOKENS[slot]).trim() || FX_COLORS[slot];
-  return {
-    text: read("text"),
-    muted: read("muted"),
-    faint: read("faint"),
-    grid: read("grid"),
-    surface: read("surface"),
-    border: read("border"),
-  };
-}
 
 interface EChartsInstance {
   setOption: (o: unknown, notMerge?: boolean) => void;
@@ -145,7 +122,7 @@ export default function EChart({
       ]);
       core.registerTheme(
         FX_THEME_NAME,
-        fxEchartsTheme(resolvePalette(ref.current)),
+        fxEchartsTheme(resolveFxTheme(ref.current)),
       );
       chartRef.current = core.init(
         ref.current,

--- a/src/components/factory/chartTheme.ts
+++ b/src/components/factory/chartTheme.ts
@@ -36,14 +36,29 @@ export const FX_COLORS = {
   border: "#30363d",
 } as const;
 
-/** Categorical palette. Index 0..5, wrapping. */
+export const FX_CAT_TOKENS = [
+  "--fx-cat-1",
+  "--fx-cat-2",
+  "--fx-cat-3",
+  "--fx-cat-4",
+  "--fx-cat-5",
+  "--fx-cat-6",
+] as const;
+
+/**
+ * Dark-surface fallback for the `--fx-cat-*` ramp in tokens.css.
+ *
+ * One ramp through the Bluefin blues, anchored on the `#4285f4` brand accent
+ * (`/press-kit`; `--color-blue` in `projectbluefin/website`). This copy only
+ * applies where the tokens are absent — a chart mounted outside `.fxRoot`.
+ */
 const CATEGORICAL = [
-  "#58a6ff",
-  "#bc8cff",
-  "#39d2c0",
-  "#f0883e",
-  "#79b8ff",
-  "#a371f7",
+  "#4285f4",
+  "#c7d7ff",
+  "#60a5fa",
+  "#8a97f7",
+  "#5c7bd1",
+  "#a2b5fa",
 ] as const;
 
 /** Dash patterns paired with the palette so series differ by shape too. */
@@ -56,12 +71,27 @@ const DASHES: Array<number[] | undefined> = [
   [1, 3],
 ];
 
-/** Severity as one hue at four intensities. Never hue-encoded, never red/green. */
+export const FX_SEV_TOKENS = {
+  unknown: "--fx-sev-unknown",
+  ok: "--fx-sev-ok",
+  watch: "--fx-sev-watch",
+  alert: "--fx-sev-alert",
+} as const;
+
+/**
+ * Severity as one hue at four intensities, plus a glyph and a word.
+ *
+ * The hue is the brand's. The Wolves cinematic names its accent `--wc-gold` and
+ * then sets it to blue; that is the design language, and a traffic-light amber
+ * grid sitting inside it reads as a different product. Colours here are the
+ * dark-surface fallback for `--fx-sev-*`; the glyph and word are the meaning and
+ * are never resolved from CSS.
+ */
 export const FX_SEVERITY = {
-  unknown: { color: "hsl(38, 6%, 45%)", glyph: "○", word: "Unknown" },
-  ok: { color: "hsl(38, 26%, 55%)", glyph: "●", word: "Nominal" },
-  watch: { color: "hsl(38, 80%, 56%)", glyph: "▲", word: "Watch" },
-  alert: { color: "hsl(38, 100%, 68%)", glyph: "■", word: "Alert" },
+  unknown: { color: "hsl(217, 8%, 52%)", glyph: "○", word: "Unknown" },
+  ok: { color: "hsl(217, 89%, 61%)", glyph: "●", word: "Nominal" },
+  watch: { color: "hsl(217, 94%, 74%)", glyph: "▲", word: "Watch" },
+  alert: { color: "hsl(217, 100%, 86%)", glyph: "■", word: "Alert" },
 } as const;
 
 export type SeverityLevel = keyof typeof FX_SEVERITY;
@@ -72,6 +102,108 @@ export function seriesColor(i: number): string {
 
 export function seriesDash(i: number): number[] | undefined {
   return DASHES[i % DASHES.length];
+}
+
+/**
+ * Parse any colour this module can hand out into sRGB 0–255 components.
+ *
+ * `getComputedStyle` serialises a custom property to `rgb()` or hex even when
+ * `tokens.css` declared it as `hsl()`, so a helper that only understood one
+ * notation silently did nothing — which is how the heatmap shipped white labels
+ * on a near-white swatch.
+ */
+function toRgb(color: string): [number, number, number] | null {
+  const value = color.trim();
+
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(value);
+  if (hex) {
+    const digits =
+      hex[1].length === 3
+        ? hex[1]
+            .split("")
+            .map((d) => d + d)
+            .join("")
+        : hex[1];
+    const n = parseInt(digits, 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+
+  const rgb = /^rgba?\(([^)]+)\)$/i.exec(value);
+  if (rgb) {
+    const parts = rgb[1]
+      .split(/[\s,/]+/)
+      .filter(Boolean)
+      .map(Number);
+    if (parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite)) {
+      return [parts[0], parts[1], parts[2]];
+    }
+  }
+
+  const hsl = /^hsla?\(([^)]+)\)$/i.exec(value);
+  if (hsl) {
+    const [h, s, l] = hsl[1]
+      .split(/[\s,/]+/)
+      .filter(Boolean)
+      .slice(0, 3)
+      .map((p) => Number(p.replace("%", "")));
+    if (![h, s, l].every(Number.isFinite)) return null;
+    const chroma = (1 - Math.abs((2 * l) / 100 - 1)) * (s / 100);
+    const x = chroma * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l / 100 - chroma / 2;
+    const sector = Math.floor((((h % 360) + 360) % 360) / 60);
+    const rgbPrime = [
+      [chroma, x, 0],
+      [x, chroma, 0],
+      [0, chroma, x],
+      [0, x, chroma],
+      [x, 0, chroma],
+      [chroma, 0, x],
+    ][sector];
+    return rgbPrime.map((c) => Math.round((c + m) * 255)) as [
+      number,
+      number,
+      number,
+    ];
+  }
+
+  return null;
+}
+
+/** WCAG relative luminance, 0 (black) to 1 (white). */
+function luminance([r, g, b]: [number, number, number]): number {
+  const linear = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+const INK_DARK = "#0b1220";
+const INK_LIGHT = "#f5f8ff";
+
+/**
+ * Ink that stays readable on a palette swatch.
+ *
+ * The ramps run from a near-navy to a near-white blue, crossing the point where
+ * white stops being the higher-contrast choice. 0.45 relative luminance is that
+ * crossing for this pair of inks.
+ */
+export function readableInk(color: string): string {
+  const rgb = toRgb(color);
+  if (!rgb) return INK_LIGHT;
+  return luminance(rgb) >= 0.45 ? INK_DARK : INK_LIGHT;
+}
+
+/**
+ * The same colour at a given alpha.
+ *
+ * Appending two hex digits to a token only works while the token happens to be
+ * hex; `factory-theming.test.js` bans that concatenation outright. This handles
+ * whatever notation the token resolved to.
+ */
+export function withAlpha(color: string, alpha: number): string {
+  const rgb = toRgb(color);
+  return rgb ? `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})` : color;
 }
 
 /**
@@ -109,13 +241,74 @@ export interface FxPalette {
   border: string;
 }
 
+export interface FxTheme {
+  palette: FxPalette;
+  /** The `--fx-cat-*` ramp, in order. */
+  categorical: string[];
+  /** `--fx-sev-*` resolved, with the glyph and word carried over unchanged. */
+  severity: Record<
+    SeverityLevel,
+    { color: string; glyph: string; word: string }
+  >;
+}
+
+/** What a chart paints with before it is mounted, or outside `.fxRoot`. */
+export const FX_FALLBACK_THEME: FxTheme = {
+  palette: { ...FX_COLORS },
+  categorical: [...CATEGORICAL],
+  severity: {
+    unknown: { ...FX_SEVERITY.unknown },
+    ok: { ...FX_SEVERITY.ok },
+    watch: { ...FX_SEVERITY.watch },
+    alert: { ...FX_SEVERITY.alert },
+  },
+};
+
 /**
- * An ECharts theme object built from resolved token values.
+ * Read the whole `--fx-*` chart palette off a mounted element.
+ *
+ * Canvas cannot resolve CSS custom properties, which is why the ramps used to
+ * be duplicated as literals here and drift from `tokens.css`. `getComputedStyle`
+ * resolves them fine, so `tokens.css` is the single source and this is the only
+ * bridge. Outside `.fxRoot` the tokens are absent and the fallback stands in.
+ */
+export function resolveFxTheme(el: HTMLElement): FxTheme {
+  const cs = getComputedStyle(el);
+  const read = (token: string, fallback: string): string =>
+    cs.getPropertyValue(token).trim() || fallback;
+
+  const severity = {} as FxTheme["severity"];
+  for (const level of Object.keys(FX_SEV_TOKENS) as SeverityLevel[]) {
+    severity[level] = {
+      ...FX_SEVERITY[level],
+      color: read(FX_SEV_TOKENS[level], FX_SEVERITY[level].color),
+    };
+  }
+
+  return {
+    palette: {
+      text: read(FX_COLOR_TOKENS.text, FX_COLORS.text),
+      muted: read(FX_COLOR_TOKENS.muted, FX_COLORS.muted),
+      faint: read(FX_COLOR_TOKENS.faint, FX_COLORS.faint),
+      grid: read(FX_COLOR_TOKENS.grid, FX_COLORS.grid),
+      surface: read(FX_COLOR_TOKENS.surface, FX_COLORS.surface),
+      border: read(FX_COLOR_TOKENS.border, FX_COLORS.border),
+    },
+    categorical: FX_CAT_TOKENS.map((token, i) => read(token, CATEGORICAL[i])),
+    severity,
+  };
+}
+
+/**
+ * An ECharts theme object built from a resolved `FxTheme`.
  *
  * Registered rather than merged into each option so a panel's own colour
- * choices still win — this only supplies what the panel left unsaid.
+ * choices still win — this only supplies what the panel left unsaid. `color` is
+ * the series palette, so a panel that names no colour is on the brand ramp in
+ * both themes for free.
  */
-export function fxEchartsTheme(palette: FxPalette): Record<string, unknown> {
+export function fxEchartsTheme(theme: FxTheme): Record<string, unknown> {
+  const { palette } = theme;
   const axis = {
     axisLine: { lineStyle: { color: palette.border } },
     axisTick: { lineStyle: { color: palette.border } },
@@ -124,6 +317,7 @@ export function fxEchartsTheme(palette: FxPalette): Record<string, unknown> {
     splitArea: { show: false },
   };
   return {
+    color: theme.categorical,
     backgroundColor: "transparent",
     textStyle: { color: palette.text },
     title: {

--- a/src/components/factory/tokens.css
+++ b/src/components/factory/tokens.css
@@ -34,22 +34,37 @@
   --fx-accent-dim: var(--ifm-color-primary-dark);
   --fx-accent-soft: var(--ifm-color-primary-lightest);
 
-  /* Severity stays one hue at four intensities plus a glyph — it is semantic,
-     not decorative, so it does not follow the brand palette. Never encode
-     severity by hue alone and never with a red/green pair. */
-  --fx-sev-unknown: var(--ifm-color-emphasis-500);
-  --fx-sev-ok: hsl(38, 30%, 42%);
-  --fx-sev-watch: hsl(38, 74%, 38%);
-  --fx-sev-alert: hsl(38, 96%, 32%);
+  /* Severity is one hue at four intensities plus a glyph — and the hue is the
+     brand's, 217, the hue of the #4285f4 wordmark accent. It used to be a
+     traffic-light amber, which read as a different product sitting inside the
+     dashboard. The Wolves cinematic (projectbluefin/website,
+     style/wolves-cinematic.scss) names its accent --wc-gold and then sets it to
+     blue; that is the whole design language in one line.
 
-  /* Categorical series, anchored on the brand blue. chartTheme.ts pairs each
-     with a dash pattern so the reading survives greyscale. */
-  --fx-cat-1: var(--ifm-color-primary);
-  --fx-cat-2: #8a63d2;
-  --fx-cat-3: #2aa198;
-  --fx-cat-4: #cb6d20;
-  --fx-cat-5: #5c7bd1;
-  --fx-cat-6: #a2b5fa;
+     Intensity runs toward contrast with the surface, so the lane that needs
+     attention is the loud one. Never encode severity by hue alone and never
+     with a red/green pair. */
+  --fx-sev-unknown: hsl(217, 8%, 52%);
+  --fx-sev-ok: hsl(217, 50%, 52%);
+  --fx-sev-watch: hsl(217, 62%, 38%);
+  --fx-sev-alert: hsl(217, 78%, 26%);
+
+  /* Categorical series: one ramp through the documented Bluefin blues, anchored
+     on the brand accent the wordmark ligature uses (docs/press-kit.md, and
+     --color-blue in projectbluefin/website). The rest are the site's own Infima
+     primary scale from src/css/custom.css. Steps alternate light and dark so
+     neighbours separate, and chartTheme.ts pairs each index with a dash pattern
+     so the reading survives greyscale.
+
+     Written as hex, not hsl: getComputedStyle serialises a custom property to
+     hex anyway, and the brand accent should be its exact value rather than a
+     round-trip that lands one digit away. */
+  --fx-cat-1: #4285f4;
+  --fx-cat-2: #22306b;
+  --fx-cat-3: #5c7bd1;
+  --fx-cat-4: #3f5aa4;
+  --fx-cat-5: #89a3f0;
+  --fx-cat-6: #2c4075;
 
   --fx-space-1: 0.25rem;
   --fx-space-2: 0.5rem;
@@ -89,6 +104,32 @@
   font-family: var(--fx-font);
   color: var(--fx-text);
   background: var(--fx-bg);
+}
+
+/*
+ * Surfaces and text follow Infima's emphasis scale, which inverts on its own.
+ * The two fixed ramps above cannot: they are tuned to be loud against white, so
+ * on a dark surface the loudest step is the darkest one and severity reads
+ * backwards. Same hue, same four intensities, mirrored.
+ *
+ * The categorical steps that were dark-on-white move light-on-black by the same
+ * rule, and --fx-cat-1 stays exactly the brand accent in both.
+ */
+[data-theme="dark"] .fxRoot {
+  --fx-sev-ok: hsl(217, 89%, 61%); /* the brand accent itself */
+  --fx-sev-watch: hsl(217, 94%, 74%);
+  --fx-sev-alert: hsl(217, 100%, 86%);
+
+  /* All six are restated, not just the ones that move: chartTheme.ts keeps a
+     copy of this block for charts mounted outside .fxRoot, and
+     factory-theming.test.js compares the two ramps step for step. A partial
+     override would make that comparison a guess. */
+  --fx-cat-1: #4285f4; /* the brand accent, unchanged in both themes */
+  --fx-cat-2: #c7d7ff;
+  --fx-cat-3: #60a5fa; /* the Wolves signal blue */
+  --fx-cat-4: #8a97f7; /* --color-blue-light */
+  --fx-cat-5: #5c7bd1;
+  --fx-cat-6: #a2b5fa;
 }
 
 /* Headings inside the dashboard use the site's heading treatment. */

--- a/src/components/factory/useFactoryTheme.ts
+++ b/src/components/factory/useFactoryTheme.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { FX_FALLBACK_THEME, resolveFxTheme, type FxTheme } from "./chartTheme";
+
+/**
+ * The resolved `--fx-*` chart palette, for the values a component needs in
+ * JavaScript rather than in CSS.
+ *
+ * Most colour belongs in a stylesheet as `var(--fx-cat-1)`. This exists for the
+ * cases that cannot: a series colour inside an ECharts option, an SVG stroke
+ * passed to `Sparkline`, a per-cell label ink. Those used to be hex literals
+ * copied out of `tokens.css`, which is how the two palettes drifted apart.
+ *
+ * Attach the returned ref to an element inside `.fxRoot`. Before mount — and so
+ * during static generation — the fallback ramp applies, which matters only for
+ * the `<details>` table, since charts do not paint server-side.
+ */
+export function useFactoryTheme(): [RefObject<HTMLDivElement | null>, FxTheme] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [theme, setTheme] = useState<FxTheme>(FX_FALLBACK_THEME);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const sync = () => {
+      if (ref.current) setTheme(resolveFxTheme(ref.current));
+    };
+    sync();
+
+    const observer = new MutationObserver(sync);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, theme];
+}


### PR DESCRIPTION
Two problems, one root cause: the dashboard was reading summaries instead of source.

## Palette

`tokens.css` and `chartTheme.ts` each carried their own colours and had drifted — a GitHub-dark categorical set (`#58a6ff`, `#bc8cff`, `#39d2c0`, `#f0883e`) in TypeScript, a different set in CSS, and a traffic-light **amber** severity ramp sitting inside a blue dashboard.

`tokens.css` is now the single source. Both ramps step through the documented Bluefin blues, anchored on the `#4285f4` wordmark accent from [`/press-kit`](https://docs.projectbluefin.io/press-kit) and `--color-blue` in `projectbluefin/website`. Severity is one hue — **217, the brand's** — at four intensities, mirrored for the dark surface so the lane that needs attention is the loud one in either theme.

> The Wolves cinematic (`projectbluefin/website`, `style/wolves-cinematic.scss`) names its accent `--wc-gold` and then sets it to `#60a5fa`. That is the design language in one line.

`chartTheme.ts` keeps a copy for canvas, which cannot read a CSS variable. `factory-theming.test.js` now compares the two ramps **step for step**, so the copy cannot drift again, and asserts `--fx-cat-1` is the brand accent in both themes.

Two bugs this surfaced:

- `getComputedStyle` serialises a custom property to hex even when `tokens.css` wrote `hsl()`, so `readableInk`'s hsl-only parse never matched and the heatmap painted white labels on near-white cells. It now computes WCAG relative luminance from hex, `rgb()` or `hsl()`.
- Appending hex alpha to a token only works while the token happens to be hex. `withAlpha` handles whatever notation the token resolved to.

## Image matrix

Read from each repository's `execute-release.yml` promotion matrix and cross-checked against the anonymous GHCR tags API. `common` → `docs/skills/image-registry.md` was wrong on three counts, and both the chart and the fetcher had inherited it:

| Claim in `image-registry.md` | Source says |
|---|---|
| `bluefin-lts` promotes `:testing` → `:lts`, `:stable` is an alias | every release workflow targets `stable` |
| `bluefin-lts-hwe`, `bluefin-lts-hwe-nvidia` are live | in no promotion matrix — retired |
| — | `bluefin-lts-nvidia`, `dakota-gaming`, `dakota-nvidia-gaming` are promoted and were missing |

So the `:lts` column was a column of dashes. The axis is `:testing` → `:stable` and nothing else.

The three missing images could not reach the dashboard at all: `FALLBACK_LANES` in `scripts/fetch-ghcr-packages.js` was written from the same summary, and **in CI that list is the only one consulted** — `github.token` is repository-scoped and cannot list an org's packages, so the Packages API returns nothing every run.

The grid is now **8 promoted images × 2 streams, 16 live lanes, no dead cells**. `fetch-ghcr-packages.test.js` pins `PROMOTED_IMAGES` against the release matrices and asserts every promoted image is a lane the fetcher actually reads.

Regenerated snapshot, showing what was invisible before:

```
bluefin-lts-nvidia       testing:2d stable:2d     <- was not in the dataset
dakota-gaming            testing:0d stable:3d     <- was not in the dataset
dakota-nvidia-gaming     testing:0d stable:3d     <- was not in the dataset
dakota                   testing:0d stable:3d     <- real promotion lag, now visible
```

## Tests

Three analytics suites duplicated a 100-line module loader that passed node's `require` to nested local imports, so the first component to grow a second local dependency broke all three at once. Extracted to `scripts/lib/load-tsx.js`, which hands the shim down recursively.

## Verification

- `just check` — 0 lint errors, typecheck clean, full suite green
- `npm run build:ci` — green
- Browser-verified `/analytics` in both themes against a freshly regenerated `ghcr-packages.json`

## Follow-up

`common` → `docs/skills/image-registry.md` still carries all three errors. Filing an issue there; this PR does not depend on it.

Assisted-by: Claude Opus 4.5 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>