### PR TITLE
fix(analytics): make the weekly active systems labels readable

### DIFF
--- a/scripts/countme-analytics-charts.test.js
+++ b/scripts/countme-analytics-charts.test.js
@@ -72,6 +72,7 @@ function loadComponent() {
 const mod = loadComponent();
 const {
   parseCount,
+  compactWeek,
   BLUEFIN_FAMILY_IMAGES,
   default: CountmeAnalyticsCharts,
 } = mod;
@@ -386,16 +387,16 @@ test("the chart carries gaps through to the series, never zeros", () => {
       .replace(/&amp;/g, "&"),
   );
 
-  const lts = option.series.find((s) => s.name === "Bluefin LTS");
+  const lts = option.series.find((s) => s.name === "LTS");
   assert.deepEqual(lts.data, [0, null, null]);
   assert.equal(lts.connectNulls, false, "a gap must break the line");
   assert.equal(lts.smooth, false, "a spline invents values between weeks");
 
-  const dakota = option.series.find((s) => s.name === "Project Bluefin Dakota");
+  const dakota = option.series.find((s) => s.name === "Dakota");
   assert.deepEqual(dakota.data, [null, 9, 14]);
 
   assert.ok(
-    !option.series.some((s) => s.name === "Project Bluefin Utah"),
+    !option.series.some((s) => s.name === "Utah"),
     "a repo with no readings must not be plotted",
   );
   assert.equal(
@@ -502,16 +503,16 @@ test("the game-mode series is drawn under its image, not as a new one", () => {
   );
 
   const names = option.series.map((s) => s.name);
-  assert.ok(names.includes("Project Bluefin Dakota"));
-  assert.ok(names.includes("Project Bluefin Dakota (game mode)"));
+  assert.ok(names.includes("Dakota"));
+  assert.ok(names.includes("Dakota \u00b7 game mode"));
   assert.ok(
     !names.some((n) => n.includes("dakota-gaming")),
     "the gaming id must never surface as an image of its own",
   );
 
-  const total = option.series.find((s) => s.name === "Project Bluefin Dakota");
+  const total = option.series.find((s) => s.name === "Dakota");
   const gaming = option.series.find(
-    (s) => s.name === "Project Bluefin Dakota (game mode)",
+    (s) => s.name === "Dakota \u00b7 game mode",
   );
   assert.deepEqual(total.data, [4, 6]);
   assert.deepEqual(gaming.data, [1, 2]);
@@ -521,4 +522,30 @@ test("the game-mode series is drawn under its image, not as a new one", () => {
     "a share carries its image's colour so it is not read as a separate image",
   );
   assert.equal(gaming.connectNulls, false);
+});
+
+test("the axis shortens its ticks but keeps the full date in the data", () => {
+  // Nine ISO dates on one axis repeat the year nine times and crowd each other
+  // out. The tooltip and the numbers table read xAxis.data, so the full date
+  // has to survive there even though the tick text does not show it.
+  const html = renderCounts(COUNTS_FIXTURE);
+  const option = JSON.parse(
+    html
+      .match(
+        /data-title="Weekly active systems"[\s\S]*?data-option="([^"]*)"/,
+      )[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&"),
+  );
+
+  assert.deepEqual(option.xAxis.data, [
+    "2026-08-17",
+    "2026-08-24",
+    "2026-08-31",
+  ]);
+  assert.equal(compactWeek("2026-08-17"), "Aug 17");
+  assert.equal(compactWeek("2026-01-05"), "Jan 5");
+  // A value that is not a date is passed through rather than rendered as
+  // "Invalid Date" on the axis.
+  assert.equal(compactWeek("not-a-date"), "not-a-date");
 });

--- a/src/components/analytics/CountmeAnalyticsCharts.tsx
+++ b/src/components/analytics/CountmeAnalyticsCharts.tsx
@@ -61,6 +61,39 @@ const REGISTRY_URL = "/data/ghcr-packages.json";
 const LEGACY_CHART_URL = `${FIRST_PARTY_ORIGIN}/legacy/bluefin.svg`;
 const LEGACY_BADGE_URL = `${FIRST_PARTY_ORIGIN}/badge-endpoints/bluefin.json`;
 
+/**
+ * Chart series names.
+ *
+ * Short on purpose: the chip row above the chart already carries the full name
+ * and the current value, so a legend repeating "Project Bluefin Dakota" five
+ * times only crowds the axis it sits under.
+ */
+export const SHORT_REPO_LABELS: Record<string, string> = {
+  bluefin: "Bluefin",
+  "bluefin-lts": "LTS",
+  dakota: "Dakota",
+  utah: "Utah",
+  server: "Server",
+};
+
+/**
+ * `2026-07-13` as `Jul 13`.
+ *
+ * Nine ISO dates across one axis repeat the year nine times and leave no room
+ * to read any of them. The full date stays on the axis data, so the tooltip and
+ * the numbers table below still carry it.
+ */
+export function compactWeek(week: string): string {
+  const d = new Date(`${week}T00:00:00Z`);
+  return Number.isNaN(d.getTime())
+    ? week
+    : d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+}
+
 /** Display names for the first-party `repo` identifiers. */
 export const REPO_LABELS: Record<string, string> = {
   bluefin: "Bluefin",
@@ -456,13 +489,26 @@ export default function CountmeAnalyticsCharts({
       tooltip: { trigger: "axis" },
       xAxis: {
         type: "category",
+        // Full ISO dates stay in the data, so the tooltip and the numbers table
+        // keep them; only the tick text is shortened.
         data: weekLabels(countmeWeeks),
+        axisLabel: {
+          fontSize: 13,
+          hideOverlap: true,
+          formatter: (value: string) => compactWeek(value),
+        },
       },
       // Anchored at zero: a floating floor turns a flat series into a cliff.
-      yAxis: { type: "value", min: 0 },
+      yAxis: {
+        type: "value",
+        min: 0,
+        minInterval: 1,
+        axisLabel: { fontSize: 13 },
+      },
+      legend: { textStyle: { fontSize: 13 }, itemGap: 18 },
       series: [
         ...activeRepos.map((repo, i) => ({
-          name: REPO_LABELS[repo] ?? repo,
+          name: SHORT_REPO_LABELS[repo] ?? repo,
           type: "line",
           // Rule 4: discrete weekly readings. No spline between them, and a
           // missing week breaks the line rather than being bridged or zeroed.
@@ -490,7 +536,7 @@ export default function CountmeAnalyticsCharts({
         ...gamingActiveRepos.map((repo) => {
           const i = activeRepos.indexOf(repo);
           return {
-            name: `${REPO_LABELS[repo] ?? repo} (game mode)`,
+            name: `${SHORT_REPO_LABELS[repo] ?? repo} · game mode`,
             type: "line",
             smooth: false,
             connectNulls: false,


### PR DESCRIPTION
The top chart's axis and legend text was unreadable.

## What was actually wrong

Not resolution — I checked. On a fresh load the canvas backing store is `1092×375` against a CSS box of `874×300` at `devicePixelRatio` 1.25, so ECharts is rasterising correctly.

The problem was density:

- Nine full ISO dates (`2026-07-13` …) across 874px, repeating the year nine times.
- A five-entry legend spelling out `Project Bluefin Dakota` and `Project Bluefin Dakota (game mode)` under an axis already short of space.
- 12px text for both.

## Changes

- Ticks render as `Jul 13`. **The full date stays in `xAxis.data`**, so the tooltip and the "Show the numbers" table still carry `2026-07-13` — the shortening is presentation only, asserted by a test.
- Series names shortened to `Bluefin`, `LTS`, `Dakota`, `Bluefin · game mode`. The chip row above the chart already carries each image's full name and current value, so presentation rule 1 is unaffected and the legend stops repeating it.
- Axis and legend text at 13px; `minInterval: 1` on the value axis so a count of systems no longer ticks in halves.

## Verification

- Page verified in a browser at `deviceScaleFactor: 2`: ticks read `Jul 13 … Sep 7`, legend markers show their line style and symbol, y-axis steps `0 1 2 3 4`.
- `just check`: 0 lint errors, 1048/1048 tests pass.
- New test asserts the axis keeps full ISO dates in its data while `compactWeek` shortens the tick text, and that a non-date value passes through rather than rendering `Invalid Date`.