### PR TITLE
feat(analytics): fold game mode into its image and show the upstream series

### DIFF
--- a/adr/0007-first-party-countme-aggregate.md
+++ b/adr/0007-first-party-countme-aggregate.md
@@ -128,3 +128,48 @@ number would age with the deployment rather than with the data.
 **Log y-axis to fit Fedora's magnitude alongside Bluefin's.** Rejected here: the
 panel no longer plots Fedora, so the range that motivated it is gone, and a log
 axis is easy to misread on a page that does not otherwise use one.
+
+## Addendum, 2026-09-12: game mode and the upstream panel
+
+Two follow-on decisions, taken after the first deployment.
+
+### Game mode is an attribute, not an image
+
+Clients report game mode two ways: a `-gaming` repo id, and a `gamemode=1`
+parameter. Live D1 carried both — `dakota-gaming` with `gamemode=1`, and a
+`bluefin` row also flagged `gamemode=1` — so this is not a Dakota-specific
+image. Treating `dakota-gaming` as its own repo would have split Dakota's
+population in two and left a phantom image in the catalogue.
+
+The service normalizes the repo id and folds both spellings into the base
+image. `weeks[i][repo]` is the whole population, including game mode.
+`weeks[i].gaming[repo]` is the part of it that was in game mode. The two are a
+population and its share, never addends: `gaming[repo] <= weeks[i][repo]` holds
+for every repo and week, and a test asserts it.
+
+A repo that reported with nobody in game mode is `0`, not `null` — a real
+measurement, distinct from a week it did not report at all. The page draws a
+game-mode series only for images with a non-zero reading, so a flat zero never
+implies a population nobody measured. Each game-mode series carries its parent
+image's colour with a dotted stroke, so it reads as a share of the line above
+it rather than as a separate image, and the current split is stated in words
+next to the image's number.
+
+Payload method bumped to `first-party-d1-v2`.
+
+### The upstream image is shown alongside
+
+`ublue-os/bluefin:stable` is published on the page next to the first-party
+counts, so the migration between the two is visible rather than inferred. This
+is `UPSTREAM_ALLOWED`, the single permitted upstream series, and it is read
+through our own worker's existing legacy routes.
+
+Upstream publishes rendered matplotlib SVGs and a rounded badge value, and no
+time-series file. The panel therefore embeds the chart upstream publishes
+instead of replotting a series that does not exist, and states the badge's
+value as its current number. The image is framed rather than recoloured:
+altering another project's published chart would misrepresent it.
+
+The two series are not the same quantity — the legacy one counts DNF metalink
+hits, the first-party one counts image check-ins — and the panel says so rather
+than inviting a subtraction.

--- a/scripts/countme-analytics-charts.test.js
+++ b/scripts/countme-analytics-charts.test.js
@@ -77,17 +77,18 @@ const {
 } = mod;
 
 // The first-party reader is its own module; see the note in the component.
-const { latestReading, reportingRepos } = loadTsxModule(
-  path.join(
-    __dirname,
-    "..",
-    "src",
-    "components",
-    "analytics",
-    "firstPartyCountme.ts",
-  ),
-  (id) => (id.endsWith(".css") ? {} : undefined),
-);
+const { latestReading, reportingRepos, latestGaming, gamingRepos } =
+  loadTsxModule(
+    path.join(
+      __dirname,
+      "..",
+      "src",
+      "components",
+      "analytics",
+      "firstPartyCountme.ts",
+    ),
+    (id) => (id.endsWith(".css") ? {} : undefined),
+  );
 
 const REGISTRY_FIXTURE = {
   generatedAt: "2026-09-10T04:08:30.490Z",
@@ -427,4 +428,97 @@ test("the panel stays unavailable when the service reports no weeks", () => {
   );
   assert.ok(panel, "an empty aggregate must still render a reasoned panel");
   assert.doesNotMatch(panel[1], /projectbluefin\.io/);
+});
+
+/**
+ * Game mode is an attribute of a ping, not an image.
+ *
+ * The service folds a `-gaming` repo id into its base image, so `weeks[i][repo]`
+ * is the whole population and `weeks[i].gaming[repo]` is the part of it in game
+ * mode. Adding the two would double-count; drawing gaming as its own image
+ * would invent a population that does not exist.
+ */
+const GAMING_FIXTURE = {
+  generatedAt: "2026-09-12T00:00:00.000Z",
+  source: "https://countme.projectbluefin.io",
+  method: "first-party-d1-v2",
+  unit: "estimated weekly active systems",
+  variants: ["bluefin", "dakota"],
+  weeks: [
+    {
+      week: "2026-08-31",
+      bluefin: 10,
+      dakota: 4,
+      utah: null,
+      gaming: { bluefin: 0, dakota: 1, utah: null },
+    },
+    {
+      week: "2026-09-07",
+      bluefin: 12,
+      dakota: 6,
+      utah: null,
+      gaming: { bluefin: 0, dakota: 2, utah: null },
+    },
+  ],
+};
+
+test("game mode is a share of its image, never added to it", () => {
+  assert.equal(latestGaming(GAMING_FIXTURE.weeks, "dakota"), 2);
+  // Reported, but nobody in game mode: a real 0, not a gap.
+  assert.equal(latestGaming(GAMING_FIXTURE.weeks, "bluefin"), 0);
+  // Never reported at all.
+  assert.equal(latestGaming(GAMING_FIXTURE.weeks, "utah"), null);
+
+  const total = latestReading(GAMING_FIXTURE.weeks, "dakota").value;
+  assert.ok(
+    latestGaming(GAMING_FIXTURE.weeks, "dakota") <= total,
+    "a share cannot exceed the population it came from",
+  );
+});
+
+test("only images that reported game mode get a game-mode series", () => {
+  // bluefin is a measured zero, so plotting it would draw a flat line on the
+  // floor and read as a population rather than an absence.
+  assert.deepEqual(
+    gamingRepos(GAMING_FIXTURE.weeks, ["bluefin", "dakota", "utah"]),
+    ["dakota"],
+  );
+});
+
+test("the game-mode series is drawn under its image, not as a new one", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CountmeAnalyticsCharts, {
+      registry: REGISTRY_FIXTURE,
+      counts: GAMING_FIXTURE,
+    }),
+  );
+  const option = JSON.parse(
+    html
+      .match(
+        /data-title="Weekly active systems"[\s\S]*?data-option="([^"]*)"/,
+      )[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&"),
+  );
+
+  const names = option.series.map((s) => s.name);
+  assert.ok(names.includes("Project Bluefin Dakota"));
+  assert.ok(names.includes("Project Bluefin Dakota (game mode)"));
+  assert.ok(
+    !names.some((n) => n.includes("dakota-gaming")),
+    "the gaming id must never surface as an image of its own",
+  );
+
+  const total = option.series.find((s) => s.name === "Project Bluefin Dakota");
+  const gaming = option.series.find(
+    (s) => s.name === "Project Bluefin Dakota (game mode)",
+  );
+  assert.deepEqual(total.data, [4, 6]);
+  assert.deepEqual(gaming.data, [1, 2]);
+  assert.equal(
+    gaming.itemStyle.color,
+    total.itemStyle.color,
+    "a share carries its image's colour so it is not read as a separate image",
+  );
+  assert.equal(gaming.connectNulls, false);
 });

--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 
 let routes;
 let render;
+let counts;
 let policy;
 let fetchHandler;
 
@@ -13,6 +14,7 @@ const repoRoot = path.join(__dirname, "..");
 test.before(async () => {
   routes = await import("../workers/countme-proxy/routes.mjs");
   render = await import("../workers/countme-proxy/render.mjs");
+  counts = await import("../workers/countme-proxy/counts.mjs");
   policy = await import("./lib/countme-sources.mjs");
   const mod = await import("../workers/countme-proxy/index.mjs");
   fetchHandler = mod.default.fetch;
@@ -23,6 +25,7 @@ const WORKER_SOURCES = [
   "workers/countme-proxy/index.mjs",
   "workers/countme-proxy/routes.mjs",
   "workers/countme-proxy/render.mjs",
+  "workers/countme-proxy/counts.mjs",
 ];
 
 /**
@@ -175,9 +178,10 @@ test("every first-party repo has a chart and a badge route", () => {
 
 test("counts.json aggregates weekly records per first-party repo", async () => {
   const db = stubDb([
-    { week: "2026-08-31", repo: "bluefin", hits: 3552 },
-    { week: "2026-08-31", repo: "bluefin-lts", hits: 194 },
-    { week: "2026-09-07", repo: "bluefin", hits: 3601 },
+    { week: "2026-08-31", repo: "bluefin", gamemode: 0, hits: 3552 },
+    { week: "2026-08-31", repo: "bluefin-lts", gamemode: 0, hits: 194 },
+    { week: "2026-09-07", repo: "bluefin", gamemode: 0, hits: 3601 },
+    { week: "2026-09-07", repo: "bluefin", gamemode: 1, hits: 1 },
   ]);
 
   const response = await get("/counts.json", db.env);
@@ -185,7 +189,7 @@ test("counts.json aggregates weekly records per first-party repo", async () => {
 
   assert.equal(response.status, 200);
   assert.equal(body.source, policy.FIRST_PARTY.origin);
-  assert.equal(body.method, "first-party-d1-v1");
+  assert.equal(body.method, "first-party-d1-v2");
   assert.equal(body.unit, "estimated weekly active systems");
   assert.ok(!body.unavailable);
   assert.deepEqual(body.variants, ["bluefin", "bluefin-lts"]);
@@ -197,19 +201,33 @@ test("counts.json aggregates weekly records per first-party repo", async () => {
       dakota: null,
       utah: null,
       server: null,
+      gaming: {
+        bluefin: 0,
+        "bluefin-lts": 0,
+        dakota: null,
+        utah: null,
+        server: null,
+      },
     },
     {
       week: "2026-09-07",
-      bluefin: 3601,
+      bluefin: 3602,
       "bluefin-lts": null,
       dakota: null,
       utah: null,
       server: null,
+      gaming: {
+        bluefin: 1,
+        "bluefin-lts": null,
+        dakota: null,
+        utah: null,
+        server: null,
+      },
     },
   ]);
 
   assert.ok(db.statements[0].sql.includes("telemetry_events"));
-  assert.deepEqual(db.statements[0].args, [...policy.PROJECTBLUEFIN_REPOS]);
+  assert.deepEqual(db.statements[0].args, [...counts.COUNTED_REPO_IDS]);
 });
 
 test("a repo missing from a week is null, never zero", async () => {
@@ -220,6 +238,7 @@ test("a repo missing from a week is null, never zero", async () => {
   const week = JSON.parse(text).weeks[0];
 
   assert.equal(week.dakota, null);
+  assert.equal(week.gaming.dakota, null);
   assert.ok("dakota" in week, "the key is present so the gap is explicit");
   assert.match(text, /"dakota":null/u);
   assert.ok(
@@ -241,6 +260,113 @@ test("a week nobody reported stays on the axis as a gap", async () => {
     ["2026-08-31", "2026-09-07", "2026-09-14"],
   );
   assert.equal(body.weeks[1].bluefin, null);
+});
+
+test("a -gaming id counts as its base image in game mode", () => {
+  assert.deepEqual(counts.normalizeCountmeRepo("dakota-gaming", 1), {
+    repo: "dakota",
+    gaming: true,
+  });
+
+  // The suffix alone is enough: a client that forgets the flag still lands in
+  // the same bucket, and so does one that sends the flag without the suffix.
+  assert.deepEqual(counts.normalizeCountmeRepo("dakota-gaming", 0), {
+    repo: "dakota",
+    gaming: true,
+  });
+  assert.deepEqual(counts.normalizeCountmeRepo("dakota", 1), {
+    repo: "dakota",
+    gaming: true,
+  });
+  assert.deepEqual(counts.normalizeCountmeRepo("dakota", 0), {
+    repo: "dakota",
+    gaming: false,
+  });
+
+  // Game mode is an attribute of a ping, not an image of Dakota's.
+  assert.deepEqual(counts.normalizeCountmeRepo("bluefin-lts-gaming", 0), {
+    repo: "bluefin-lts",
+    gaming: true,
+  });
+
+  // Anything outside the first-party set still drops, suffixed or not.
+  assert.equal(counts.normalizeCountmeRepo("eos", 0), null);
+  assert.equal(counts.normalizeCountmeRepo("eos-gaming", 1), null);
+  assert.equal(counts.normalizeCountmeRepo("-gaming", 1), null);
+  assert.equal(counts.normalizeCountmeRepo(undefined, 0), null);
+});
+
+test("normalization is idempotent", () => {
+  for (const [repo, gamemode] of [
+    ["dakota-gaming", 1],
+    ["dakota-gaming", 0],
+    ["dakota", 1],
+    ["bluefin", 0],
+  ]) {
+    const once = counts.normalizeCountmeRepo(repo, gamemode);
+    const twice = counts.normalizeCountmeRepo(once.repo, once.gaming ? 1 : 0);
+    assert.deepEqual(twice, once, `${repo}/${gamemode} must settle`);
+  }
+});
+
+test("dakota-gaming folds into the dakota total and its gaming share", async () => {
+  const db = stubDb([
+    { week: "2026-09-07", repo: "dakota", gamemode: 0, hits: 18 },
+    { week: "2026-09-07", repo: "dakota-gaming", gamemode: 1, hits: 1 },
+    { week: "2026-09-07", repo: "eos", gamemode: 0, hits: 8 },
+  ]);
+
+  const body = await (await get("/counts.json", db.env)).json();
+  const week = body.weeks[0];
+
+  assert.equal(week.dakota, 19, "the gaming image is part of Dakota");
+  assert.equal(week.gaming.dakota, 1);
+  assert.ok(!("dakota-gaming" in week), "gaming is not a repo of its own");
+  assert.ok(!("eos" in week), "a repo outside the policy set never appears");
+  assert.deepEqual(body.variants, ["dakota"]);
+});
+
+test("a repo that reported no game mode that week is 0, not null", async () => {
+  const db = stubDb([
+    { week: "2026-09-07", repo: "bluefin", gamemode: 0, hits: 12 },
+    { week: "2026-09-07", repo: "dakota", gamemode: 1, hits: 3 },
+  ]);
+
+  const week = (await (await get("/counts.json", db.env)).json()).weeks[0];
+
+  assert.equal(week.gaming.bluefin, 0, "it reported, nobody was in game mode");
+  assert.equal(week.gaming.utah, null, "it did not report at all");
+  assert.equal(week.utah, null);
+  assert.equal(week.gaming.dakota, 3, "every Dakota ping was in game mode");
+  assert.equal(week.dakota, 3);
+});
+
+test("the gaming share never exceeds the total it came from", async () => {
+  const db = stubDb([
+    { week: "2026-08-31", repo: "dakota", gamemode: 0, hits: 18 },
+    { week: "2026-08-31", repo: "dakota-gaming", gamemode: 1, hits: 4 },
+    { week: "2026-08-31", repo: "bluefin", gamemode: 1, hits: 1 },
+    { week: "2026-09-14", repo: "bluefin-lts", gamemode: 0, hits: 2 },
+    { week: "2026-09-14", repo: "dakota", gamemode: 1, hits: 7 },
+  ]);
+
+  const body = await (await get("/counts.json", db.env)).json();
+
+  for (const week of body.weeks) {
+    for (const repo of policy.PROJECTBLUEFIN_REPOS) {
+      const total = week[repo];
+      const gaming = week.gaming[repo];
+
+      if (total === null) {
+        assert.equal(gaming, null, `${repo} ${week.week}: no data either way`);
+        continue;
+      }
+      assert.ok(
+        gaming <= total,
+        `${repo} ${week.week}: gaming ${gaming} exceeds total ${total}`,
+      );
+    }
+  }
 });
 
 test("counts.json declares a source every first-party repo may use", async () => {
@@ -302,10 +428,11 @@ test("an empty database yields a pending document at HTTP 200", async () => {
   assert.equal(body.stateReason, policy.FIRST_PARTY_PENDING_REASON);
 });
 
-test("charts and badges render from the database without leaving the edge", async () => {
+test("charts and badges show the total, game mode included", async () => {
   const db = stubDb([
-    { week: "2026-08-31", repo: "bluefin-lts", hits: 100 },
-    { week: "2026-09-07", repo: "bluefin-lts", hits: 194 },
+    { week: "2026-08-31", repo: "bluefin-lts", gamemode: 0, hits: 100 },
+    { week: "2026-09-07", repo: "bluefin-lts", gamemode: 0, hits: 194 },
+    { week: "2026-09-07", repo: "bluefin-lts-gaming", gamemode: 1, hits: 6 },
   ]);
   const stub = stubFetch(async () => new Response("", { status: 500 }));
 
@@ -319,13 +446,13 @@ test("charts and badges render from the database without leaving the edge", asyn
     );
     assert.equal(chart.headers.get("cache-control"), "public, max-age=900");
     assert.match(svg, /Bluefin LTS/u);
-    assert.match(svg, />194</u);
+    assert.match(svg, />200</u, "the plotted value is the population");
 
     const badge = await get("/badge-endpoints/bluefin-lts.json", db.env);
     assert.deepEqual(await badge.json(), {
       schemaVersion: 1,
       label: "Bluefin LTS",
-      message: "194",
+      message: "200",
       color: "bc8cff",
     });
 

--- a/src/components/analytics/CountmeAnalyticsCharts.module.css
+++ b/src/components/analytics/CountmeAnalyticsCharts.module.css
@@ -209,3 +209,29 @@
     gap: var(--fx-space-2);
   }
 }
+
+/* Upstream chart, published by ublue-os/countme and proxied unmodified. It is
+   an image rather than a plotted series because upstream ships no time-series
+   file; its axis is upstream's, so it is framed rather than blended in. */
+.legacyFigure {
+  margin: 0;
+}
+
+.legacyChart {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--fx-border);
+  border-radius: var(--fx-radius-md);
+  /* Upstream renders on white. It is framed and padded so it reads as an
+     embedded external artifact rather than a panel of ours, and it is not
+     recoloured: altering another project's published chart misrepresents it. */
+  background: #fff;
+  padding: var(--fx-space-2);
+}
+
+/* Game mode is a share of the image it belongs to, so it is stated inline with
+   that image's number rather than given a chip of its own. */
+.gamingSplit {
+  color: var(--fx-text-muted);
+}

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -13,6 +13,10 @@ import {
 import { FIRST_PARTY_PENDING_REASON } from "@site/scripts/lib/countme-sources.mjs";
 import {
   COUNTS_URL,
+  FIRST_PARTY_ORIGIN,
+  gamingRepos,
+  gamingSeries,
+  latestGaming,
   latestReading,
   measuredWeekCount,
   reportingRepos,
@@ -41,6 +45,21 @@ const REGISTRY_URL = "/data/ghcr-packages.json";
  * pairing twice published a Fedora-derived number under a Project Bluefin name,
  * so the two stay in separate files and the gate stays a real gate.
  */
+
+/**
+ * The one upstream series anyone may publish, per `UPSTREAM_ALLOWED`:
+ * `ublue-os/bluefin:stable`, counted by `ublue-os/countme`.
+ *
+ * Both are read through our own worker rather than from GitHub directly, so the
+ * page talks to a single origin and `raw.githubusercontent.com` does not need
+ * to appear in `connect-src` for this.
+ *
+ * Upstream publishes a rendered chart and a rounded badge value, and no
+ * time-series file, so this panel shows the image it publishes rather than
+ * replotting a series that does not exist.
+ */
+const LEGACY_CHART_URL = `${FIRST_PARTY_ORIGIN}/growth_bluefins.svg`;
+const LEGACY_BADGE_URL = `${FIRST_PARTY_ORIGIN}/badge-endpoints/bluefin.json`;
 
 /** Display names for the first-party `repo` identifiers. */
 export const REPO_LABELS: Record<string, string> = {
@@ -372,6 +391,27 @@ export default function CountmeAnalyticsCharts({
     [countmeWeeks],
   );
 
+  // ── Upstream image, the one permitted legacy series ────────────────────
+  //
+  // UPSTREAM_ALLOWED is the single exception to the first-party rule:
+  // ublue-os/bluefin:stable, counted by ublue-os/countme. Both the badge and
+  // the chart are proxied by our worker, so this stays on one origin and needs
+  // no second CSP entry.
+  const [legacyActive, setLegacyActive] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch(LEGACY_BADGE_URL);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const badge = (await res.json()) as { message?: string };
+        setLegacyActive(badge?.message ?? null);
+      } catch {
+        setLegacyActive(null);
+      }
+    })();
+  }, []);
+
   /** Readings that exist, so the panel can print a number per series. */
   const countmeReadings = useMemo(
     () =>
@@ -379,8 +419,29 @@ export default function CountmeAnalyticsCharts({
         repo,
         label: REPO_LABELS[repo] ?? repo,
         reading: latestReading(countmeWeeks, repo),
+        gaming: latestGaming(countmeWeeks, repo),
       })),
     [activeRepos, countmeWeeks],
+  );
+
+  /**
+   * Latest reading summed across every reporting image.
+   *
+   * Each image's own latest week is used, because they do not all report in the
+   * same week. Null when nothing has reported at all, so the panel says
+   * "accumulating data" rather than claiming a fleet of zero.
+   */
+  const firstPartyTotal = useMemo(() => {
+    const readings = countmeReadings
+      .map((r) => r.reading?.value)
+      .filter((v): v is number => typeof v === "number");
+    return readings.length ? readings.reduce((sum, v) => sum + v, 0) : null;
+  }, [countmeReadings]);
+
+  /** Images that actually reported game mode, so a flat zero is never drawn. */
+  const gamingActiveRepos = useMemo(
+    () => gamingRepos(countmeWeeks, activeRepos),
+    [countmeWeeks, activeRepos],
   );
 
   /** Rule 5: the point count is real readings, not axis length. */
@@ -399,29 +460,56 @@ export default function CountmeAnalyticsCharts({
       },
       // Anchored at zero: a floating floor turns a flat series into a cliff.
       yAxis: { type: "value", min: 0 },
-      series: activeRepos.map((repo, i) => ({
-        name: REPO_LABELS[repo] ?? repo,
-        type: "line",
-        // Rule 4: discrete weekly readings. No spline between them, and a
-        // missing week breaks the line rather than being bridged or zeroed.
-        smooth: false,
-        connectNulls: false,
-        showSymbol: true,
-        symbolSize: 7,
-        // The Bluefin palette is six shades of one hue, so colour alone cannot
-        // separate series. chartTheme pairs each index with a dash pattern and a
-        // symbol for exactly this; both survive greyscale and colour blindness.
-        symbol: SERIES_SYMBOLS[i % SERIES_SYMBOLS.length],
-        data: repoSeries(countmeWeeks, repo),
-        itemStyle: { color: cat[i % cat.length] },
-        lineStyle: {
-          width: 2,
-          color: cat[i % cat.length],
-          type: seriesDash(i),
-        },
-      })),
+      series: [
+        ...activeRepos.map((repo, i) => ({
+          name: REPO_LABELS[repo] ?? repo,
+          type: "line",
+          // Rule 4: discrete weekly readings. No spline between them, and a
+          // missing week breaks the line rather than being bridged or zeroed.
+          smooth: false,
+          connectNulls: false,
+          showSymbol: true,
+          symbolSize: 7,
+          // The Bluefin palette is six shades of one hue, so colour alone
+          // cannot separate series. chartTheme pairs each index with a dash
+          // pattern and a symbol for exactly this; both survive greyscale and
+          // colour blindness.
+          symbol: SERIES_SYMBOLS[i % SERIES_SYMBOLS.length],
+          data: repoSeries(countmeWeeks, repo),
+          itemStyle: { color: cat[i % cat.length] },
+          lineStyle: {
+            width: 2,
+            color: cat[i % cat.length],
+            type: seriesDash(i),
+          },
+        })),
+        // Game mode is a share of the image above it, never a separate image,
+        // so it carries that image's colour and sits under its line. It is
+        // drawn only for images that actually reported it, so a flat zero does
+        // not imply a population nobody measured.
+        ...gamingActiveRepos.map((repo) => {
+          const i = activeRepos.indexOf(repo);
+          return {
+            name: `${REPO_LABELS[repo] ?? repo} (game mode)`,
+            type: "line",
+            smooth: false,
+            connectNulls: false,
+            showSymbol: true,
+            symbolSize: 6,
+            symbol: "emptyCircle",
+            data: gamingSeries(countmeWeeks, repo),
+            itemStyle: { color: cat[i % cat.length] },
+            lineStyle: {
+              width: 1,
+              color: cat[i % cat.length],
+              type: "dotted",
+              opacity: 0.85,
+            },
+          };
+        }),
+      ],
     }),
-    [countmeWeeks, activeRepos, cat],
+    [countmeWeeks, activeRepos, gamingActiveRepos, cat],
   );
 
   /**
@@ -547,7 +635,7 @@ export default function CountmeAnalyticsCharts({
             {/* Rule 1: every series states its current number, in text, next
                 to the graphic rather than only inside it. */}
             <p className={styles.legendRow}>
-              {countmeReadings.map(({ repo, label, reading }, i) => (
+              {countmeReadings.map(({ repo, label, reading, gaming }, i) => (
                 <span key={repo} className={styles.legendChip}>
                   <span
                     className={styles.legendGlyph}
@@ -558,6 +646,12 @@ export default function CountmeAnalyticsCharts({
                   </span>
                   {label}:{" "}
                   {reading ? reading.value.toLocaleString() : "accumulating"}
+                  {reading && gaming !== null && gaming > 0 ? (
+                    <span className={styles.gamingSplit}>
+                      {" "}
+                      ({gaming.toLocaleString()} in game mode)
+                    </span>
+                  ) : null}
                 </span>
               ))}
             </p>
@@ -581,6 +675,69 @@ export default function CountmeAnalyticsCharts({
               FIRST_PARTY_PENDING_REASON
             }
           />
+        )}
+      </section>
+
+      {/* ── 2. Upstream image, for watching the migration ────────────────── */}
+      <section className={styles.panelCard}>
+        <header className={styles.sectionHeader}>
+          <Heading as="h3" className={styles.sectionTitle}>
+            Upstream Image (Legacy)
+          </Heading>
+          <p className={styles.sectionSubtext}>
+            <code>ublue-os/bluefin:stable</code> is counted by{" "}
+            <Link to="https://github.com/ublue-os/countme">
+              ublue-os/countme
+            </Link>
+            , not by Project Bluefin. It is shown alongside the first-party
+            counts so the migration between them is visible. The two are
+            measured by different services and are not the same quantity: the
+            legacy series counts DNF metalink hits, the first-party series
+            counts image check-ins.
+          </p>
+        </header>
+
+        {/* Rule 1: both sides of the comparison carry their current value. */}
+        <p className={styles.legendRow}>
+          <span className={styles.legendChip}>
+            <span className={styles.legendGlyph} aria-hidden="true">
+              ◇
+            </span>
+            Upstream <code>bluefin:stable</code>:{" "}
+            {legacyActive ?? "unavailable"}
+          </span>
+          <span className={styles.legendChip}>
+            <span className={styles.legendGlyph} aria-hidden="true">
+              ●
+            </span>
+            Project Bluefin images:{" "}
+            {firstPartyTotal === null
+              ? "accumulating data"
+              : firstPartyTotal.toLocaleString()}
+          </span>
+        </p>
+
+        {legacyActive === null ? (
+          <Unavailable
+            what="Upstream count"
+            reason="The upstream badge could not be read."
+          />
+        ) : (
+          <figure className={styles.legacyFigure}>
+            <img
+              className={styles.legacyChart}
+              src={LEGACY_CHART_URL}
+              alt={`Upstream ublue-os/bluefin growth chart. Current upstream active users: ${legacyActive}.`}
+              loading="lazy"
+              width={1200}
+              height={700}
+            />
+            <figcaption className={styles.chartNote}>
+              Chart published by <code>ublue-os/countme</code> and proxied
+              unmodified. Its axis and scale are upstream&rsquo;s, so it is not
+              plotted on the same domain as the first-party panel above.
+            </figcaption>
+          </figure>
         )}
       </section>
 

--- a/src/components/analytics/firstPartyCountme.ts
+++ b/src/components/analytics/firstPartyCountme.ts
@@ -21,7 +21,10 @@ import {
  * The aggregate is fetched at runtime rather than built into the site because
  * it accumulates continuously, while the site rebuilds only on merge.
  */
-export const COUNTS_URL = `${FIRST_PARTY.origin}/counts.json`;
+/** The first-party origin. Every route below is served by our own worker. */
+export const FIRST_PARTY_ORIGIN: string = FIRST_PARTY.origin;
+
+export const COUNTS_URL = `${FIRST_PARTY_ORIGIN}/counts.json`;
 
 /** One week of first-party counts. A missing repo is `null` — a gap, never 0. */
 export interface CountmeWeek {
@@ -108,4 +111,54 @@ export function measuredWeekCount(
   return weeks.filter((w) =>
     repos.some((repo) => parseReading(w[repo]) !== null),
   ).length;
+}
+
+/**
+ * Game-mode counts for a week, when the service reports them.
+ *
+ * Game mode is an attribute of a ping, not an image: a client reports it as a
+ * `-gaming` repo id or a `gamemode=1` flag, and the service folds both into the
+ * base image. `weeks[i][repo]` is therefore the whole population and
+ * `weeks[i].gaming[repo]` is the part of it that was in game mode, so the two
+ * are never added together.
+ */
+export function gamingOf(
+  week: CountmeWeek | undefined,
+): Record<string, unknown> {
+  const gaming = week?.gaming;
+  return gaming && typeof gaming === "object"
+    ? (gaming as Record<string, unknown>)
+    : {};
+}
+
+/** A repo's game-mode series across the week axis, gaps preserved as null. */
+export function gamingSeries(
+  weeks: CountmeWeek[],
+  repo: string,
+): Array<number | null> {
+  return weeks.map((w) => parseReading(gamingOf(w)[repo]));
+}
+
+/**
+ * Latest game-mode reading for a repo, read backwards like `latestReading`.
+ *
+ * A repo that reported but had nobody in game mode is `0`, which is a real
+ * measurement and distinct from the `null` of a week it did not report at all.
+ */
+export function latestGaming(
+  weeks: CountmeWeek[],
+  repo: string,
+): number | null {
+  for (let i = weeks.length - 1; i >= 0; i -= 1) {
+    const value = parseReading(gamingOf(weeks[i])[repo]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+/** Repos carrying at least one non-zero game-mode reading. */
+export function gamingRepos(weeks: CountmeWeek[], repos: string[]): string[] {
+  return repos.filter((repo) =>
+    weeks.some((w) => (parseReading(gamingOf(w)[repo]) ?? 0) > 0),
+  );
 }

--- a/workers/countme-proxy/counts.mjs
+++ b/workers/countme-proxy/counts.mjs
@@ -1,0 +1,149 @@
+// Shaping the counts document. Pure functions only: the D1 round-trip lives in
+// index.mjs so the counting rules can be tested without a database.
+
+import {
+  FIRST_PARTY,
+  FIRST_PARTY_PENDING_REASON,
+  PROJECTBLUEFIN_REPOS,
+} from "../../scripts/lib/countme-sources.mjs";
+
+const COUNT_METHOD = "first-party-d1-v2";
+const COUNT_UNIT = "estimated weekly active systems";
+const WEEK_WINDOW_DAYS = 180;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Game mode is an attribute of a ping, not an image of its own.
+ *
+ * Clients report it two ways — a `-gaming` repo id, or `gamemode=1` — and both
+ * must land in the same bucket, counted under the base image.
+ */
+export const GAMING_SUFFIX = "-gaming";
+
+/** Every repo id the service accepts, in both spellings. */
+export const COUNTED_REPO_IDS = [
+  ...PROJECTBLUEFIN_REPOS,
+  ...PROJECTBLUEFIN_REPOS.map((repo) => `${repo}${GAMING_SUFFIX}`),
+];
+
+/**
+ * Weekly counts per reported repo and game-mode flag, Monday-anchored.
+ *
+ * `weekday 0` advances to that week's Sunday, so `-6 days` lands on its Monday
+ * — the same week key the published series has always used.
+ */
+export const WEEKLY_COUNTS_SQL = `SELECT date(received_at, 'weekday 0', '-6 days') AS week,
+          repo,
+          gamemode,
+          COUNT(*) AS hits
+   FROM telemetry_events
+   WHERE received_at >= date('now', '-${WEEK_WINDOW_DAYS} days')
+     AND repo IN (${COUNTED_REPO_IDS.map(() => "?").join(", ")})
+   GROUP BY week, repo, gamemode
+   ORDER BY week ASC`;
+
+/**
+ * Fold a reported id into a first-party repo plus a game-mode flag.
+ *
+ * Idempotent: feeding a result back through changes nothing, because the
+ * suffix is already gone and the flag is already set. Returns null for ids
+ * that are not ours, which is how anything outside PROJECTBLUEFIN_REPOS drops.
+ */
+export function normalizeCountmeRepo(repo, gamemode) {
+  const id = String(repo ?? "");
+  const suffixed = id.endsWith(GAMING_SUFFIX);
+  const base = suffixed ? id.slice(0, -GAMING_SUFFIX.length) : id;
+
+  if (!PROJECTBLUEFIN_REPOS.includes(base)) return null;
+
+  return { repo: base, gaming: suffixed || Number(gamemode) === 1 };
+}
+
+function countsMeta() {
+  return {
+    generatedAt: new Date().toISOString(),
+    source: FIRST_PARTY.origin,
+    method: COUNT_METHOD,
+    unit: COUNT_UNIT,
+  };
+}
+
+/** The document served when nothing countable is available yet. */
+export function pendingCountsDocument() {
+  return {
+    ...countsMeta(),
+    variants: [],
+    weeks: [],
+    unavailable: true,
+    stateReason: FIRST_PARTY_PENDING_REASON,
+  };
+}
+
+/** Every Monday from `first` through `last`, so a silent week stays visible. */
+function weekAxis(first, last) {
+  const axis = [];
+  for (
+    let stamp = Date.parse(`${first}T00:00:00Z`);
+    stamp <= Date.parse(`${last}T00:00:00Z`);
+    stamp += WEEK_MS
+  ) {
+    axis.push(new Date(stamp).toISOString().slice(0, 10));
+  }
+  return axis;
+}
+
+/**
+ * The counts document.
+ *
+ * `week[repo]` is the total for that image, game mode included, because that
+ * is the population. `week.gaming[repo]` is the part of it that was in game
+ * mode: 0 is a real measurement — the image reported, nobody was in game mode
+ * — while null means the image did not report at all that week. The same
+ * distinction governs the totals, so neither can be inferred from the other.
+ */
+export function buildCountsDocument(rows) {
+  const counted = (Array.isArray(rows) ? rows : []).filter(
+    (row) => row && typeof row.week === "string" && Number.isFinite(row.hits),
+  );
+
+  const byWeek = new Map();
+  for (const row of counted) {
+    const normalized = normalizeCountmeRepo(row.repo, row.gamemode);
+    if (!normalized) continue;
+
+    const week = byWeek.get(row.week) || new Map();
+    const cell = week.get(normalized.repo) || { total: 0, gaming: 0 };
+    cell.total += row.hits;
+    if (normalized.gaming) cell.gaming += row.hits;
+    week.set(normalized.repo, cell);
+    byWeek.set(row.week, week);
+  }
+
+  if (byWeek.size === 0) return pendingCountsDocument();
+
+  const observed = [...byWeek.keys()].sort();
+  const weeks = weekAxis(observed[0], observed[observed.length - 1]).map(
+    (week) => {
+      const counts = byWeek.get(week);
+      const entry = { week };
+      const gaming = {};
+
+      for (const repo of PROJECTBLUEFIN_REPOS) {
+        const cell = counts && counts.get(repo);
+        entry[repo] = cell ? cell.total : null;
+        gaming[repo] = cell ? cell.gaming : null;
+      }
+
+      entry.gaming = gaming;
+      return entry;
+    },
+  );
+
+  return {
+    ...countsMeta(),
+    variants: PROJECTBLUEFIN_REPOS.filter((repo) =>
+      weeks.some((week) => week[repo] !== null),
+    ),
+    weeks,
+  };
+}

--- a/workers/countme-proxy/index.mjs
+++ b/workers/countme-proxy/index.mjs
@@ -9,16 +9,13 @@ import {
   renderRepoChartSvg,
 } from "./render.mjs";
 import {
-  FIRST_PARTY,
-  FIRST_PARTY_PENDING_REASON,
-  PROJECTBLUEFIN_REPOS,
-} from "../../scripts/lib/countme-sources.mjs";
+  COUNTED_REPO_IDS,
+  WEEKLY_COUNTS_SQL,
+  buildCountsDocument,
+  pendingCountsDocument,
+} from "./counts.mjs";
 
 const USER_AGENT = "projectbluefin-countme-worker/1.0";
-const COUNT_METHOD = "first-party-d1-v1";
-const COUNT_UNIT = "estimated weekly active systems";
-const WEEK_WINDOW_DAYS = 180;
-const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 function baseHeaders(extra = {}) {
   return {
@@ -107,102 +104,19 @@ function jsonResponse(payload, maxAgeSeconds) {
   });
 }
 
-/**
- * Weekly counts per first-party repo, Monday-anchored.
- *
- * `weekday 0` advances to that week's Sunday, so `-6 days` lands on its Monday
- * — the same week key the published series has always used.
- */
-const WEEKLY_COUNTS_SQL = `SELECT date(received_at, 'weekday 0', '-6 days') AS week,
-          repo,
-          COUNT(*) AS hits
-   FROM telemetry_events
-   WHERE received_at >= date('now', '-${WEEK_WINDOW_DAYS} days')
-     AND repo IN (${PROJECTBLUEFIN_REPOS.map(() => "?").join(", ")})
-   GROUP BY week, repo
-   ORDER BY week ASC`;
-
-function countsMeta() {
-  return {
-    generatedAt: new Date().toISOString(),
-    source: FIRST_PARTY.origin,
-    method: COUNT_METHOD,
-    unit: COUNT_UNIT,
-  };
-}
-
-function pendingCounts() {
-  return {
-    ...countsMeta(),
-    variants: [],
-    weeks: [],
-    unavailable: true,
-    stateReason: FIRST_PARTY_PENDING_REASON,
-  };
-}
-
-/** Every Monday from `first` through `last`, so a silent week stays visible. */
-function weekAxis(first, last) {
-  const axis = [];
-  for (
-    let stamp = Date.parse(`${first}T00:00:00Z`);
-    stamp <= Date.parse(`${last}T00:00:00Z`);
-    stamp += WEEK_MS
-  ) {
-    axis.push(new Date(stamp).toISOString().slice(0, 10));
-  }
-  return axis;
-}
-
-/**
- * The counts document. A repo with no rows in a week is null, never 0: we
- * cannot distinguish "nobody reported" from "nobody was running it".
- */
+/** Runs the weekly query and hands the rows to the counting rules. */
 async function aggregateWeeklyCounts(env) {
-  if (!env || !env.DB) return pendingCounts();
+  if (!env || !env.DB) return pendingCountsDocument();
 
-  let rows;
   try {
     const query = await env.DB.prepare(WEEKLY_COUNTS_SQL)
-      .bind(...PROJECTBLUEFIN_REPOS)
+      .bind(...COUNTED_REPO_IDS)
       .all();
-    rows = (query && query.results) || [];
+    return buildCountsDocument((query && query.results) || []);
   } catch (err) {
     console.error("Failed to aggregate countme records:", err);
-    return pendingCounts();
+    return pendingCountsDocument();
   }
-
-  const counted = rows.filter(
-    (row) => row && typeof row.week === "string" && Number.isFinite(row.hits),
-  );
-  if (counted.length === 0) return pendingCounts();
-
-  const byWeek = new Map();
-  for (const row of counted) {
-    const week = byWeek.get(row.week) || new Map();
-    week.set(row.repo, (week.get(row.repo) || 0) + row.hits);
-    byWeek.set(row.week, week);
-  }
-
-  const observed = [...byWeek.keys()].sort();
-  const weeks = weekAxis(observed[0], observed[observed.length - 1]).map(
-    (week) => {
-      const counts = byWeek.get(week);
-      const entry = { week };
-      for (const repo of PROJECTBLUEFIN_REPOS) {
-        entry[repo] = counts && counts.has(repo) ? counts.get(repo) : null;
-      }
-      return entry;
-    },
-  );
-
-  return {
-    ...countsMeta(),
-    variants: PROJECTBLUEFIN_REPOS.filter((repo) =>
-      weeks.some((week) => week[repo] !== null),
-    ),
-    weeks,
-  };
 }
 
 async function createCountsResponse(env) {


### PR DESCRIPTION
Follows #1244.

## Game mode counts as its image

Game mode arrived two ways — a `-gaming` repo id and a `gamemode=1` parameter — and live D1 held both, plus a `bluefin` row also flagged `gamemode=1`. So it is an attribute of a ping, not a Dakota-specific image. Left as-is, `dakota-gaming` was a phantom repo splitting Dakota's population in two.

- The service normalizes the repo id and folds both spellings into the base image.
- `weeks[i][repo]` is the **population**, including game mode. `weeks[i].gaming[repo]` is the **share** of it in game mode. Never addends; `gaming[repo] <= weeks[i][repo]` is asserted per repo per week.
- A repo that reported with nobody in game mode is `0`. A repo that did not report is `null`.
- The page plots a game-mode series only for images with a non-zero reading, so a flat zero never implies a population nobody measured.
- Each game-mode series carries its parent image's colour with a dotted stroke, so it reads as a share of the line above it rather than a new image. The split is also stated in words next to that image's number.
- Method bumped to `first-party-d1-v2`.

Live effect: `dakota` went 3 → 4 as the `dakota-gaming` ping folded in, with `gaming.dakota = 1`. `dakota-gaming` no longer appears as a variant.

## Upstream series shown alongside

`ublue-os/bluefin:stable` now appears on the page next to the first-party counts so migration between them is visible rather than inferred. That is `UPSTREAM_ALLOWED`, the single permitted upstream series, read through the worker's existing legacy routes — no new CSP entry and no new worker route.

Upstream publishes rendered matplotlib SVGs and a rounded badge value, and **no time-series file**. The panel therefore embeds the chart upstream publishes rather than replotting a series that does not exist, and states the badge value (`4.8k`) as its current number. The image is framed, not recoloured: altering another project's published chart would misrepresent it.

The panel states plainly that the two series are not the same quantity — legacy counts DNF metalink hits, first-party counts image check-ins — so the difference is not read as a decline.

## Verification

- Worker deployed: version `4ca03c13-0935-446f-89b7-6adcf4b9d2c3`.
- Live `/counts.json`: `dakota: 4`, `gaming.dakota: 1`, `gaming["bluefin-lts"]: 0`, `utah` null in both. `variants` excludes `dakota-gaming`.
- Page verified in a browser against the live endpoint: `Project Bluefin Dakota: 4 (1 in game mode)`, `Bluefin: 1 (1 in game mode)`, `Bluefin LTS: 2` with no suffix since its share is a real zero. Legacy chart loads and renders.
- `just check`: 0 lint errors, 1044/1044 tests pass, typecheck clean.

ADR 0007 extended with both decisions.