### PR TITLE
fix(countme): ink the upstream chart title

### DIFF
--- a/scripts/countme-worker.test.js
+++ b/scripts/countme-worker.test.js
@@ -844,3 +844,42 @@ test("the untouched legacy route still returns upstream's own bytes", async () =
     globalThis.fetch = restore;
   }
 });
+
+test("the chart title is inked, not left to default black", async () => {
+  // matplotlib omits `style` on the title's group, so a remap that only
+  // rewrites declared colours leaves it black on a dark panel. Every other text
+  // group carries its own fill.
+  const upstreamSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg">' +
+    '<g id="text_17"><g style="fill: #616161" transform="translate(1 2)"/></g>' +
+    '<g id="text_18">\n <!-- Weekly Active Devices -->\n ' +
+    '<g transform="translate(3 4)"/></g>' +
+    '<g id="line2d_1"><g transform="translate(5 6)"/></g>' +
+    "</svg>";
+
+  const restore = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(upstreamSvg, {
+      status: 200,
+      headers: { "content-type": "image/svg+xml" },
+    });
+
+  try {
+    const res = await fetchHandler(
+      new Request("https://countme.projectbluefin.io/legacy/bluefin.svg"),
+      {},
+      { waitUntil() {} },
+    );
+    const body = await res.text();
+
+    assert.match(
+      body,
+      /<g id="text_18">\s*<!-- Weekly Active Devices -->\s*<g style="fill: #8b949e" transform="translate\(3 4\)"/u,
+      "the title must be given the same ink as the axis labels",
+    );
+    // A plotted group is not text and must keep its own styling untouched.
+    assert.match(body, /<g id="line2d_1"><g transform="translate\(5 6\)"/u);
+  } finally {
+    globalThis.fetch = restore;
+  }
+});

--- a/workers/countme-proxy/render.mjs
+++ b/workers/countme-proxy/render.mjs
@@ -279,6 +279,20 @@ const UPSTREAM_PALETTE = Object.freeze({
   "#77aadd": "#58a6ff", // the series itself, in Bluefin blue
 });
 
+/** The ink every text group gets, including the ones upstream leaves unset. */
+const UPSTREAM_INK = "#8b949e";
+
+/**
+ * Text groups matplotlib emits with no fill of their own.
+ *
+ * Axis labels and ticks carry `style="fill: ..."`; the chart title does not, so
+ * it falls back to the SVG default of black and stays black through a colour
+ * remap that only rewrites declared values. Matching the group opener is what
+ * makes this catch the title without touching the plotted paths.
+ */
+const UNSTYLED_TEXT_GROUP =
+  /(<g id="text_\d+">\s*(?:<!--[\s\S]*?-->\s*)?<g )(transform=)/gu;
+
 export function restyleUpstreamChart(svg) {
   let out = String(svg);
 
@@ -286,6 +300,8 @@ export function restyleUpstreamChart(svg) {
     out = out.replaceAll(from, to);
     out = out.replaceAll(from.toUpperCase(), to);
   }
+
+  out = out.replace(UNSTYLED_TEXT_GROUP, `$1style="fill: ${UPSTREAM_INK}" $2`);
 
   // matplotlib paints the canvas as an opaque rect before anything else.
   // `fill="none"` above handles the declared colour; this catches the pair of


### PR DESCRIPTION
"Weekly Active Devices" rendered black on the dark panel.

matplotlib emits the title's `<g>` with **no `style` attribute at all**, so it falls back to the SVG default of black. Every other text group carries an explicit `style="fill: ..."`, which is why the colour remap caught them and missed this one:

```
text_1..17, text_19: style=fill: #8b949e
text_18:             style=NONE      <- the title
```

The restyle now supplies the label ink to any text group lacking one, matched on the group opener (`<g id="text_N">` followed by its `<g transform=`) so plotted paths and clip groups are untouched.

## Verification

- Worker deployed: version `e12968c9-458f-4b3a-8513-c06af92f3ab6`.
- Live SVG: title group is now `<g style="fill: #8b949e" transform="translate(487.895 …)">`; zero unstyled text groups remain; palette is `#58a6ff #7d848d #8b949e` with no black and no `#ffffff`.
- Page verified in a browser: title renders in the same muted grey as the axis labels.
- `node --test scripts/countme-worker.test.js`: 32 pass, including a new test asserting the title is inked and that a non-text group keeps its own styling.