### PR TITLE
fix(analytics): stop publishing internal service posture in a panel reason

### DIFF
--- a/docs/skills/monthly-reports.md
+++ b/docs/skills/monthly-reports.md
@@ -81,7 +81,7 @@ added.
    - `<ReportEcosystem>`: Countme, Homebrew, and Flathub source states.
    - `<ReportLaneHealth>`: Publishing lane metrics (Testing, LTS, Dakota).
    - `<ReportCountmeTrend>`: Weekly active systems from countme. Unavailable
-     until `countme.projectbluefin.io` publishes a read endpoint; it states
+     until first-party counts are published; it states
      that reason rather than charting an upstream number.
    - `<ReportAutomationStats>`: Factory autonomous vs human PR breakdown.
    - `<ReportDoraCadence>`: Deployment cadence and velocity indicators.
@@ -164,7 +164,7 @@ snapshot and its provenance remain available to server-rendered output.
   `countme.projectbluefin.io`. Fedora's `totals.csv` — the source behind
   `static/data/countme-history.json` — counts mirror hits for a Fedora repo
   and is never a substitute for one of our images. Until the first-party
-  service publishes a read endpoint, `extractCountmeMetrics()` returns an
+  counts are published, `extractCountmeMetrics()` returns an
   unavailable measurement carrying `FIRST_PARTY_PENDING_REASON` from
   `scripts/lib/countme-sources.mjs`: the report keeps the countme panel and
   states the reason, and the Active Systems hero KPI does not appear.

--- a/scripts/countme-analytics-charts.test.js
+++ b/scripts/countme-analytics-charts.test.js
@@ -135,10 +135,10 @@ test("the catalogue names every family common ships into", () => {
   assert.deepEqual(ids, ["bluefin", "bluefin-lts", "dakota", "utah", "server"]);
 });
 
-test("the count panel names its source instead of substituting a number", () => {
-  // Every Project Bluefin count comes from countme.projectbluefin.io, which
-  // publishes no read endpoint yet. The honest render is an unavailable panel
-  // carrying the reason — never an upstream figure standing in for ours.
+test("the count panel says it lacks data without naming infrastructure", () => {
+  // Presentation rule 6 requires the panel to say it is unavailable and why.
+  // AGENTS.md requires that it never emit a host address or an internal URL.
+  // Both hold: it speaks about the data, not the plumbing.
   const html = renderToStaticMarkup(
     React.createElement(CountmeAnalyticsCharts, {
       registry: REGISTRY_FIXTURE,
@@ -152,7 +152,9 @@ test("the count panel names its source instead of substituting a number", () => 
     panel,
     "the weekly active systems panel must say it is unavailable",
   );
-  assert.match(panel[1], /countme\.projectbluefin\.io/);
+  assert.match(panel[1], /not published yet/);
+  assert.doesNotMatch(panel[1], /projectbluefin\.io/);
+  assert.doesNotMatch(panel[1], /endpoint/i);
 });
 
 const PROMOTED = [

--- a/scripts/countme-first-party.test.js
+++ b/scripts/countme-first-party.test.js
@@ -238,3 +238,30 @@ test("countme is never called telemetry in published copy", () => {
     `say "countme", not "telemetry":\n${offenders.join("\n")}`,
   );
 });
+
+test("a reason string never discloses infrastructure", async () => {
+  const { FIRST_PARTY_PENDING_REASON } = await policy;
+
+  // AGENTS.md, Data pipelines: "Never emit a host address, an internal URL, or
+  // a token." This string renders on /analytics, /factory/metrics and the
+  // monthly report. It shipped naming the host AND stating that the service was
+  // collecting but published no read endpoint — a description of internal
+  // posture, on a public page, in an error message.
+  for (const banned of [
+    /projectbluefin\.io/i,
+    /\bendpoint\b/i,
+    /\bD1\b/,
+    /cloudflare/i,
+    /\bworker\b/i,
+    /https?:\/\//,
+  ]) {
+    assert.doesNotMatch(
+      FIRST_PARTY_PENDING_REASON,
+      banned,
+      `the published reason must not describe infrastructure (${banned})`,
+    );
+  }
+
+  // Presentation rule 6 still has to hold: it must say something.
+  assert.ok(FIRST_PARTY_PENDING_REASON.trim().length > 0);
+});

--- a/scripts/lib/countme-sources.mjs
+++ b/scripts/lib/countme-sources.mjs
@@ -85,12 +85,15 @@ export function isPermittedSource(repo, source) {
 /**
  * The reason a panel shows when a first-party count is not available yet.
  *
- * `countme.projectbluefin.io/metalink` is live and writing to D1, but the
- * service publishes no read endpoint, so nothing can query it. Until it does,
- * the honest render is an unavailable panel that says why — never a substituted
- * upstream number.
+ * AGENTS.md: "Never emit a host address, an internal URL, or a token." This
+ * string is rendered on /analytics, /factory/metrics and the monthly report, so
+ * it says that the number is not published and stops. It must never describe
+ * service topology, endpoint inventory, or what is or is not reachable —
+ * a panel explaining which internal routes do not exist yet is an
+ * infrastructure disclosure wearing an error message.
+ *
+ * Presentation rule 6 still applies: the panel says it lacks data, and why, in
+ * terms of the data rather than the plumbing.
  */
 export const FIRST_PARTY_PENDING_REASON =
-  "Counted by countme.projectbluefin.io, which is collecting but does not yet " +
-  "publish a read endpoint. Fedora and ublue-os numbers are not a permitted " +
-  "substitute for a Project Bluefin image.";
+  "Weekly active systems are not published yet.";

--- a/scripts/report-chart.test.js
+++ b/scripts/report-chart.test.js
@@ -522,16 +522,19 @@ test("ReportCountmeTrend preserves zero and explains unavailable sources", () =>
   assert.match(unavailable, /Data unavailable/);
   assert.match(unavailable, /HTTP 503/);
 
-  // The monthly report passes no reason: it has no total to pass, because a
-  // Project Bluefin count comes from countme.projectbluefin.io and that
-  // service publishes no read endpoint yet. The panel supplies that reason
-  // itself rather than showing an unexplained blank.
+  // The monthly report passes no reason, so the panel supplies one itself
+  // rather than showing an unexplained blank. That fallback is published copy,
+  // so it says the number is not published and stops: AGENTS.md forbids
+  // emitting a host address or an internal URL, and an error message that
+  // inventories which internal routes do not exist yet is a disclosure.
   const noReason = renderComponent(
     "ReportCountmeTrend",
     { currentTotal: null, historyPoints: [], variants: [] },
     { "../Sparkline": sparklineStub },
   );
-  assert.match(noReason, /countme\.projectbluefin\.io/);
+  assert.match(noReason, /not published yet/);
+  assert.doesNotMatch(noReason, /projectbluefin\.io/);
+  assert.doesNotMatch(noReason, /endpoint/i);
 });
 
 test("ReportLaneHealth exposes pending and unavailable lane states", () => {

--- a/src/components/factory/panels/MetricsPanels.tsx
+++ b/src/components/factory/panels/MetricsPanels.tsx
@@ -152,7 +152,7 @@ export default function MetricsPanels(): React.JSX.Element {
  * This panel used to chart `countme-history.json`'s `bluefin` and
  * `bluefin-lts` series, which were Fedora and EPEL mirror hits wearing our
  * names. Those keys no longer exist and may not come back. Until the
- * first-party service publishes a read endpoint, the panel states that instead
+ * first-party counts are published, the panel states that instead
  * of substituting an upstream number.
  */
 function ActiveDevices() {

--- a/src/components/reports/ReportCountmeTrend.tsx
+++ b/src/components/reports/ReportCountmeTrend.tsx
@@ -31,7 +31,7 @@ export default function ReportCountmeTrend({
   const explicitReason = unavailableReason ?? stateReason;
   if (explicitReason || currentTotal === null || currentTotal === undefined) {
     // A Project Bluefin count comes from countme.projectbluefin.io or from
-    // nowhere. With no read endpoint published yet the generator has no total
+    // nowhere. With no first-party count published yet the generator has no total
     // to pass, so the panel says why rather than charting an upstream number.
     return (
       <div className={styles.container} role="status">


### PR DESCRIPTION
AGENTS.md, Data pipelines: **"Never emit a host address, an internal URL, or a token."**

`FIRST_PARTY_PENDING_REASON` rendered this on `/analytics`, `/factory/metrics` and every monthly report:

> Counted by countme.projectbluefin.io, which is collecting but does not yet publish a read endpoint. Fedora and ublue-os numbers are not a permitted substitute for a Project Bluefin image.

That names the host and then describes its internal posture — that it ingests, and that a read path does not exist. An error message enumerating which internal routes are missing is an infrastructure disclosure, and it was live on the public docs site.

Now: **"Weekly active systems are not published yet."** and nothing else. Presentation rule 6 still holds — the panel says it lacks data and why, in terms of the data rather than the plumbing. Same phrasing scrubbed from `docs/skills/monthly-reports.md`, which publishes.

**Two tests were enforcing the disclosure.** `report-chart.test.js` and `countme-analytics-charts.test.js` both asserted the panel matched `/countme\.projectbluefin\.io/`. Inverted. `countme-first-party.test.js` gains a gate failing on a host, a URL, or the words endpoint / D1 / Cloudflare / Worker in any published reason string.

`just check` green, `build:ci` green, no match for `read endpoint` in the built bundle.

Assisted-by: Claude Opus 4.5 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>