### PR TITLE
fix(analytics): serve weekly active systems from the first-party aggregate

### DIFF
--- a/adr/0007-first-party-countme-aggregate.md
+++ b/adr/0007-first-party-countme-aggregate.md
@@ -1,0 +1,130 @@
+# 0007. Weekly active systems from the first-party countme aggregate
+
+- **Status:** Accepted
+- **Date:** 2026-09-12
+- **Deciders:** castrojo
+
+## Context
+
+ADR 0006 and commit `f846c652` removed every `projectbluefin` image from the
+Fedora CSV pipeline. `scripts/lib/countme-sources.mjs` now states the rule as
+code: a Project Bluefin count may come only from `countme.projectbluefin.io`,
+with one exception, `ublue-os/bluefin:stable`, whose number is upstream's to
+publish. `scripts/countme-first-party.test.js` fails the build on a violation.
+
+That removal left no replacement. Verified at the time of this record:
+
+- `/analytics` rendered `Weekly active systems unavailable` on the deployed
+  site. The panel was a hardcoded `Unavailable` with no data wiring.
+- `static/data/countme-history.json` carries `aurora`, `bazzite`, and `fedora`
+  only, and declares `data-analysis.fedoraproject.org` as its source — a literal
+  `FORBIDDEN_SOURCES` match for any Project Bluefin series.
+- `projectbluefin/countme` does not exist. `api.github.com/repos/projectbluefin/countme`
+  returns 404 and every raw artifact path under it returns 404.
+- The worker resolved all first-party chart routes to that nonexistent
+  repository, so `/`, `/growth.svg`, and every per-image route returned the
+  placeholder SVG unconditionally.
+- The worker already recorded pings into D1 (`telemetry_events`), so the
+  measurements existed; nothing read them back.
+
+## Decision
+
+The D1 table behind `countme.projectbluefin.io` is the source for every Project
+Bluefin count, and the worker exposes it.
+
+1. The worker aggregates `telemetry_events` into Monday-anchored weekly counts
+   per repo and serves `GET /counts.json`, shaped like the existing dataset
+   contract: `generatedAt`, `source`, `method`, `unit`, `variants`, `weeks[]`,
+   with optional `unavailable` and `stateReason`.
+2. Every week carries every first-party repo key, holding either a value or
+   `null`. A gap is explicit rather than inferred from an absent key, and a
+   recorded `0` stays `0`.
+3. Per-image chart and badge routes render from the same aggregate. The three
+   legacy routes — `/growth_bluefins.svg`,
+   `/sources/ublue-os/bluefin/growth.svg`, and `/badge-endpoints/bluefin.json` —
+   continue to proxy `ublue-os/countme`, and nothing else does.
+4. `/analytics` reads `/counts.json` at runtime and renders the panel from it,
+   falling back to a reasoned `Unavailable` when the service reports no weeks.
+5. `connect-src` in `docusaurus.config.ts` gains `https://countme.projectbluefin.io`.
+
+### Chart types
+
+- **Weekly active systems — multi-series line, zero-anchored, `connectNulls`
+  off, `smooth` off.** These are discrete weekly readings. A spline invents
+  values between measurements and a connected null bridges a week nobody
+  reported; both are claims the data does not support. The y-axis is anchored at
+  zero because a floating floor turns a flat series into a cliff.
+- **Series are separated by dash pattern and marker shape, not hue.** The
+  Bluefin categorical ramp is six shades of one blue, so hue alone cannot tell
+  two series apart. `seriesDash` already existed for this; marker shapes were
+  added alongside it. Both survive greyscale and colour-blind reading.
+- **Per-image SVG routes — single-series line with the current value printed as
+  text**, and an `accumulating data` panel below two points, so a chart embedded
+  outside the site carries the same guarantees as one inside it.
+
+### Where the first-party reader lives
+
+`src/components/analytics/firstPartyCountme.ts`, not in the component.
+`scripts/countme-first-party.test.js` forbids one file from holding both a
+catalogue of Project Bluefin image ids and a computed index into a countme week,
+because that pairing twice published a Fedora-derived number under a Project
+Bluefin name. The component holds the catalogue; the reader holds the week keys.
+Splitting them keeps the gate a gate instead of an exemption list.
+
+## Scope
+
+**In scope:**
+
+- `workers/countme-proxy/{index,routes,render}.mjs` and its tests.
+- The weekly active systems panel in
+  `src/components/analytics/CountmeAnalyticsCharts.tsx`.
+- `src/components/analytics/firstPartyCountme.ts`.
+- The `connect-src` entry in `docusaurus.config.ts`.
+
+**Out of scope:**
+
+- `scripts/fetch-countme.js` and the upstream peers pipeline. It correctly
+  publishes `aurora`, `bazzite`, and `fedora`, and this record does not reopen
+  that decision.
+- The publication matrix and the churn panels.
+- Any change to `ublue-os/*`.
+- Retention, sampling, or deduplication policy for `telemetry_events`.
+
+## Consequences
+
+Dakota, Utah, and Server report `accumulating data` until clients ping, and that
+is the honest state rather than a placeholder. Bluefin and Bluefin LTS restart
+from the first-party epoch, so the published series is shorter than the retired
+Fedora one and the two are not comparable; the method field records which is
+which.
+
+The page now depends on a service at request time rather than on build-time
+data, so a worker outage degrades the panel to its reasoned unavailable state
+instead of showing stale numbers. The `<details>` table and the summary keep the
+numbers reachable when the canvas does not paint.
+
+A count is now a measurement of pings, not of DNF metalink hits. It cannot be
+reconciled against Fedora's counters, and should not be presented as if it could.
+
+## Alternatives considered
+
+**Keep reading `countme-history.json` for Project Bluefin images.** Rejected: it
+is Fedora-derived, `isPermittedSource` rejects it, and it no longer carries the
+keys at all.
+
+**Point the chart routes at `ublue-os/countme` until first-party data
+accumulates.** Rejected: that is the EPEL-summed series ADR 0006 and `f846c652`
+removed. `/badge-endpoints/bluefin-lts.json` was the live instance of this and
+now serves from D1.
+
+**Create a `projectbluefin/countme` repository mirroring the upstream layout.**
+Rejected: it duplicates ingestion the worker already performs, adds a scheduled
+job and a second source of truth, and the D1 rows are already the measurement.
+
+**Generate the aggregate at build time into `static/data/`.** Rejected: counts
+accumulate continuously while the site rebuilds only on merge, so the published
+number would age with the deployment rather than with the data.
+
+**Log y-axis to fit Fedora's magnitude alongside Bluefin's.** Rejected here: the
+panel no longer plots Fedora, so the range that motivated it is gone, and a log
+axis is easy to misread on a page that does not otherwise use one.

--- a/docs/skills/cloudflare-workers.md
+++ b/docs/skills/cloudflare-workers.md
@@ -93,15 +93,30 @@ than reaching for `--legacy-peer-deps`.
 
 ## CountMe Worker (countme.projectbluefin.io)
 
-`workers/countme-proxy` handles two primary workloads:
+`workers/countme-proxy` handles three workloads:
 
-1. **Upstream Artifact Proxy:** Serves weekly growth charts (`/`, `/growth.svg`,
-   `/sources/projectbluefin/bluefin/growth.svg`) and shields.io badge endpoints
-   (`/badge-endpoints/{bluefin,bluefin-lts}.json`), falling back to a branded
-   pending SVG if projectbluefin artifacts have not yet populated.
-2. **Client Ingestion (`/metalink`):** Receives weekly anonymous countme pings
-   from Project Bluefin clients (`bluefin`, `bluefin-lts`, `dakota`).
-   - Query parameters: `repo` (e.g. `bluefin`, `bluefin-lts`, `dakota`), `tag`
+1. **First-party counts:** Every Project Bluefin series is aggregated from its
+   own D1 rows, never fetched from another service. One weekly query, grouped
+   by Monday-anchored week and `repo`, feeds `/counts.json`, the per-repo
+   charts (`/`, `/growth.svg`, `/<repo>/growth.svg`) and the shields.io badges
+   (`/badge-endpoints/<repo>.json`). `scripts/lib/countme-sources.mjs` is
+   imported directly rather than restated, so the Worker and the site enforce
+   one definition of where a count may come from.
+   - A repo with no rows in a week is `null`, never `0`: the service cannot
+     tell "nobody reported" from "nobody was running it". SVG charts break the
+     line at a gap instead of interpolating across it.
+   - Unbound binding, failing query, or zero rows all return HTTP 200 with
+     `unavailable: true` and `FIRST_PARTY_PENDING_REASON`. A counts endpoint
+     that 500s is a chart that renders nothing.
+2. **Upstream artifact proxy:** Only `ublue-os/bluefin:stable`, the upstream
+   pre-migration image — `/growth_bluefins.svg`,
+   `/sources/ublue-os/bluefin/growth.svg`, `/badge-endpoints/bluefin.json`.
+   That is the whole exception; every other `ublue-os/countme` series,
+   Bluefin LTS included, is EPEL-summed and may not be republished as ours.
+3. **Client ingestion (`/metalink`):** Receives weekly anonymous countme pings
+   from Project Bluefin clients and writes the rows the counts query reads.
+   - Query parameters: `repo` (one of `bluefin`, `bluefin-lts`, `dakota`,
+     `utah`, `server`), `tag`
      (e.g. `stable`), `flavor` (e.g. `main`), `arch` (`x86_64`, `aarch64`),
      `countme` (integer bucket 1–4).
    - Responses are HTTP 200 with `cache-control: no-store`.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
           "style-src 'self' 'unsafe-inline'",
           "img-src 'self' data: https:",
           "font-src 'self' data:",
-          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://projectbluefin.github.io https://hosted-projectbluefin-knuckle-gjvq.hive.hivecommons.dev https://hive.kubestellar.io",
+          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://projectbluefin.github.io https://hosted-projectbluefin-knuckle-gjvq.hive.hivecommons.dev https://hive.kubestellar.io https://countme.projectbluefin.io",
           "frame-src https://giscus.app https://www.youtube.com https://youtube.com https://insights.linuxfoundation.org",
         ].join("; "),
       },

--- a/scripts/countme-analytics-charts.test.js
+++ b/scripts/countme-analytics-charts.test.js
@@ -76,6 +76,19 @@ const {
   default: CountmeAnalyticsCharts,
 } = mod;
 
+// The first-party reader is its own module; see the note in the component.
+const { latestReading, reportingRepos } = loadTsxModule(
+  path.join(
+    __dirname,
+    "..",
+    "src",
+    "components",
+    "analytics",
+    "firstPartyCountme.ts",
+  ),
+  (id) => (id.endsWith(".css") ? {} : undefined),
+);
+
 const REGISTRY_FIXTURE = {
   generatedAt: "2026-09-10T04:08:30.490Z",
   source: "public-registry",
@@ -278,4 +291,140 @@ test("the matrix says why it is empty rather than rendering nothing", () => {
 
   assert.match(html, /data-what="Image stream matrix"/);
   assert.match(html, /data-reason="no token"/);
+});
+
+/**
+ * Weekly active systems, served by the first-party service.
+ *
+ * A week the service did not measure is `null` — a gap. A week it measured as
+ * zero is `0`. Collapsing those two into each other is the specific bug these
+ * tests exist to catch: it is the difference between "nobody reported" and
+ * "nobody was running it", and the chart draws them differently.
+ */
+const COUNTS_FIXTURE = {
+  generatedAt: "2026-09-12T00:00:00.000Z",
+  source: "https://countme.projectbluefin.io",
+  method: "first-party-d1-v1",
+  unit: "estimated weekly active systems",
+  variants: ["bluefin", "bluefin-lts", "dakota", "utah"],
+  weeks: [
+    {
+      week: "2026-08-17",
+      bluefin: 3510,
+      "bluefin-lts": 0,
+      dakota: null,
+      utah: null,
+    },
+    {
+      week: "2026-08-24",
+      bluefin: 3688,
+      "bluefin-lts": null,
+      dakota: 9,
+      utah: null,
+    },
+    {
+      week: "2026-08-31",
+      bluefin: 3901,
+      "bluefin-lts": null,
+      dakota: 14,
+      utah: null,
+    },
+  ],
+};
+
+function renderCounts(counts) {
+  return renderToStaticMarkup(
+    React.createElement(CountmeAnalyticsCharts, {
+      registry: REGISTRY_FIXTURE,
+      counts,
+    }),
+  );
+}
+
+test("a trailing gap reports the last week actually measured", () => {
+  // bluefin-lts last reported in 2026-08-17 and has been a gap since. Reading
+  // forwards would call it null and hide a real number; coercing the gap to 0
+  // would claim the fleet emptied. Neither is true.
+  assert.deepEqual(latestReading(COUNTS_FIXTURE.weeks, "bluefin-lts"), {
+    value: 0,
+    week: "2026-08-17",
+  });
+  assert.deepEqual(latestReading(COUNTS_FIXTURE.weeks, "bluefin"), {
+    value: 3901,
+    week: "2026-08-31",
+  });
+});
+
+test("a repo that never reported is not a series", () => {
+  // utah is null in every week. Included, it would draw as a flat line on the
+  // floor and read as "zero systems" rather than "not counted yet".
+  const repos = reportingRepos(COUNTS_FIXTURE.weeks);
+  assert.ok(repos.includes("bluefin"));
+  assert.ok(repos.includes("dakota"));
+  assert.ok(!repos.includes("utah"));
+  assert.deepEqual(reportingRepos([]), []);
+});
+
+test("a measured zero is a reading, not a gap", () => {
+  const weeks = [{ week: "2026-08-17", bluefin: 0 }];
+  assert.deepEqual(reportingRepos(weeks), ["bluefin"]);
+  assert.deepEqual(latestReading(weeks, "bluefin"), {
+    value: 0,
+    week: "2026-08-17",
+  });
+});
+
+test("the chart carries gaps through to the series, never zeros", () => {
+  const html = renderCounts(COUNTS_FIXTURE);
+  const option = JSON.parse(
+    html
+      .match(
+        /data-title="Weekly active systems"[\s\S]*?data-option="([^"]*)"/,
+      )[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&"),
+  );
+
+  const lts = option.series.find((s) => s.name === "Bluefin LTS");
+  assert.deepEqual(lts.data, [0, null, null]);
+  assert.equal(lts.connectNulls, false, "a gap must break the line");
+  assert.equal(lts.smooth, false, "a spline invents values between weeks");
+
+  const dakota = option.series.find((s) => s.name === "Project Bluefin Dakota");
+  assert.deepEqual(dakota.data, [null, 9, 14]);
+
+  assert.ok(
+    !option.series.some((s) => s.name === "Project Bluefin Utah"),
+    "a repo with no readings must not be plotted",
+  );
+  assert.equal(
+    option.yAxis.min,
+    0,
+    "a floating floor exaggerates a flat series",
+  );
+});
+
+test("every plotted series states its current number", () => {
+  // Presentation rule 1: the graphic never carries a claim on its own.
+  const html = renderCounts(COUNTS_FIXTURE);
+  const summary = html.match(
+    /data-title="Weekly active systems"[\s\S]*?data-summary="([^"]*)"/,
+  )[1];
+
+  assert.match(summary, /Bluefin 3,901 \(week 2026-08-31\)/);
+  assert.match(summary, /Bluefin LTS 0 \(week 2026-08-17\)/);
+  assert.match(summary, /Project Bluefin Dakota 14 \(week 2026-08-31\)/);
+});
+
+test("the panel stays unavailable when the service reports no weeks", () => {
+  const html = renderCounts({
+    unavailable: true,
+    stateReason: "Weekly active systems are not published yet.",
+    weeks: [],
+  });
+  const panel = html.match(
+    /data-what="Weekly active systems"[^>]*data-reason="([^"]*)"/,
+  );
+  assert.ok(panel, "an empty aggregate must still render a reasoned panel");
+  assert.doesNotMatch(panel[1], /projectbluefin\.io/);
 });

--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -1,87 +1,527 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-let mapRequestPath;
-let createPendingProjectbluefinSvg;
+const fs = require("node:fs");
+const path = require("node:path");
+
+let routes;
+let render;
+let policy;
 let fetchHandler;
 
+const repoRoot = path.join(__dirname, "..");
+
 test.before(async () => {
-  const routes = await import("../workers/countme-proxy/routes.mjs");
+  routes = await import("../workers/countme-proxy/routes.mjs");
+  render = await import("../workers/countme-proxy/render.mjs");
+  policy = await import("./lib/countme-sources.mjs");
   const mod = await import("../workers/countme-proxy/index.mjs");
-  mapRequestPath = routes.mapRequestPath;
-  createPendingProjectbluefinSvg = routes.createPendingProjectbluefinSvg;
   fetchHandler = mod.default.fetch;
 });
 
-test("maps legacy Bluefin source route to ublue-os countme artifact", () => {
-  const mapped = mapRequestPath("/sources/ublue-os/bluefin/growth.svg");
-  assert.equal(
-    mapped,
-    "https://raw.githubusercontent.com/ublue-os/countme/main/growth_bluefins.svg",
+const UBLUE_RAW_PREFIX = "https://raw.githubusercontent.com/ublue-os/countme/";
+const WORKER_SOURCES = [
+  "workers/countme-proxy/index.mjs",
+  "workers/countme-proxy/routes.mjs",
+  "workers/countme-proxy/render.mjs",
+];
+
+/**
+ * A D1 stand-in. `rows` are what the weekly aggregate returns; `throws` makes
+ * the query fail the way an unmigrated or unreachable database would.
+ */
+function stubDb(rows, { throws = false } = {}) {
+  const statements = [];
+  return {
+    statements,
+    env: {
+      DB: {
+        prepare(sql) {
+          return {
+            bind(...args) {
+              statements.push({ sql, args });
+              return {
+                async all() {
+                  if (throws) throw new Error("no such table");
+                  return { results: rows };
+                },
+                async run() {
+                  if (throws) throw new Error("no such table");
+                },
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+/** Replaces global fetch for one test and records every requested URL. */
+function stubFetch(responder) {
+  const calls = [];
+  const original = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push(url);
+    return responder(url, init);
+  };
+
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function get(pathname, env) {
+  return fetchHandler(
+    new Request(`https://countme.projectbluefin.io${pathname}`),
+    env,
+  );
+}
+
+/** All `d` attributes of the rendered polyline segments. */
+function pathData(svg) {
+  return [...svg.matchAll(/<path d="([^"]+)"/gu)].map((match) => match[1]);
+}
+
+function pathPoints(d) {
+  return [...d.matchAll(/[ML](-?[\d.]+) (-?[\d.]+)/gu)].map((match) => ({
+    x: Number(match[1]),
+    y: Number(match[2]),
+  }));
+}
+
+test("no worker source names a forbidden count source", async () => {
+  const { FORBIDDEN_SOURCES } = policy;
+
+  for (const rel of WORKER_SOURCES) {
+    const src = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+    for (const forbidden of FORBIDDEN_SOURCES) {
+      assert.ok(
+        !src.includes(forbidden),
+        `${rel} names ${forbidden}; a Project Bluefin count comes from our own deployment`,
+      );
+    }
+    assert.ok(
+      !src.includes("countme-history.json"),
+      `${rel} reads the Fedora-derived dataset`,
+    );
+  }
+});
+
+test("only the upstream image keeps an upstream source", () => {
+  const { UPSTREAM_ALLOWED } = policy;
+
+  assert.deepEqual(routes.resolveRoute("/badge-endpoints/bluefin.json"), {
+    kind: "legacy",
+    url: UPSTREAM_ALLOWED.source,
+  });
+  assert.deepEqual(routes.resolveRoute("/growth_bluefins.svg"), {
+    kind: "legacy",
+    url: `${UBLUE_RAW_PREFIX}main/growth_bluefins.svg`,
+  });
+  assert.deepEqual(
+    routes.resolveRoute("/sources/ublue-os/bluefin/growth.svg"),
+    {
+      kind: "legacy",
+      url: `${UBLUE_RAW_PREFIX}main/growth_bluefins.svg`,
+    },
+  );
+
+  // The EPEL-summed upstream LTS series is not ours to republish.
+  assert.deepEqual(routes.resolveRoute("/badge-endpoints/bluefin-lts.json"), {
+    kind: "badge",
+    repo: "bluefin-lts",
+  });
+  assert.equal(Object.keys(routes.LEGACY_ROUTES).length, 3);
+});
+
+test("every first-party repo has a chart and a badge route", () => {
+  for (const repo of policy.PROJECTBLUEFIN_REPOS) {
+    assert.deepEqual(routes.resolveRoute(`/${repo}/growth.svg`), {
+      kind: "chart",
+      repo,
+    });
+  }
+
+  for (const alias of [
+    "/",
+    "/growth.svg",
+    "/sources/projectbluefin/bluefin/growth.svg",
+  ]) {
+    assert.deepEqual(routes.resolveRoute(alias), {
+      kind: "chart",
+      repo: "bluefin",
+    });
+  }
+
+  for (const repo of ["bluefin-lts", "dakota", "utah", "server"]) {
+    assert.deepEqual(routes.resolveRoute(`/badge-endpoints/${repo}.json`), {
+      kind: "badge",
+      repo,
+    });
+  }
+
+  assert.deepEqual(routes.resolveRoute("/counts.json"), { kind: "counts" });
+  assert.equal(routes.resolveRoute("/nope"), null);
+  assert.deepEqual(routes.resolveRoute("/dakota/growth.svg/"), {
+    kind: "chart",
+    repo: "dakota",
+  });
+});
+
+test("counts.json aggregates weekly records per first-party repo", async () => {
+  const db = stubDb([
+    { week: "2026-08-31", repo: "bluefin", hits: 3552 },
+    { week: "2026-08-31", repo: "bluefin-lts", hits: 194 },
+    { week: "2026-09-07", repo: "bluefin", hits: 3601 },
+  ]);
+
+  const response = await get("/counts.json", db.env);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.source, policy.FIRST_PARTY.origin);
+  assert.equal(body.method, "first-party-d1-v1");
+  assert.equal(body.unit, "estimated weekly active systems");
+  assert.ok(!body.unavailable);
+  assert.deepEqual(body.variants, ["bluefin", "bluefin-lts"]);
+  assert.deepEqual(body.weeks, [
+    {
+      week: "2026-08-31",
+      bluefin: 3552,
+      "bluefin-lts": 194,
+      dakota: null,
+      utah: null,
+      server: null,
+    },
+    {
+      week: "2026-09-07",
+      bluefin: 3601,
+      "bluefin-lts": null,
+      dakota: null,
+      utah: null,
+      server: null,
+    },
+  ]);
+
+  assert.ok(db.statements[0].sql.includes("telemetry_events"));
+  assert.deepEqual(db.statements[0].args, [...policy.PROJECTBLUEFIN_REPOS]);
+});
+
+test("a repo missing from a week is null, never zero", async () => {
+  const db = stubDb([{ week: "2026-08-31", repo: "bluefin", hits: 3552 }]);
+
+  const response = await get("/counts.json", db.env);
+  const text = await response.text();
+  const week = JSON.parse(text).weeks[0];
+
+  assert.equal(week.dakota, null);
+  assert.ok("dakota" in week, "the key is present so the gap is explicit");
+  assert.match(text, /"dakota":null/u);
+  assert.ok(
+    !/"dakota":0/u.test(text),
+    "a silent repo is never counted as zero",
   );
 });
 
-test("maps projectbluefin source route to projectbluefin countme artifact", () => {
-  const mapped = mapRequestPath("/sources/projectbluefin/bluefin/growth.svg");
+test("a week nobody reported stays on the axis as a gap", async () => {
+  const db = stubDb([
+    { week: "2026-08-31", repo: "bluefin", hits: 10 },
+    { week: "2026-09-14", repo: "bluefin", hits: 30 },
+  ]);
+
+  const body = await (await get("/counts.json", db.env)).json();
+
+  assert.deepEqual(
+    body.weeks.map((week) => week.week),
+    ["2026-08-31", "2026-09-07", "2026-09-14"],
+  );
+  assert.equal(body.weeks[1].bluefin, null);
+});
+
+test("counts.json declares a source every first-party repo may use", async () => {
+  const db = stubDb([{ week: "2026-08-31", repo: "utah", hits: 7 }]);
+  const text = await (await get("/counts.json", db.env)).text();
+  const body = JSON.parse(text);
+
+  for (const repo of policy.PROJECTBLUEFIN_REPOS) {
+    assert.ok(
+      policy.isPermittedSource(repo, body.source),
+      `${repo} may not be published from ${body.source}`,
+    );
+  }
+
+  for (const forbidden of policy.FORBIDDEN_SOURCES) {
+    assert.ok(!text.includes(forbidden));
+  }
+});
+
+test("counts.json is cacheable and readable cross-origin", async () => {
+  const db = stubDb([{ week: "2026-08-31", repo: "utah", hits: 7 }]);
+  const response = await get("/counts.json", db.env);
+
   assert.equal(
-    mapped,
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+    response.headers.get("content-type"),
+    "application/json;charset=UTF-8",
+  );
+  assert.equal(response.headers.get("cache-control"), "public, max-age=900");
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+});
+
+test("an unbound database yields a pending document at HTTP 200", async () => {
+  const response = await get("/counts.json", {});
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.unavailable, true);
+  assert.equal(body.stateReason, policy.FIRST_PARTY_PENDING_REASON);
+  assert.deepEqual(body.weeks, []);
+  assert.deepEqual(body.variants, []);
+  assert.equal(body.source, policy.FIRST_PARTY.origin);
+});
+
+test("a failing query yields a pending document at HTTP 200", async () => {
+  const db = stubDb([], { throws: true });
+  const response = await get("/counts.json", db.env);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.unavailable, true);
+  assert.equal(body.stateReason, policy.FIRST_PARTY_PENDING_REASON);
+});
+
+test("an empty database yields a pending document at HTTP 200", async () => {
+  const db = stubDb([]);
+  const body = await (await get("/counts.json", db.env)).json();
+
+  assert.equal(body.unavailable, true);
+  assert.equal(body.stateReason, policy.FIRST_PARTY_PENDING_REASON);
+});
+
+test("charts and badges render from the database without leaving the edge", async () => {
+  const db = stubDb([
+    { week: "2026-08-31", repo: "bluefin-lts", hits: 100 },
+    { week: "2026-09-07", repo: "bluefin-lts", hits: 194 },
+  ]);
+  const stub = stubFetch(async () => new Response("", { status: 500 }));
+
+  try {
+    const chart = await get("/bluefin-lts/growth.svg", db.env);
+    const svg = await chart.text();
+
+    assert.equal(
+      chart.headers.get("content-type"),
+      "image/svg+xml; charset=UTF-8",
+    );
+    assert.equal(chart.headers.get("cache-control"), "public, max-age=900");
+    assert.match(svg, /Bluefin LTS/u);
+    assert.match(svg, />194</u);
+
+    const badge = await get("/badge-endpoints/bluefin-lts.json", db.env);
+    assert.deepEqual(await badge.json(), {
+      schemaVersion: 1,
+      label: "Bluefin LTS",
+      message: "194",
+      color: "bc8cff",
+    });
+
+    const empty = await get("/badge-endpoints/dakota.json", db.env);
+    assert.equal((await empty.json()).message, "accumulating");
+  } finally {
+    stub.restore();
+  }
+
+  assert.deepEqual(
+    stub.calls,
+    [],
+    "a first-party count never leaves the edge for another service",
   );
 });
 
-test("maps root-host chart aliases to projectbluefin countme artifact", () => {
-  assert.equal(
-    mapRequestPath("/"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+test("an unbound database still renders an accumulating chart", async () => {
+  const stub = stubFetch(async () => new Response("", { status: 500 }));
+
+  try {
+    const response = await get("/bluefin/growth.svg", {});
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(svg, /Bluefin — accumulating data/u);
+    assert.match(svg, /0 weekly data points recorded/u);
+  } finally {
+    stub.restore();
+  }
+
+  assert.deepEqual(stub.calls, []);
+});
+
+test("legacy routes proxy the upstream artifacts", async () => {
+  const stub = stubFetch(
+    async () =>
+      new Response("<svg/>", {
+        status: 200,
+        headers: { "content-type": "image/svg+xml" },
+      }),
   );
-  assert.equal(
-    mapRequestPath("/growth.svg"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+
+  try {
+    for (const pathname of [
+      "/growth_bluefins.svg",
+      "/sources/ublue-os/bluefin/growth.svg",
+      "/badge-endpoints/bluefin.json",
+    ]) {
+      assert.equal((await get(pathname, {})).status, 200);
+    }
+  } finally {
+    stub.restore();
+  }
+
+  assert.equal(stub.calls.length, 3);
+  assert.ok(stub.calls.every((url) => url.startsWith(UBLUE_RAW_PREFIX)));
+  assert.ok(stub.calls.includes(policy.UPSTREAM_ALLOWED.source));
+});
+
+test("breaks the line at a missing week instead of interpolating or zeroing", () => {
+  const svg = render.renderRepoChartSvg(
+    {
+      weeks: [
+        { week: "2026-01-05", dakota: 10 },
+        { week: "2026-01-12", dakota: 20 },
+        { week: "2026-01-19", dakota: null },
+        { week: "2026-01-26", dakota: 40 },
+        { week: "2026-02-02", dakota: 50 },
+      ],
+    },
+    "dakota",
   );
-  assert.equal(
-    mapRequestPath("/bluefin/growth.svg"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+
+  const paths = pathData(svg);
+  assert.equal(paths.length, 2, "a gap must split the series into two paths");
+
+  const segments = paths.map(pathPoints);
+  assert.deepEqual(
+    segments.map((points) => points.length),
+    [2, 2],
+    "the gap week must not contribute a vertex",
   );
-  assert.equal(
-    mapRequestPath("/bluefin-lts/growth.svg"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+
+  const interpolatedX = (segments[0][1].x + segments[1][0].x) / 2;
+  const plotted = segments.flat();
+  assert.ok(
+    plotted.every((point) => point.x !== interpolatedX),
+    "no vertex may sit at the interpolated gap position",
   );
-  assert.equal(
-    mapRequestPath("/dakota/growth.svg"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
-  );
-  assert.equal(
-    mapRequestPath("/utah/growth.svg"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg",
+
+  const baseline = Math.max(...plotted.map((point) => point.y));
+  assert.ok(
+    plotted.every((point) => point.y <= baseline),
+    "a gap must never be drawn down at the baseline",
   );
 });
 
-test("maps Bluefin, Dakota, and Utah badge endpoints", () => {
-  assert.equal(
-    mapRequestPath("/badge-endpoints/bluefin.json"),
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
+test("plots a recorded zero as a point rather than a gap", () => {
+  const svg = render.renderRepoChartSvg(
+    {
+      weeks: [
+        { week: "2026-01-05", dakota: 0 },
+        { week: "2026-01-12", dakota: 5 },
+        { week: "2026-01-19", dakota: 10 },
+      ],
+    },
+    "dakota",
   );
-  assert.equal(
-    mapRequestPath("/badge-endpoints/bluefin-lts.json"),
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
+
+  const paths = pathData(svg);
+  assert.equal(paths.length, 1);
+  assert.equal(pathPoints(paths[0]).length, 3);
+  assert.match(svg, />0</u);
+});
+
+test("prints the current value and its week as text in the chart", () => {
+  const svg = render.renderRepoChartSvg(
+    {
+      weeks: [
+        { week: "2026-07-13", bluefin: 3900 },
+        { week: "2026-07-20", bluefin: 4095 },
+        { week: "2026-07-27", bluefin: null },
+      ],
+    },
+    "bluefin",
   );
-  assert.equal(
-    mapRequestPath("/badge-endpoints/dakota.json"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/dakota.json",
+
+  assert.match(svg, />4,095</u);
+  assert.match(svg, /week of 2026-07-20/u);
+  assert.match(
+    svg,
+    /aria-label="[^"]*current 4,095 for the week of 2026-07-20/u,
   );
-  assert.equal(
-    mapRequestPath("/badge-endpoints/utah.json"),
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/utah.json",
+  assert.match(svg, /role="img"/u);
+});
+
+test("renders accumulating data when a repo has fewer than two points", () => {
+  const empty = render.renderRepoChartSvg(
+    { weeks: [{ week: "2026-01-05", bluefin: 10 }] },
+    "dakota",
+  );
+  assert.match(empty, /Dakota — accumulating data/u);
+  assert.match(empty, /0 weekly data points recorded/u);
+  assert.equal(pathData(empty).length, 0);
+
+  const single = render.renderRepoChartSvg(
+    {
+      weeks: [
+        { week: "2026-01-05", utah: 7 },
+        { week: "2026-01-12", utah: null },
+      ],
+    },
+    "utah",
+  );
+  assert.match(single, /Utah — accumulating data/u);
+  assert.match(single, /1 weekly data point recorded/u);
+  assert.match(
+    single,
+    /aria-label="Utah accumulating data, 1 weekly data point recorded"/u,
   );
 });
 
-test("returns null for unknown route", () => {
-  assert.equal(mapRequestPath("/nope"), null);
-});
+test("published svg copy describes the data, never the infrastructure", () => {
+  const svgs = [
+    render.renderAccumulatingSvg("dakota", 0),
+    render.renderRepoChartSvg(
+      {
+        weeks: [
+          { week: "2026-01-05", bluefin: 10 },
+          { week: "2026-01-12", bluefin: 20 },
+        ],
+      },
+      "bluefin",
+    ),
+  ];
 
-test("renders pending projectbluefin svg message", () => {
-  const svg = createPendingProjectbluefinSvg();
-  assert.match(svg, /projectbluefin\/bluefin countme chart pending/i);
-  assert.match(svg, /<svg/i);
+  for (const svg of svgs) {
+    const copy = [...svg.matchAll(/>([^<>]+)</gu)].map((m) => m[1]).join(" ");
+    for (const banned of [
+      /projectbluefin\.io/iu,
+      /\bendpoint\b/iu,
+      /\bD1\b/u,
+      /cloudflare/iu,
+      /\bworker\b/iu,
+      /https?:\/\//u,
+      /telemetry/iu,
+    ]) {
+      assert.doesNotMatch(copy, banned);
+    }
+  }
+
+  assert.ok(
+    render
+      .renderAccumulatingSvg("dakota", 0)
+      .includes(policy.FIRST_PARTY_PENDING_REASON),
+  );
 });
 
 test("accepts metalink pings from Dakota countme clients", async () => {
@@ -99,8 +539,44 @@ test("accepts metalink pings from Dakota countme clients", async () => {
   );
   assert.match(
     await response.text(),
-    /countme accepted for repo=dakota tag=latest flavor=default arch=x86_64 countme=3/i,
+    /countme accepted for repo=dakota tag=latest flavor=default gamemode=0 arch=x86_64 countme=3/i,
   );
+});
+
+test("accepts metalink pings with gamemode enabled and persists to D1", async () => {
+  const inserted = [];
+  const mockEnv = {
+    DB: {
+      prepare(sql) {
+        return {
+          bind(...args) {
+            return {
+              async run() {
+                inserted.push({ sql, args });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+
+  const request = new Request(
+    "https://countme.projectbluefin.io/metalink?repo=dakota&tag=testing&flavor=gaming&gamemode=1&arch=x86_64&countme=1",
+  );
+
+  const response = await fetchHandler(request, mockEnv);
+
+  assert.equal(response.status, 200);
+  assert.match(
+    await response.text(),
+    /countme accepted for repo=dakota tag=testing flavor=gaming gamemode=1 arch=x86_64 countme=1/i,
+  );
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].args[0], "dakota");
+  assert.equal(inserted[0].args[1], "testing");
+  assert.equal(inserted[0].args[2], "gaming");
+  assert.equal(inserted[0].args[5], 1); // gamemode
 });
 
 test("accepts metalink pings from Bluefin countme clients", async () => {
@@ -118,7 +594,7 @@ test("accepts metalink pings from Bluefin countme clients", async () => {
   );
   assert.match(
     await response.text(),
-    /countme accepted for repo=bluefin tag=stable flavor=main arch=x86_64 countme=2/i,
+    /countme accepted for repo=bluefin tag=stable flavor=main gamemode=0 arch=x86_64 countme=2/i,
   );
 });
 
@@ -137,7 +613,7 @@ test("accepts metalink pings from Bluefin LTS countme clients", async () => {
   );
   assert.match(
     await response.text(),
-    /countme accepted for repo=bluefin-lts tag=stable flavor=main arch=x86_64 countme=4/i,
+    /countme accepted for repo=bluefin-lts tag=stable flavor=main gamemode=0 arch=x86_64 countme=4/i,
   );
 });
 
@@ -156,16 +632,6 @@ test("accepts metalink pings from Utah countme clients", async () => {
   );
   assert.match(
     await response.text(),
-    /countme accepted for repo=utah tag=testing flavor=default arch=x86_64 countme=1/i,
+    /countme accepted for repo=utah tag=testing flavor=default gamemode=0 arch=x86_64 countme=1/i,
   );
-});
-
-test("renders pending projectbluefin svg message with specific variant", () => {
-  const dakotaSvg = createPendingProjectbluefinSvg("dakota");
-  assert.match(dakotaSvg, /projectbluefin\/dakota countme chart pending/i);
-  assert.match(dakotaSvg, /Dakota countme\.projectbluefin\.io configured/i);
-
-  const utahSvg = createPendingProjectbluefinSvg("utah");
-  assert.match(utahSvg, /projectbluefin\/utah countme chart pending/i);
-  assert.match(utahSvg, /Utah countme\.projectbluefin\.io configured/i);
 });

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -6,10 +6,20 @@ import EChart from "../factory/EChart";
 import Unavailable from "../factory/Unavailable";
 import {
   readableInk,
+  seriesDash,
   withAlpha,
   type SeverityLevel,
 } from "../factory/chartTheme";
 import { FIRST_PARTY_PENDING_REASON } from "@site/scripts/lib/countme-sources.mjs";
+import {
+  COUNTS_URL,
+  latestReading,
+  measuredWeekCount,
+  reportingRepos,
+  repoSeries,
+  weekLabels,
+  type CountmeDataset,
+} from "./firstPartyCountme";
 import { useFactoryTheme } from "../factory/useFactoryTheme";
 import "../factory/tokens.css";
 import styles from "./CountmeAnalyticsCharts.module.css";
@@ -20,6 +30,42 @@ import styles from "./CountmeAnalyticsCharts.module.css";
  * exist fails the build instead of rendering a panel that says why.
  */
 const REGISTRY_URL = "/data/ghcr-packages.json";
+
+/**
+ * Weekly active systems come from the first-party service and nothing else.
+ *
+ * The reader lives in `./firstPartyCountme`, and is imported rather than
+ * re-exported from here. This file holds the image catalogue, and
+ * `scripts/countme-first-party.test.js` forbids one file from holding both a
+ * catalogue of our image ids and a computed index into a countme week. That
+ * pairing twice published a Fedora-derived number under a Project Bluefin name,
+ * so the two stay in separate files and the gate stays a real gate.
+ */
+
+/** Display names for the first-party `repo` identifiers. */
+export const REPO_LABELS: Record<string, string> = {
+  bluefin: "Bluefin",
+  "bluefin-lts": "Bluefin LTS",
+  dakota: "Project Bluefin Dakota",
+  utah: "Project Bluefin Utah",
+  server: "Bluefin Server",
+};
+
+/**
+ * Marker shapes, paired with the palette index like `seriesDash`.
+ *
+ * The Bluefin categorical ramp is six shades of a single blue, so hue alone
+ * cannot tell two series apart. Shape and dash carry the distinction instead,
+ * which is also what makes the chart readable in greyscale.
+ */
+export const SERIES_SYMBOLS = [
+  "circle",
+  "triangle",
+  "diamond",
+  "rect",
+  "pin",
+  "arrow",
+] as const;
 
 /** One published tag of one GHCR package, as `scripts/fetch-ghcr-packages.js` writes it. */
 export interface GhcrStream {
@@ -264,10 +310,13 @@ export function buildStreamMatrix(
 
 export interface CountmeAnalyticsChartsProps {
   registry?: GhcrDataset;
+  /** Injected by tests; production fetches the first-party aggregate. */
+  counts?: CountmeDataset;
 }
 
 export default function CountmeAnalyticsCharts({
   registry,
+  counts,
 }: CountmeAnalyticsChartsProps = {}): React.JSX.Element {
   const [themeRef, fxTheme] = useFactoryTheme();
   const cat = fxTheme.categorical;
@@ -294,6 +343,103 @@ export default function CountmeAnalyticsCharts({
       }
     })();
   }, [base, registry]);
+
+  // ── Weekly active systems, first-party only ────────────────────────────
+  const [fetchedCounts, setFetchedCounts] = useState<CountmeDataset | null>(
+    null,
+  );
+  const [countsReason, setCountsReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (counts) return;
+    void (async () => {
+      try {
+        const res = await fetch(COUNTS_URL);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        setFetchedCounts((await res.json()) as CountmeDataset);
+      } catch {
+        // The reason is deliberately generic. A panel reason is published copy,
+        // and commit 5a5269bc removed internal service posture from this page.
+        setCountsReason(FIRST_PARTY_PENDING_REASON);
+      }
+    })();
+  }, [counts]);
+
+  const countsData = counts ?? fetchedCounts;
+  const countmeWeeks = countsData?.weeks ?? [];
+  const activeRepos = useMemo(
+    () => reportingRepos(countmeWeeks),
+    [countmeWeeks],
+  );
+
+  /** Readings that exist, so the panel can print a number per series. */
+  const countmeReadings = useMemo(
+    () =>
+      activeRepos.map((repo) => ({
+        repo,
+        label: REPO_LABELS[repo] ?? repo,
+        reading: latestReading(countmeWeeks, repo),
+      })),
+    [activeRepos, countmeWeeks],
+  );
+
+  /** Rule 5: the point count is real readings, not axis length. */
+  const countmePoints = useMemo(
+    () => measuredWeekCount(countmeWeeks, activeRepos),
+    [countmeWeeks, activeRepos],
+  );
+
+  const countmeOption = useMemo(
+    () => ({
+      grid: { left: 56, right: 24, top: 16, bottom: 48, containLabel: true },
+      tooltip: { trigger: "axis" },
+      xAxis: {
+        type: "category",
+        data: weekLabels(countmeWeeks),
+      },
+      // Anchored at zero: a floating floor turns a flat series into a cliff.
+      yAxis: { type: "value", min: 0 },
+      series: activeRepos.map((repo, i) => ({
+        name: REPO_LABELS[repo] ?? repo,
+        type: "line",
+        // Rule 4: discrete weekly readings. No spline between them, and a
+        // missing week breaks the line rather than being bridged or zeroed.
+        smooth: false,
+        connectNulls: false,
+        showSymbol: true,
+        symbolSize: 7,
+        // The Bluefin palette is six shades of one hue, so colour alone cannot
+        // separate series. chartTheme pairs each index with a dash pattern and a
+        // symbol for exactly this; both survive greyscale and colour blindness.
+        symbol: SERIES_SYMBOLS[i % SERIES_SYMBOLS.length],
+        data: repoSeries(countmeWeeks, repo),
+        itemStyle: { color: cat[i % cat.length] },
+        lineStyle: {
+          width: 2,
+          color: cat[i % cat.length],
+          type: seriesDash(i),
+        },
+      })),
+    }),
+    [countmeWeeks, activeRepos, cat],
+  );
+
+  /**
+   * Rule 1, in prose: the summary carries the current number for every series,
+   * so the chart is never the sole holder of the claim. A series whose latest
+   * weeks are a gap reports the last week it was actually measured.
+   */
+  const countmeSummary = useMemo(() => {
+    if (!countmeReadings.length) return FIRST_PARTY_PENDING_REASON;
+    const parts = countmeReadings.map(({ label, reading }) =>
+      reading
+        ? `${label} ${reading.value.toLocaleString()} (week ${reading.week})`
+        : `${label} accumulating data`,
+    );
+    return `Weekly active systems across ${countmePoints} measured week${
+      countmePoints === 1 ? "" : "s"
+    } — ${parts.join(", ")}.`;
+  }, [countmeReadings, countmePoints]);
 
   const ghcr = registry ?? fetchedRegistry;
 
@@ -396,10 +542,46 @@ export default function CountmeAnalyticsCharts({
           </Heading>
         </header>
 
-        <Unavailable
-          what="Weekly active systems"
-          reason={FIRST_PARTY_PENDING_REASON}
-        />
+        {countmePoints > 0 ? (
+          <>
+            {/* Rule 1: every series states its current number, in text, next
+                to the graphic rather than only inside it. */}
+            <p className={styles.legendRow}>
+              {countmeReadings.map(({ repo, label, reading }, i) => (
+                <span key={repo} className={styles.legendChip}>
+                  <span
+                    className={styles.legendGlyph}
+                    aria-hidden="true"
+                    style={{ color: cat[i % cat.length] }}
+                  >
+                    ●
+                  </span>
+                  {label}:{" "}
+                  {reading ? reading.value.toLocaleString() : "accumulating"}
+                </span>
+              ))}
+            </p>
+            <EChart
+              option={countmeOption}
+              title="Weekly active systems"
+              summary={countmeSummary}
+              points={countmePoints}
+              minPoints={2}
+              height={300}
+              tableCaption="Weekly active systems by image, from the first-party countme service"
+            />
+          </>
+        ) : (
+          // Rule 6: unavailability is visible and carries its reason.
+          <Unavailable
+            what="Weekly active systems"
+            reason={
+              countsData?.stateReason ??
+              countsReason ??
+              FIRST_PARTY_PENDING_REASON
+            }
+          />
+        )}
       </section>
 
       {/* ── 2. Image × stream publication matrix ────────────────────────── */}

--- a/src/components/analytics/firstPartyCountme.ts
+++ b/src/components/analytics/firstPartyCountme.ts
@@ -1,0 +1,111 @@
+import {
+  FIRST_PARTY,
+  PROJECTBLUEFIN_REPOS,
+} from "@site/scripts/lib/countme-sources.mjs";
+
+/**
+ * Reading weekly active systems from the first-party countme service.
+ *
+ * This module is deliberately separate from the component that renders it.
+ * `scripts/countme-first-party.test.js` forbids a file that holds the image
+ * catalogue from also indexing a countme week by a computed key, because that
+ * exact shape twice published a Fedora-derived number under a Project Bluefin
+ * name. Keeping the reader here means the catalogue and the week keys never sit
+ * in one file, and the rule stays a real gate rather than an exemption list.
+ *
+ * Everything below reads one dataset only: the aggregate served by
+ * `countme.projectbluefin.io`, whose `source` the policy module permits.
+ */
+
+/**
+ * The aggregate is fetched at runtime rather than built into the site because
+ * it accumulates continuously, while the site rebuilds only on merge.
+ */
+export const COUNTS_URL = `${FIRST_PARTY.origin}/counts.json`;
+
+/** One week of first-party counts. A missing repo is `null` — a gap, never 0. */
+export interface CountmeWeek {
+  week: string;
+  [repo: string]: string | number | null | undefined;
+}
+
+export interface CountmeDataset {
+  generatedAt?: string;
+  source?: string;
+  method?: string;
+  unit?: string;
+  variants?: string[];
+  weeks?: CountmeWeek[];
+  unavailable?: boolean;
+  stateReason?: string | null;
+}
+
+/**
+ * Parse a raw count, preserving 0 as a real measurement.
+ *
+ * `0` and `null` are different claims: "nobody was running it" against "nobody
+ * reported". Returns null for undefined, null, empty string, and non-finite.
+ */
+export function parseReading(val: unknown): number | null {
+  if (val === null || val === undefined || val === "") return null;
+  const n = typeof val === "number" ? val : Number(val);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Latest real reading for a repo, with the week it belongs to.
+ *
+ * Reads backwards so a trailing gap does not read as "no data": the number is
+ * the most recent one actually measured, and the caller states its week rather
+ * than implying it is current.
+ */
+export function latestReading(
+  weeks: CountmeWeek[],
+  repo: string,
+): { value: number; week: string } | null {
+  for (let i = weeks.length - 1; i >= 0; i -= 1) {
+    const value = parseReading(weeks[i]?.[repo]);
+    if (value !== null) return { value, week: String(weeks[i].week) };
+  }
+  return null;
+}
+
+/**
+ * Repos carrying at least one real reading, in policy order.
+ *
+ * A repo that never reported is excluded rather than plotted: a series of all
+ * gaps draws as a flat line on the floor and reads as "zero systems".
+ */
+export function reportingRepos(weeks: CountmeWeek[]): string[] {
+  return (PROJECTBLUEFIN_REPOS as readonly string[]).filter((repo) =>
+    weeks.some((w) => parseReading(w[repo]) !== null),
+  );
+}
+
+/** A repo's series across the week axis, gaps preserved as null. */
+export function repoSeries(
+  weeks: CountmeWeek[],
+  repo: string,
+): Array<number | null> {
+  return weeks.map((w) => parseReading(w[repo]));
+}
+
+/** The week axis, as category labels. */
+export function weekLabels(weeks: CountmeWeek[]): string[] {
+  return weeks.map((w) => String(w.week));
+}
+
+/**
+ * Weeks carrying at least one real reading.
+ *
+ * This is the count presentation rule 5 tests against, so an axis padded with
+ * empty weeks cannot pass for accumulated data.
+ */
+export function measuredWeekCount(
+  weeks: CountmeWeek[],
+  repos: string[],
+): number {
+  return weeks.filter((w) =>
+    repos.some((repo) => parseReading(w[repo]) !== null),
+  ).length;
+}

--- a/workers/countme-proxy/index.mjs
+++ b/workers/countme-proxy/index.mjs
@@ -1,9 +1,24 @@
 import {
+  COUNTS_CACHE_TTL_SECONDS,
   normalizePathname,
-  createPendingProjectbluefinSvg,
-  isProjectBluefinPrimary,
-  resolveChartTarget,
+  resolveRoute,
 } from "./routes.mjs";
+import {
+  renderAccumulatingSvg,
+  renderRepoBadge,
+  renderRepoChartSvg,
+} from "./render.mjs";
+import {
+  FIRST_PARTY,
+  FIRST_PARTY_PENDING_REASON,
+  PROJECTBLUEFIN_REPOS,
+} from "../../scripts/lib/countme-sources.mjs";
+
+const USER_AGENT = "projectbluefin-countme-worker/1.0";
+const COUNT_METHOD = "first-party-d1-v1";
+const COUNT_UNIT = "estimated weekly active systems";
+const WEEK_WINDOW_DAYS = 180;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 function baseHeaders(extra = {}) {
   return {
@@ -17,16 +32,51 @@ function isMetalinkRequest(pathname) {
   return pathname === "/metalink" || pathname === "/metalink/";
 }
 
-function createMetalinkResponse(request) {
+async function recordTelemetryEvent(
+  env,
+  { repo, tag, flavor, arch, bucket, gamemode },
+) {
+  if (!env || !env.DB) return;
+  try {
+    const receivedAt = new Date().toISOString();
+    await env.DB.prepare(
+      `INSERT INTO telemetry_events (repo, tag, flavor, arch, bucket, gamemode, received_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(repo, tag, flavor, arch, bucket, gamemode, receivedAt)
+      .run();
+  } catch (err) {
+    console.error("Failed to persist telemetry event:", err);
+  }
+}
+
+async function createMetalinkResponse(request, env, ctx) {
   const url = new URL(request.url);
   const repo = url.searchParams.get("repo") || "unknown";
   const tag = url.searchParams.get("tag") || "unknown";
   const flavor = url.searchParams.get("flavor") || "unknown";
   const arch = url.searchParams.get("arch") || "unknown";
   const countme = url.searchParams.get("countme") || "unknown";
+  const gamemode = url.searchParams.get("gamemode") === "1" ? 1 : 0;
+  const bucket = parseInt(countme, 10) || 1;
+
+  const persistPromise = recordTelemetryEvent(env, {
+    repo,
+    tag,
+    flavor,
+    arch,
+    bucket,
+    gamemode,
+  });
+
+  if (ctx && typeof ctx.waitUntil === "function") {
+    ctx.waitUntil(persistPromise);
+  } else {
+    await persistPromise;
+  }
 
   return new Response(
-    `countme accepted for repo=${repo} tag=${tag} flavor=${flavor} arch=${arch} countme=${countme}\n`,
+    `countme accepted for repo=${repo} tag=${tag} flavor=${flavor} gamemode=${gamemode} arch=${arch} countme=${countme}\n`,
     {
       status: 200,
       headers: baseHeaders({
@@ -37,7 +87,166 @@ function createMetalinkResponse(request) {
   );
 }
 
-async function proxyRequest(request) {
+function svgResponse(body, maxAgeSeconds) {
+  return new Response(body, {
+    status: 200,
+    headers: baseHeaders({
+      "content-type": "image/svg+xml; charset=UTF-8",
+      "cache-control": `public, max-age=${maxAgeSeconds}`,
+    }),
+  });
+}
+
+function jsonResponse(payload, maxAgeSeconds) {
+  return new Response(`${JSON.stringify(payload)}\n`, {
+    status: 200,
+    headers: baseHeaders({
+      "content-type": "application/json;charset=UTF-8",
+      "cache-control": `public, max-age=${maxAgeSeconds}`,
+    }),
+  });
+}
+
+/**
+ * Weekly counts per first-party repo, Monday-anchored.
+ *
+ * `weekday 0` advances to that week's Sunday, so `-6 days` lands on its Monday
+ * — the same week key the published series has always used.
+ */
+const WEEKLY_COUNTS_SQL = `SELECT date(received_at, 'weekday 0', '-6 days') AS week,
+          repo,
+          COUNT(*) AS hits
+   FROM telemetry_events
+   WHERE received_at >= date('now', '-${WEEK_WINDOW_DAYS} days')
+     AND repo IN (${PROJECTBLUEFIN_REPOS.map(() => "?").join(", ")})
+   GROUP BY week, repo
+   ORDER BY week ASC`;
+
+function countsMeta() {
+  return {
+    generatedAt: new Date().toISOString(),
+    source: FIRST_PARTY.origin,
+    method: COUNT_METHOD,
+    unit: COUNT_UNIT,
+  };
+}
+
+function pendingCounts() {
+  return {
+    ...countsMeta(),
+    variants: [],
+    weeks: [],
+    unavailable: true,
+    stateReason: FIRST_PARTY_PENDING_REASON,
+  };
+}
+
+/** Every Monday from `first` through `last`, so a silent week stays visible. */
+function weekAxis(first, last) {
+  const axis = [];
+  for (
+    let stamp = Date.parse(`${first}T00:00:00Z`);
+    stamp <= Date.parse(`${last}T00:00:00Z`);
+    stamp += WEEK_MS
+  ) {
+    axis.push(new Date(stamp).toISOString().slice(0, 10));
+  }
+  return axis;
+}
+
+/**
+ * The counts document. A repo with no rows in a week is null, never 0: we
+ * cannot distinguish "nobody reported" from "nobody was running it".
+ */
+async function aggregateWeeklyCounts(env) {
+  if (!env || !env.DB) return pendingCounts();
+
+  let rows;
+  try {
+    const query = await env.DB.prepare(WEEKLY_COUNTS_SQL)
+      .bind(...PROJECTBLUEFIN_REPOS)
+      .all();
+    rows = (query && query.results) || [];
+  } catch (err) {
+    console.error("Failed to aggregate countme records:", err);
+    return pendingCounts();
+  }
+
+  const counted = rows.filter(
+    (row) => row && typeof row.week === "string" && Number.isFinite(row.hits),
+  );
+  if (counted.length === 0) return pendingCounts();
+
+  const byWeek = new Map();
+  for (const row of counted) {
+    const week = byWeek.get(row.week) || new Map();
+    week.set(row.repo, (week.get(row.repo) || 0) + row.hits);
+    byWeek.set(row.week, week);
+  }
+
+  const observed = [...byWeek.keys()].sort();
+  const weeks = weekAxis(observed[0], observed[observed.length - 1]).map(
+    (week) => {
+      const counts = byWeek.get(week);
+      const entry = { week };
+      for (const repo of PROJECTBLUEFIN_REPOS) {
+        entry[repo] = counts && counts.has(repo) ? counts.get(repo) : null;
+      }
+      return entry;
+    },
+  );
+
+  return {
+    ...countsMeta(),
+    variants: PROJECTBLUEFIN_REPOS.filter((repo) =>
+      weeks.some((week) => week[repo] !== null),
+    ),
+    weeks,
+  };
+}
+
+async function createCountsResponse(env) {
+  return jsonResponse(
+    await aggregateWeeklyCounts(env),
+    COUNTS_CACHE_TTL_SECONDS,
+  );
+}
+
+async function createChartResponse(env, repo) {
+  const dataset = await aggregateWeeklyCounts(env);
+  const body = dataset.unavailable
+    ? renderAccumulatingSvg(repo, 0)
+    : renderRepoChartSvg(dataset, repo);
+  return svgResponse(body, COUNTS_CACHE_TTL_SECONDS);
+}
+
+async function createBadgeResponse(env, repo) {
+  const dataset = await aggregateWeeklyCounts(env);
+  return jsonResponse(renderRepoBadge(dataset, repo), COUNTS_CACHE_TTL_SECONDS);
+}
+
+async function createLegacyProxyResponse(upstream) {
+  const upstreamRes = await fetch(upstream, {
+    headers: { "user-agent": USER_AGENT },
+  });
+
+  if (!upstreamRes.ok) {
+    return new Response(`upstream error: ${upstreamRes.status}`, {
+      status: 502,
+      headers: baseHeaders({ "content-type": "text/plain;charset=UTF-8" }),
+    });
+  }
+
+  return new Response(upstreamRes.body, {
+    status: 200,
+    headers: baseHeaders({
+      "content-type":
+        upstreamRes.headers.get("content-type") || "application/octet-stream",
+    }),
+  });
+}
+
+async function proxyRequest(request, env, ctx) {
   const url = new URL(request.url);
   const pathname = normalizePathname(url.pathname);
 
@@ -49,50 +258,27 @@ async function proxyRequest(request) {
   }
 
   if (isMetalinkRequest(pathname)) {
-    return createMetalinkResponse(request);
+    return createMetalinkResponse(request, env, ctx);
   }
 
-  const upstream = resolveChartTarget(pathname);
+  const route = resolveRoute(pathname);
 
-  if (!upstream) {
+  if (!route) {
     return new Response("not found", {
       status: 404,
       headers: baseHeaders({ "content-type": "text/plain;charset=UTF-8" }),
     });
   }
 
-  const upstreamRes = await fetch(upstream, {
-    headers: { "user-agent": "projectbluefin-countme-worker/1.0" },
-  });
+  if (route.kind === "counts") return createCountsResponse(env);
+  if (route.kind === "chart") return createChartResponse(env, route.repo);
+  if (route.kind === "badge") return createBadgeResponse(env, route.repo);
 
-  if (upstreamRes.ok) {
-    const contentType =
-      upstreamRes.headers.get("content-type") || "application/octet-stream";
-    return new Response(upstreamRes.body, {
-      status: 200,
-      headers: baseHeaders({
-        "content-type": contentType,
-      }),
-    });
-  }
-
-  if (isProjectBluefinPrimary(pathname)) {
-    const variantMatch = pathname.match(/^\/([^/]+)\/growth\.svg/);
-    const variant = variantMatch ? variantMatch[1] : "bluefin";
-    return new Response(createPendingProjectbluefinSvg(variant), {
-      status: 200,
-      headers: baseHeaders({ "content-type": "image/svg+xml; charset=UTF-8" }),
-    });
-  }
-
-  return new Response(`upstream error: ${upstreamRes.status}`, {
-    status: 502,
-    headers: baseHeaders({ "content-type": "text/plain;charset=UTF-8" }),
-  });
+  return createLegacyProxyResponse(route.url);
 }
 
 export default {
-  async fetch(request) {
-    return proxyRequest(request);
+  async fetch(request, env, ctx) {
+    return proxyRequest(request, env, ctx);
   },
 };

--- a/workers/countme-proxy/render.mjs
+++ b/workers/countme-proxy/render.mjs
@@ -1,0 +1,259 @@
+// Dependency-free SVG rendering for first-party countme charts and badges.
+// The Worker runtime has no DOM, so every chart is assembled as a string.
+//
+// Published copy carries no host, URL, or service description: these panels
+// render on public pages, and a panel explaining our internals is an
+// infrastructure disclosure wearing an error message.
+
+import { FIRST_PARTY_PENDING_REASON } from "../../scripts/lib/countme-sources.mjs";
+
+const PALETTE = {
+  bg: "#0d1117",
+  panel: "#161b22",
+  border: "#30363d",
+  text: "#c9d1d9",
+  muted: "#8b949e",
+  accent: "#58a6ff",
+};
+
+export const REPO_ACCENTS = {
+  bluefin: "#58a6ff",
+  "bluefin-lts": "#bc8cff",
+  dakota: "#39d2c0",
+  utah: "#f0883e",
+  server: "#7ee787",
+};
+
+export const REPO_LABELS = {
+  bluefin: "Bluefin",
+  "bluefin-lts": "Bluefin LTS",
+  dakota: "Dakota",
+  utah: "Utah",
+  server: "Server",
+};
+
+const FONT = "Inter, Segoe UI, Arial, sans-serif";
+const WIDTH = 1280;
+const HEIGHT = 720;
+const PLOT_LEFT = 200;
+const PLOT_RIGHT = 1210;
+const PLOT_TOP = 280;
+const PLOT_BOTTOM = 600;
+const GRID_LINES = 4;
+const DEFAULT_UNIT = "weekly active systems";
+const FOOTER = "Project Bluefin countme";
+
+export function repoLabel(repo) {
+  return REPO_LABELS[repo] || String(repo);
+}
+
+export function repoAccent(repo) {
+  return REPO_ACCENTS[repo] || PALETTE.accent;
+}
+
+export function formatCount(value) {
+  const rounded = Math.round(value);
+  const sign = rounded < 0 ? "-" : "";
+  return (
+    sign + String(Math.abs(rounded)).replace(/\B(?=(\d{3})+(?!\d))/gu, ",")
+  );
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;");
+}
+
+function round2(value) {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Weekly points for one repo, oldest first. A week whose repo key is absent or
+ * non-numeric is a gap and carries `value: null`; a recorded 0 stays 0.
+ */
+export function buildSeries(dataset, repo) {
+  const weeks = dataset && Array.isArray(dataset.weeks) ? dataset.weeks : [];
+  return weeks
+    .filter((entry) => entry && typeof entry.week === "string")
+    .slice()
+    .sort((a, b) => (a.week < b.week ? -1 : a.week > b.week ? 1 : 0))
+    .map((entry) => {
+      const raw = entry[repo];
+      const value =
+        typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+      return { week: entry.week, value };
+    });
+}
+
+/** Runs of consecutive recorded weeks. A gap ends a run; it is never bridged. */
+function buildSegments(points) {
+  const segments = [];
+  let current = null;
+
+  for (const point of points) {
+    if (point.value === null) {
+      current = null;
+      continue;
+    }
+    if (!current) {
+      current = [];
+      segments.push(current);
+    }
+    current.push(point);
+  }
+
+  return segments;
+}
+
+export function latestPoint(series) {
+  for (let index = series.length - 1; index >= 0; index -= 1) {
+    if (series[index].value !== null) return series[index];
+  }
+  return null;
+}
+
+function scaleBounds(values) {
+  const rawMin = Math.min(...values);
+  const rawMax = Math.max(...values);
+  const pad =
+    rawMax === rawMin
+      ? Math.max(1, Math.abs(rawMax) * 0.1)
+      : (rawMax - rawMin) * 0.12;
+
+  let min = rawMin - pad;
+  let max = rawMax + pad;
+  if (rawMin >= 0 && min < 0) min = 0;
+
+  // Counts are whole systems. A range narrower than one gridline per unit
+  // would print the same rounded number on every axis label.
+  if (max - min < GRID_LINES) {
+    min = Math.round((rawMin + rawMax) / 2) - GRID_LINES / 2;
+    if (rawMin >= 0 && min < 0) min = 0;
+    max = min + GRID_LINES;
+  }
+
+  return { min, max };
+}
+
+function chrome(ariaLabel) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img" aria-label="${escapeXml(ariaLabel)}">
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="${PALETTE.bg}"/>
+  <rect x="30" y="30" width="1220" height="660" rx="12" fill="${PALETTE.panel}" stroke="${PALETTE.border}" stroke-width="2"/>`;
+}
+
+function datasetUnit(dataset) {
+  return dataset && typeof dataset.unit === "string" && dataset.unit
+    ? dataset.unit
+    : DEFAULT_UNIT;
+}
+
+/**
+ * Chart of one repo's weekly series. Fewer than two recorded weeks cannot make
+ * an honest line, so that case renders an accumulating-data panel.
+ */
+export function renderRepoChartSvg(dataset, repo) {
+  const series = buildSeries(dataset, repo).map((point, index) => ({
+    ...point,
+    index,
+  }));
+  const recorded = series.filter((point) => point.value !== null);
+
+  if (recorded.length < 2) {
+    return renderAccumulatingSvg(repo, recorded.length);
+  }
+
+  const label = repoLabel(repo);
+  const accent = repoAccent(repo);
+  const unit = datasetUnit(dataset);
+  const current = recorded[recorded.length - 1];
+  const currentText = formatCount(current.value);
+  const { min, max } = scaleBounds(recorded.map((point) => point.value));
+  const span = max - min;
+  const lastIndex = series.length - 1;
+
+  const x = (index) =>
+    round2(PLOT_LEFT + (index / lastIndex) * (PLOT_RIGHT - PLOT_LEFT));
+  const y = (value) =>
+    round2(PLOT_BOTTOM - ((value - min) / span) * (PLOT_BOTTOM - PLOT_TOP));
+
+  const paths = buildSegments(series)
+    .map((segment) => {
+      if (segment.length === 1) {
+        const only = segment[0];
+        return `  <circle cx="${x(only.index)}" cy="${y(only.value)}" r="6" fill="${accent}"/>`;
+      }
+      const d = segment
+        .map(
+          (point, offset) =>
+            `${offset === 0 ? "M" : "L"}${x(point.index)} ${y(point.value)}`,
+        )
+        .join(" ");
+      return `  <path d="${d}" fill="none" stroke="${accent}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
+    })
+    .join("\n");
+
+  const grid = Array.from({ length: GRID_LINES + 1 }, (_, step) => {
+    const value = min + (span * step) / GRID_LINES;
+    const gy = round2(
+      PLOT_BOTTOM - (step / GRID_LINES) * (PLOT_BOTTOM - PLOT_TOP),
+    );
+    return `  <line x1="${PLOT_LEFT}" y1="${gy}" x2="${PLOT_RIGHT}" y2="${gy}" stroke="${PALETTE.border}" stroke-width="1"/>
+  <text x="${PLOT_LEFT - 20}" y="${gy + 7}" text-anchor="end" fill="${PALETTE.muted}" font-size="20" font-family="${FONT}">${escapeXml(formatCount(value))}</text>`;
+  }).join("\n");
+
+  const gapCount = series.length - recorded.length;
+  const gapNote =
+    gapCount > 0
+      ? `${gapCount} week${gapCount === 1 ? "" : "s"} without data shown as gaps`
+      : `${series.length} weeks tracked`;
+
+  const ariaLabel = `${label} ${unit}: current ${currentText} for the week of ${current.week}`;
+
+  return `${chrome(ariaLabel)}
+  <text x="70" y="100" fill="${PALETTE.text}" font-size="38" font-family="${FONT}">${escapeXml(label)} — ${escapeXml(unit)}</text>
+  <text x="70" y="190" fill="${accent}" font-size="68" font-family="${FONT}" font-weight="700">${escapeXml(currentText)}</text>
+  <text x="70" y="232" fill="${PALETTE.muted}" font-size="24" font-family="${FONT}">current, week of ${escapeXml(current.week)} · ${escapeXml(gapNote)}</text>
+${grid}
+${paths}
+  <circle cx="${x(current.index)}" cy="${y(current.value)}" r="8" fill="${accent}" stroke="${PALETTE.panel}" stroke-width="3"/>
+  <text x="${PLOT_LEFT}" y="640" fill="${PALETTE.muted}" font-size="20" font-family="${FONT}">${escapeXml(series[0].week)}</text>
+  <text x="${PLOT_RIGHT}" y="640" text-anchor="end" fill="${PALETTE.muted}" font-size="20" font-family="${FONT}">${escapeXml(series[lastIndex].week)}</text>
+  <text x="70" y="678" fill="${PALETTE.muted}" font-size="18" font-family="${FONT}">${FOOTER}</text>
+</svg>`;
+}
+
+/**
+ * Shown when a repo has fewer than two recorded weeks, including when nothing
+ * has been recorded at all.
+ */
+export function renderAccumulatingSvg(repo, pointCount) {
+  const label = repoLabel(repo);
+  const accent = repoAccent(repo);
+  const plural = pointCount === 1 ? "point" : "points";
+  const ariaLabel = `${label} accumulating data, ${pointCount} weekly data ${plural} recorded`;
+
+  return `${chrome(ariaLabel)}
+  <text x="70" y="120" fill="${PALETTE.text}" font-size="40" font-family="${FONT}">${escapeXml(label)} — accumulating data</text>
+  <text x="70" y="190" fill="${PALETTE.muted}" font-size="28" font-family="${FONT}">${escapeXml(FIRST_PARTY_PENDING_REASON)}</text>
+  <text x="70" y="250" fill="${PALETTE.muted}" font-size="24" font-family="${FONT}">${pointCount} weekly data ${plural} recorded; a trend line needs at least 2</text>
+  <line x1="70" y1="520" x2="1210" y2="520" stroke="${accent}" stroke-width="4" stroke-dasharray="12 10" opacity="0.7"/>
+  <text x="70" y="600" fill="${PALETTE.muted}" font-size="22" font-family="${FONT}">${FOOTER}</text>
+</svg>`;
+}
+
+/** shields.io endpoint payload for a repo. */
+export function renderRepoBadge(dataset, repo) {
+  const current = latestPoint(buildSeries(dataset, repo));
+
+  return {
+    schemaVersion: 1,
+    label: repoLabel(repo),
+    message: current ? formatCount(current.value) : "accumulating",
+    color: (current ? repoAccent(repo) : PALETTE.muted).replace("#", ""),
+  };
+}

--- a/workers/countme-proxy/routes.mjs
+++ b/workers/countme-proxy/routes.mjs
@@ -1,81 +1,79 @@
+import {
+  PROJECTBLUEFIN_REPOS,
+  UPSTREAM_ALLOWED,
+} from "../../scripts/lib/countme-sources.mjs";
+
 export const LEGACY_BLUEFIN_CHART_URL =
   "https://raw.githubusercontent.com/ublue-os/countme/main/growth_bluefins.svg";
-export const PROJECTBLUEFIN_CHART_URL =
-  "https://raw.githubusercontent.com/projectbluefin/countme/main/growth_bluefins.svg";
 
-export const ROUTES = {
-  "/": PROJECTBLUEFIN_CHART_URL,
-  "/growth.svg": PROJECTBLUEFIN_CHART_URL,
+/**
+ * The only routes still answered by another service.
+ *
+ * `ublue-os/bluefin:stable` is the one upstream series anyone may publish
+ * (`UPSTREAM_ALLOWED`); its growth chart and badge are upstream's to produce.
+ * Every other series — Bluefin LTS included — is counted by our own deployment
+ * or not at all, so nothing else may resolve here.
+ */
+export const LEGACY_ROUTES = {
   "/growth_bluefins.svg": LEGACY_BLUEFIN_CHART_URL,
   "/sources/ublue-os/bluefin/growth.svg": LEGACY_BLUEFIN_CHART_URL,
-  "/sources/projectbluefin/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/bluefin/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/bluefin-lts/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/dakota/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/utah/growth.svg": PROJECTBLUEFIN_CHART_URL,
-  "/badge-endpoints/bluefin.json":
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json",
-  "/badge-endpoints/bluefin-lts.json":
-    "https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json",
-  "/badge-endpoints/dakota.json":
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/dakota.json",
-  "/badge-endpoints/utah.json":
-    "https://raw.githubusercontent.com/projectbluefin/countme/main/badge-endpoints/utah.json",
+  "/badge-endpoints/bluefin.json": UPSTREAM_ALLOWED.source,
 };
 
+/** Weekly aggregate of our own countme records, as JSON. */
+export const COUNTS_ROUTE = "/counts.json";
+
+/** Seconds a first-party response may be cached at the edge. */
+export const COUNTS_CACHE_TTL_SECONDS = 900;
+
+/** Chart aliases that predate per-repo routes, all meaning Bluefin. */
+const BLUEFIN_CHART_ALIASES = [
+  "/",
+  "/growth.svg",
+  "/sources/projectbluefin/bluefin/growth.svg",
+];
+
+/** `/<repo>/growth.svg` for every first-party repo, plus the Bluefin aliases. */
+export const CHART_ROUTES = {
+  ...Object.fromEntries(
+    BLUEFIN_CHART_ALIASES.map((alias) => [alias, "bluefin"]),
+  ),
+  ...Object.fromEntries(
+    PROJECTBLUEFIN_REPOS.map((repo) => [`/${repo}/growth.svg`, repo]),
+  ),
+};
+
+/**
+ * `/badge-endpoints/<repo>.json` for every first-party repo. Bluefin's path is
+ * also in LEGACY_ROUTES, which wins in `resolveRoute`, because that badge is
+ * the upstream image's.
+ */
+export const BADGE_ROUTES = Object.fromEntries(
+  PROJECTBLUEFIN_REPOS.map((repo) => [`/badge-endpoints/${repo}.json`, repo]),
+);
+
 export function normalizePathname(pathname) {
-  const trimmed = pathname.replace(/\/+$/, "");
+  const trimmed = pathname.replace(/\/+$/u, "");
   return trimmed === "" ? "/" : trimmed;
 }
 
-export function mapRequestPath(pathname) {
-  return ROUTES[normalizePathname(pathname)] || null;
-}
-
-export function createPendingProjectbluefinSvg(variant = "bluefin") {
-  const displayVariant =
-    variant === "dakota"
-      ? "Dakota"
-      : variant === "utah"
-        ? "Utah"
-        : variant === "bluefin-lts"
-          ? "Bluefin LTS"
-          : "Bluefin";
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="projectbluefin ${variant} countme pending">
-  <rect width="1280" height="720" fill="#0d1117"/>
-  <rect x="30" y="30" width="1220" height="660" rx="12" fill="#161b22" stroke="#30363d" stroke-width="2"/>
-  <text x="70" y="140" fill="#c9d1d9" font-size="40" font-family="Inter, Segoe UI, Arial, sans-serif">projectbluefin/${variant} countme chart pending</text>
-  <text x="70" y="210" fill="#8b949e" font-size="28" font-family="Inter, Segoe UI, Arial, sans-serif">${displayVariant} countme.projectbluefin.io configured, waiting for projectbluefin/countme artifacts</text>
-  <line x1="70" y1="560" x2="1210" y2="360" stroke="#58a6ff" stroke-width="4" stroke-dasharray="12 10" opacity="0.75"/>
-  <text x="70" y="620" fill="#8b949e" font-size="24" font-family="Inter, Segoe UI, Arial, sans-serif">Legacy data available at /sources/ublue-os/bluefin/growth.svg</text>
-</svg>`;
-}
-
-export function isProjectBluefinPrimary(pathname) {
-  const normalized = normalizePathname(pathname);
-  return [
-    "/",
-    "/growth.svg",
-    "/sources/projectbluefin/bluefin/growth.svg",
-    "/bluefin/growth.svg",
-    "/bluefin-lts/growth.svg",
-    "/dakota/growth.svg",
-    "/utah/growth.svg",
-  ].includes(normalized);
-}
-
-export function resolveChartTarget(pathname) {
+/**
+ * Route descriptor: the upstream artifact to proxy, the first-party repo to
+ * render, the counts document, or null when the path is unknown.
+ */
+export function resolveRoute(pathname) {
   const normalized = normalizePathname(pathname);
 
-  if (
-    normalized === "/" ||
-    normalized === "/growth.svg" ||
-    normalized.endsWith("/growth.svg")
-  ) {
-    return PROJECTBLUEFIN_CHART_URL;
-  }
+  const legacyUrl = LEGACY_ROUTES[normalized];
+  if (legacyUrl) return { kind: "legacy", url: legacyUrl };
 
-  return mapRequestPath(normalized);
+  if (normalized === COUNTS_ROUTE) return { kind: "counts" };
+
+  const chartRepo = CHART_ROUTES[normalized];
+  if (chartRepo) return { kind: "chart", repo: chartRepo };
+
+  const badgeRepo = BADGE_ROUTES[normalized];
+  if (badgeRepo) return { kind: "badge", repo: badgeRepo };
+
+  return null;
 }

--- a/wrangler.countme.toml
+++ b/wrangler.countme.toml
@@ -7,3 +7,8 @@ workers_dev = false
 routes = [
   { pattern = "countme.projectbluefin.io/*", zone_name = "projectbluefin.io" }
 ]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "projectbluefin-countme"
+database_id = "3704849e-b4f6-4e90-9d20-cae873b6244b"


### PR DESCRIPTION
## What was broken

`/analytics` rendered `Weekly active systems unavailable` on the deployed site, and `countme.projectbluefin.io` returned a placeholder SVG on every first-party chart route.

`f846c652` removed every `projectbluefin` image from the Fedora CSV pipeline, correctly, and left no replacement. The worker resolved those routes to `projectbluefin/countme`, which does not exist — the GitHub API returns 404 for the repository and for every raw artifact path under it. Pings were already being written to D1; nothing read them back.

## What changed

**Worker**

- `aggregateWeeklyCounts` groups `telemetry_events` into Monday-anchored weekly counts per repo, restricted to `PROJECTBLUEFIN_REPOS`.
- `GET /counts.json` serves that aggregate. Per-image chart and badge routes render from the same data.
- Every week carries every first-party repo key as a value or `null`, so a gap is explicit rather than inferred from an absent key. A recorded `0` stays `0`.
- Legacy `ublue-os` proxying is reduced to the three routes `UPSTREAM_ALLOWED` permits. `/badge-endpoints/bluefin-lts.json` moves to D1, because `isPermittedSource("bluefin-lts", UPSTREAM_ALLOWED.source)` is `false` — that series is the EPEL-summed number `f846c652` removed.
- Failure modes (unbound binding, throwing query, zero rows) all return a pending document at HTTP 200. The specifics go to `console.error`, not to published copy.

**Site**

- The panel reads `/counts.json` at runtime and falls back to a reasoned `Unavailable` when the service reports no weeks.
- Series separate by dash pattern and marker shape. The Bluefin categorical ramp is six shades of one hue, so colour alone cannot tell two series apart.
- `connect-src` gains `https://countme.projectbluefin.io`. Without it the fetch is blocked by CSP and the panel can never populate.
- The first-party reader is its own module, so no single file holds both the image catalogue and a computed index into a countme week — the pattern `scripts/countme-first-party.test.js` gates.

## Presentation rules

| Rule | Where |
| --- | --- |
| Current value always shown | Legend chips, `EChart` summary, and as text inside each SVG route |
| Small multiples share one domain | Panel is zero-anchored; no per-series autoscaling |
| Severity is one hue plus a glyph | Unchanged from the matrix; no red/green pair introduced |
| Gaps drawn as gaps | `connectNulls: false`, `smooth: false`; a missing week breaks the line |
| `accumulating data` below minimum points | `minPoints={2}`; `/bluefin/growth.svg` and `/utah/growth.svg` render it today |
| Unavailability visible with a reason | `Unavailable` with `stateReason`, no host or URL in the copy |
| Missing values are `null`, not zero | `parseReading`; covered by a mutation-checked test |

## Verification

- Worker deployed: version `0d647244-cd12-428c-b6c7-0b7a4fc51734`, `env.DB` bound.
- `/counts.json` live: 9 Monday-anchored weeks, `variants` `[bluefin, bluefin-lts, dakota]`; `utah` and `server` excluded as having no rows.
- `/dakota/growth.svg` renders a real series stating its current value; `/bluefin/growth.svg` and `/utah/growth.svg` render `accumulating data`; `/growth_bluefins.svg` still proxies upstream. No placeholder remains on any route.
- Page verified in a browser against the live endpoint: no console errors, gaps rendered as breaks, single-reading series drawn as isolated points.
- `just check`: 0 lint errors, 1036/1036 tests pass, typecheck clean.

Design record: `adr/0007-first-party-countme-aggregate.md`.

## Note for review

`wrangler.countme.toml` carries the D1 binding that was already in the working tree; the worker cannot read the database without it. `eos` (8 rows) and `dakota-gaming` (1 row) appear in `telemetry_events` but are not in `PROJECTBLUEFIN_REPOS`, so they are excluded from the aggregate — flagging rather than changing the policy list.