### PR TITLE
feat(countme): serve the upstream chart in the Bluefin palette

### DIFF
--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -762,3 +762,85 @@ test("accepts metalink pings from Utah countme clients", async () => {
     /countme accepted for repo=utah tag=testing flavor=default gamemode=0 arch=x86_64 countme=1/i,
   );
 });
+
+test("the themed legacy chart recolours upstream without re-deriving it", async () => {
+  // isPermittedSource allows exactly one source for ublue-os/bluefin:stable, so
+  // this route must fetch the same artifact the untouched route serves and only
+  // change its colours. Recomputing the series from Fedora's CSV — how upstream
+  // builds it — would be a forbidden source wearing our palette.
+  const upstreamSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg">' +
+    '<rect fill="#ffffff" width="10" height="10"/>' +
+    '<path stroke="#cccccc" d="M0 0"/>' +
+    '<text fill="#616161">2026-01</text>' +
+    '<path stroke="#77aadd" d="M1 1 L2 2"/>' +
+    "</svg>";
+
+  const calls = [];
+  const restore = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return new Response(upstreamSvg, {
+      status: 200,
+      headers: { "content-type": "image/svg+xml" },
+    });
+  };
+
+  try {
+    const res = await fetchHandler(
+      new Request("https://countme.projectbluefin.io/legacy/bluefin.svg"),
+      {},
+      { waitUntil() {} },
+    );
+    const body = await res.text();
+
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /svg/);
+    assert.equal(
+      calls.length,
+      1,
+      "the themed chart must come from one upstream fetch",
+    );
+    assert.match(calls[0], /ublue-os\/countme/);
+    assert.doesNotMatch(
+      calls[0],
+      /data-analysis\.fedoraproject\.org/,
+      "the series must never be recomputed from the forbidden source",
+    );
+
+    // Upstream's white canvas must not survive onto a dark panel.
+    assert.doesNotMatch(body, /#ffffff/i);
+    assert.doesNotMatch(body, /#77aadd/i);
+    assert.match(body, /#58a6ff/, "the series takes the Bluefin accent");
+
+    // The geometry is upstream's and must be untouched.
+    assert.match(body, /d="M1 1 L2 2"/);
+    assert.match(body, /2026-01/);
+  } finally {
+    globalThis.fetch = restore;
+  }
+});
+
+test("the untouched legacy route still returns upstream's own bytes", async () => {
+  const upstreamSvg =
+    '<svg><rect fill="#ffffff"/><path stroke="#77aadd"/></svg>';
+  const restore = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(upstreamSvg, {
+      status: 200,
+      headers: { "content-type": "image/svg+xml" },
+    });
+
+  try {
+    const res = await fetchHandler(
+      new Request("https://countme.projectbluefin.io/growth_bluefins.svg"),
+      {},
+      { waitUntil() {} },
+    );
+    const body = await res.text();
+    assert.match(body, /#ffffff/, "upstream's artifact stays byte-for-byte");
+    assert.match(body, /#77aadd/);
+  } finally {
+    globalThis.fetch = restore;
+  }
+});

--- a/src/components/analytics/CountmeAnalyticsCharts.module.css
+++ b/src/components/analytics/CountmeAnalyticsCharts.module.css
@@ -223,11 +223,11 @@
   height: auto;
   border: 1px solid var(--fx-border);
   border-radius: var(--fx-radius-md);
-  /* Upstream renders on white. It is framed and padded so it reads as an
-     embedded external artifact rather than a panel of ours, and it is not
-     recoloured: altering another project's published chart misrepresents it. */
-  background: #fff;
-  padding: var(--fx-space-2);
+  /* The worker recolours upstream's chart to the Bluefin palette and leaves
+     its canvas transparent, so the panel surface shows through and the chart
+     follows the light and dark themes without a second copy. */
+  background: var(--fx-surface-2);
+  padding: var(--fx-space-3);
 }
 
 /* Game mode is a share of the image it belongs to, so it is stated inline with

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -58,7 +58,7 @@ const REGISTRY_URL = "/data/ghcr-packages.json";
  * time-series file, so this panel shows the image it publishes rather than
  * replotting a series that does not exist.
  */
-const LEGACY_CHART_URL = `${FIRST_PARTY_ORIGIN}/growth_bluefins.svg`;
+const LEGACY_CHART_URL = `${FIRST_PARTY_ORIGIN}/legacy/bluefin.svg`;
 const LEGACY_BADGE_URL = `${FIRST_PARTY_ORIGIN}/badge-endpoints/bluefin.json`;
 
 /** Display names for the first-party `repo` identifiers. */
@@ -685,15 +685,11 @@ export default function CountmeAnalyticsCharts({
             Upstream Image (Legacy)
           </Heading>
           <p className={styles.sectionSubtext}>
-            <code>ublue-os/bluefin:stable</code> is counted by{" "}
+            <code>ublue-os/bluefin:stable</code>, counted by{" "}
             <Link to="https://github.com/ublue-os/countme">
               ublue-os/countme
             </Link>
-            , not by Project Bluefin. It is shown alongside the first-party
-            counts so the migration between them is visible. The two are
-            measured by different services and are not the same quantity: the
-            legacy series counts DNF metalink hits, the first-party series
-            counts image check-ins.
+            . Metalink hits, not image check-ins.
           </p>
         </header>
 
@@ -733,9 +729,8 @@ export default function CountmeAnalyticsCharts({
               height={700}
             />
             <figcaption className={styles.chartNote}>
-              Chart published by <code>ublue-os/countme</code> and proxied
-              unmodified. Its axis and scale are upstream&rsquo;s, so it is not
-              plotted on the same domain as the first-party panel above.
+              Published by <code>ublue-os/countme</code>, recoloured only.
+              Upstream&rsquo;s scale.
             </figcaption>
           </figure>
         )}

--- a/workers/countme-proxy/index.mjs
+++ b/workers/countme-proxy/index.mjs
@@ -5,6 +5,7 @@ import {
 } from "./routes.mjs";
 import {
   renderAccumulatingSvg,
+  restyleUpstreamChart,
   renderRepoBadge,
   renderRepoChartSvg,
 } from "./render.mjs";
@@ -160,6 +161,32 @@ async function createLegacyProxyResponse(upstream) {
   });
 }
 
+/**
+ * Upstream's chart in the Bluefin palette.
+ *
+ * The bytes are fetched from the same artifact the untouched legacy route
+ * serves, so the data and its provenance are identical; only the four colours
+ * matplotlib emits are rewritten. A failure falls back to nothing rather than
+ * to a substitute series: there is no other permitted source for this image.
+ */
+async function createThemedLegacyResponse(upstream) {
+  const upstreamRes = await fetch(upstream, {
+    headers: { "user-agent": USER_AGENT },
+  });
+
+  if (!upstreamRes.ok) {
+    return new Response(`upstream error: ${upstreamRes.status}`, {
+      status: 502,
+      headers: baseHeaders({ "content-type": "text/plain;charset=UTF-8" }),
+    });
+  }
+
+  return svgResponse(
+    restyleUpstreamChart(await upstreamRes.text()),
+    COUNTS_CACHE_TTL_SECONDS,
+  );
+}
+
 async function proxyRequest(request, env, ctx) {
   const url = new URL(request.url);
   const pathname = normalizePathname(url.pathname);
@@ -187,6 +214,8 @@ async function proxyRequest(request, env, ctx) {
   if (route.kind === "counts") return createCountsResponse(env);
   if (route.kind === "chart") return createChartResponse(env, route.repo);
   if (route.kind === "badge") return createBadgeResponse(env, route.repo);
+  if (route.kind === "legacy-themed")
+    return createThemedLegacyResponse(route.url);
 
   return createLegacyProxyResponse(route.url);
 }

--- a/workers/countme-proxy/render.mjs
+++ b/workers/countme-proxy/render.mjs
@@ -257,3 +257,40 @@ export function renderRepoBadge(dataset, repo) {
     color: (current ? repoAccent(repo) : PALETTE.muted).replace("#", ""),
   };
 }
+
+/**
+ * The upstream chart, recoloured to the Bluefin palette.
+ *
+ * Presentation only. Every coordinate, tick and label stays exactly as upstream
+ * drew it; this rewrites the four colours matplotlib emits and nothing else.
+ * The data is not re-derived, because it may not be: `isPermittedSource` allows
+ * one source for `ublue-os/bluefin:stable`, and recomputing the series from
+ * Fedora's CSV would be a forbidden source wearing our palette.
+ *
+ * The background becomes transparent rather than dark. An SVG inside an `<img>`
+ * cannot read the page's CSS, so a baked dark canvas would be wrong in light
+ * mode; letting the panel behind it show through is correct in both. The ink
+ * tones are chosen to clear AA on either surface for the same reason.
+ */
+const UPSTREAM_PALETTE = Object.freeze({
+  "#ffffff": "none", // canvas — let the panel behind show through
+  "#cccccc": "#7d848d", // gridlines
+  "#616161": "#8b949e", // axis labels and ticks
+  "#77aadd": "#58a6ff", // the series itself, in Bluefin blue
+});
+
+export function restyleUpstreamChart(svg) {
+  let out = String(svg);
+
+  for (const [from, to] of Object.entries(UPSTREAM_PALETTE)) {
+    out = out.replaceAll(from, to);
+    out = out.replaceAll(from.toUpperCase(), to);
+  }
+
+  // matplotlib paints the canvas as an opaque rect before anything else.
+  // `fill="none"` above handles the declared colour; this catches the pair of
+  // full-bleed rects it emits with an explicit style instead.
+  out = out.replaceAll('style="fill: none"', 'style="fill:none"');
+
+  return out;
+}

--- a/workers/countme-proxy/routes.mjs
+++ b/workers/countme-proxy/routes.mjs
@@ -20,6 +20,21 @@ export const LEGACY_ROUTES = {
   "/badge-endpoints/bluefin.json": UPSTREAM_ALLOWED.source,
 };
 
+/**
+ * The upstream chart, restyled to the Bluefin palette.
+ *
+ * Presentation only. The series, its axes and its values are upstream's,
+ * fetched from the same artifact as `/growth_bluefins.svg` and never
+ * re-derived: `isPermittedSource` allows exactly one source for
+ * `ublue-os/bluefin:stable`, so recomputing this series from Fedora's CSV —
+ * which is how upstream builds it — would be a forbidden source wearing our
+ * palette. Recolouring the artifact claims nothing new about the data.
+ *
+ * `/growth_bluefins.svg` keeps returning upstream's bytes unchanged, for
+ * anything that expects the original.
+ */
+export const LEGACY_THEMED_ROUTE = "/legacy/bluefin.svg";
+
 /** Weekly aggregate of our own countme records, as JSON. */
 export const COUNTS_ROUTE = "/counts.json";
 
@@ -65,6 +80,9 @@ export function resolveRoute(pathname) {
   const normalized = normalizePathname(pathname);
 
   const legacyUrl = LEGACY_ROUTES[normalized];
+
+  if (normalized === LEGACY_THEMED_ROUTE)
+    return { kind: "legacy-themed", url: LEGACY_BLUEFIN_CHART_URL };
   if (legacyUrl) return { kind: "legacy", url: legacyUrl };
 
   if (normalized === COUNTS_ROUTE) return { kind: "counts" };


### PR DESCRIPTION
The upstream growth chart rendered on matplotlib's white canvas — a foreign slab inside a dark panel.

## What changed

`/legacy/bluefin.svg` returns the same upstream artifact with its four colours remapped:

| upstream | becomes | |
| --- | --- | --- |
| `#ffffff` | `none` | canvas goes transparent so the panel shows through |
| `#cccccc` | `#7d848d` | gridlines |
| `#616161` | `#8b949e` | axis labels and ticks |
| `#77aadd` | `#58a6ff` | the series, in Bluefin blue |

Geometry, ticks and labels are untouched — 34,452 bytes against upstream's 34,464, the difference being colour strings only.

The canvas is transparent rather than dark on purpose: an SVG inside an `<img>` cannot read the page's CSS, so a baked dark canvas would be wrong in light mode. Letting the panel behind show through is correct in both.

## Why it is recoloured and not regenerated

`isPermittedSource` is strict equality for the upstream image:

```js
if (repo === UPSTREAM_ALLOWED.id) return s === UPSTREAM_ALLOWED.source;
```

Upstream builds this chart from Fedora's `totals.csv` (`graph.sh` → `main.py`). Recomputing the series the same way would attach a `FORBIDDEN_SOURCES` match to `ublue-os/bluefin:stable` and fail `countme-first-party.test.js`. There is no permitted *series* for that image, only the badge's point value.

Recolouring the permitted artifact claims nothing new about the data.

## Untouched routes

`/growth_bluefins.svg` and `/sources/ublue-os/bluefin/growth.svg` keep returning upstream's bytes byte-for-byte, asserted by a test, for anything that expects the original.

## Verification

- Worker deployed: version `21295866-4cf7-43c6-9956-0de2c56f9983`.
- Themed route contains no `#ffffff` and no `#77aadd`; series is `#58a6ff`.
- Untouched route still returns `#ffffff #cccccc #616161 #77aadd`.
- Page verified in a browser: chart loads at 1536×864 and reads as a native panel.
- `just check`: 0 lint errors, 1046/1046 tests pass.

Panel copy also trimmed to match the compression in 9dc763f2.